### PR TITLE
feat: add Refresh Metadata option to detail view menu

### DIFF
--- a/Sashimi/Services/JellyfinClient.swift
+++ b/Sashimi/Services/JellyfinClient.swift
@@ -501,6 +501,18 @@ actor JellyfinClient {
         _ = try await request(path: "/Items/\(itemId)", method: "DELETE")
     }
 
+    func refreshMetadata(itemId: String, replaceImages: Bool = false) async throws {
+        var queryItems = [
+            URLQueryItem(name: "Recursive", value: "true"),
+            URLQueryItem(name: "MetadataRefreshMode", value: "FullRefresh"),
+            URLQueryItem(name: "ImageRefreshMode", value: "FullRefresh")
+        ]
+        if replaceImages {
+            queryItems.append(URLQueryItem(name: "ReplaceAllImages", value: "true"))
+        }
+        _ = try await request(path: "/Items/\(itemId)/Refresh", method: "POST", queryItems: queryItems)
+    }
+
     func getItem(itemId: String) async throws -> BaseItemDto {
         guard let userId else { throw JellyfinError.notConfigured }
 


### PR DESCRIPTION
## Summary
- Add `refreshMetadata` function to JellyfinClient (POST /Items/{id}/Refresh)
- Add "Refresh Metadata" button in detail view More menu
- Force image reload after refresh using refreshID state
- Shows toast notification when refresh is triggered

This allows users to manually refresh metadata and images for items that may have missing or outdated thumbnails.

Fixes #54

## Test plan
- [x] Installed on Living Room Apple TV
- [x] Installed on Bedroom Apple TV

🤖 Generated with [Claude Code](https://claude.com/claude-code)