### PR TITLE
Add native tvOS audio/subtitle controls

### DIFF
--- a/Sashimi/Services/JellyfinClient.swift
+++ b/Sashimi/Services/JellyfinClient.swift
@@ -535,7 +535,7 @@ actor JellyfinClient {
         let data = try await request(
             path: "/Users/\(userId)/Items/\(itemId)",
             queryItems: [
-                URLQueryItem(name: "Fields", value: "Overview,PrimaryImageAspectRatio,CommunityRating,OfficialRating,Genres,Taglines,People"),
+                URLQueryItem(name: "Fields", value: "Overview,PrimaryImageAspectRatio,CommunityRating,OfficialRating,Genres,Taglines,People,UserData"),
                 URLQueryItem(name: "EnableImageTypes", value: "Primary,Backdrop,Thumb")
             ]
         )

--- a/Sashimi/Views/Player/PlayerView.swift
+++ b/Sashimi/Views/Player/PlayerView.swift
@@ -7,6 +7,24 @@ private enum PlayerTheme {
     static let cardBackground = Color(white: 0.12)
 }
 
+// MARK: - AVPlayerViewController Wrapper
+// Uses native tvOS player controls including swipe-down info panel for audio/subtitle selection
+
+struct TVPlayerViewController: UIViewControllerRepresentable {
+    let player: AVPlayer
+
+    func makeUIViewController(context: Context) -> AVPlayerViewController {
+        let controller = AVPlayerViewController()
+        controller.player = player
+        controller.allowsPictureInPicturePlayback = false
+        return controller
+    }
+
+    func updateUIViewController(_ uiViewController: AVPlayerViewController, context: Context) {
+        uiViewController.player = player
+    }
+}
+
 struct PlayerView: View {
     let item: BaseItemDto
 
@@ -27,8 +45,8 @@ struct PlayerView: View {
             } else if let error = viewModel.error ?? (viewModel.errorMessage != nil ? PlayerError.noStreamURL : nil) {
                 errorView(error: error)
             } else if let player = viewModel.player {
-                // Native VideoPlayer with built-in tvOS controls
-                VideoPlayer(player: player)
+                // Native AVPlayerViewController for full tvOS controls including audio/subtitle selection
+                TVPlayerViewController(player: player)
                     .ignoresSafeArea()
             }
 


### PR DESCRIPTION
## Summary
- Replace SwiftUI `VideoPlayer` with `AVPlayerViewController` for full tvOS controls
- Native info panel exposes audio track and subtitle selection buttons (tap to show controls)
- Fetch fresh item data from server before checking resume position
- Add `UserData` field to `getItem` API call for accurate playback position

Fixes #39

## Test plan
- [x] Tap during playback shows controls with audio/subtitle buttons
- [x] Audio track selection works
- [x] Subtitle selection works (Auto/Off/CC)
- [x] Resume dialog appears after watching ~1-2 min and returning

🤖 Generated with [Claude Code](https://claude.com/claude-code)