### PR TITLE
fix: Remove redundant library name labels from library cards

### DIFF
--- a/Sashimi/Views/Library/LibraryView.swift
+++ b/Sashimi/Views/Library/LibraryView.swift
@@ -61,23 +61,13 @@ struct LibraryCard: View {
     let library: LibraryView_Model
 
     var body: some View {
-        VStack {
-            AsyncItemImage(
-                itemId: library.id,
-                imageType: "Primary",
-                maxWidth: 400
-            )
-            .frame(width: 300, height: 170)
-            .clipShape(RoundedRectangle(cornerRadius: 12))
-            .overlay {
-                RoundedRectangle(cornerRadius: 12)
-                    .fill(.black.opacity(0.4))
-
-                Text(library.name)
-                    .font(.title3)
-                    .fontWeight(.semibold)
-            }
-        }
+        AsyncItemImage(
+            itemId: library.id,
+            imageType: "Primary",
+            maxWidth: 400
+        )
+        .frame(width: 300, height: 170)
+        .clipShape(RoundedRectangle(cornerRadius: 12))
     }
 }
 


### PR DESCRIPTION
## Summary
- Remove text overlay from library cards since server images already include the library name

Fixes #60

## Test plan
- [x] Deployed to both Apple TVs

🤖 Generated with [Claude Code](https://claude.com/claude-code)