### PR TITLE
Fix color contrast for accessibility

### DIFF
--- a/Sashimi/Views/Components/MediaRow.swift
+++ b/Sashimi/Views/Components/MediaRow.swift
@@ -5,8 +5,8 @@ private enum SashimiTheme {
     static let cardBackground = Color(white: 0.12)
     static let accent = Color(red: 0.36, green: 0.68, blue: 0.90)
     static let textPrimary = Color.white
-    static let textSecondary = Color(white: 0.65)
-    static let textTertiary = Color(white: 0.45)
+    static let textSecondary = Color(white: 0.75)
+    static let textTertiary = Color(white: 0.55)
     static let focusGlow = Color(red: 0.36, green: 0.68, blue: 0.90).opacity(0.5)
 }
 

--- a/Sashimi/Views/Detail/MediaDetailView.swift
+++ b/Sashimi/Views/Detail/MediaDetailView.swift
@@ -11,8 +11,8 @@ private enum SashimiTheme {
     static let accentSecondary = Color(red: 0.95, green: 0.65, blue: 0.25)
     static let highlight = Color(red: 0.36, green: 0.68, blue: 0.90) // Blue accent for highlights
     static let textPrimary = Color.white
-    static let textSecondary = Color(white: 0.70)
-    static let textTertiary = Color(white: 0.45)
+    static let textSecondary = Color(white: 0.75)
+    static let textTertiary = Color(white: 0.55)
     static let progressBackground = Color(white: 0.25)
 }
 

--- a/Sashimi/Views/Home/ContinueWatchingRow.swift
+++ b/Sashimi/Views/Home/ContinueWatchingRow.swift
@@ -5,8 +5,8 @@ private enum SashimiTheme {
     static let cardBackground = Color(white: 0.12)
     static let accent = Color(red: 0.36, green: 0.68, blue: 0.90)
     static let textPrimary = Color.white
-    static let textSecondary = Color(white: 0.65)
-    static let textTertiary = Color(white: 0.45)
+    static let textSecondary = Color(white: 0.75)
+    static let textTertiary = Color(white: 0.55)
     static let progressBackground = Color(white: 0.25)
     static let focusGlow = Color(red: 0.36, green: 0.68, blue: 0.90).opacity(0.5)
 }

--- a/Sashimi/Views/Home/HomeView.swift
+++ b/Sashimi/Views/Home/HomeView.swift
@@ -14,8 +14,8 @@ private enum SashimiTheme {
     static let cardBackground = Color(white: 0.12)
     static let accent = Color(red: 0.36, green: 0.68, blue: 0.90)
     static let textPrimary = Color.white
-    static let textSecondary = Color(white: 0.65)
-    static let textTertiary = Color(white: 0.45)
+    static let textSecondary = Color(white: 0.75)
+    static let textTertiary = Color(white: 0.55)
     static let progressBackground = Color(white: 0.25)
     static let focusGlow = Color(red: 0.36, green: 0.68, blue: 0.90).opacity(0.5)
 }

--- a/Sashimi/Views/Library/SearchView.swift
+++ b/Sashimi/Views/Library/SearchView.swift
@@ -8,8 +8,8 @@ private enum SashimiTheme {
     static let cardBackground = Color(white: 0.12)
     static let accent = Color(red: 0.36, green: 0.68, blue: 0.90)
     static let textPrimary = Color.white
-    static let textSecondary = Color(white: 0.65)
-    static let textTertiary = Color(white: 0.45)
+    static let textSecondary = Color(white: 0.75)
+    static let textTertiary = Color(white: 0.55)
 }
 
 struct SearchView: View {


### PR DESCRIPTION
## Summary
- Increase textSecondary from 0.65/0.70 to 0.75
- Increase textTertiary from 0.45 to 0.55
- Updates all 5 files with SashimiTheme definitions
- Improves WCAG AA compliance for text contrast

Closes #26

## Test plan
- [x] Text is more readable throughout the app
- [x] Visual hierarchy still maintained

🤖 Generated with [Claude Code](https://claude.com/claude-code)