### PR TITLE
Fix resume dialog focus and deduplicate continue watching

### DIFF
--- a/Sashimi/Views/Player/PlayerView.swift
+++ b/Sashimi/Views/Player/PlayerView.swift
@@ -12,6 +12,7 @@ private enum PlayerTheme {
 
 struct TVPlayerViewController: UIViewControllerRepresentable {
     let player: AVPlayer
+    var isInteractionEnabled: Bool = true
 
     func makeCoordinator() -> Coordinator {
         Coordinator()
@@ -30,6 +31,8 @@ struct TVPlayerViewController: UIViewControllerRepresentable {
 
     func updateUIViewController(_ uiViewController: AVPlayerViewController, context: Context) {
         uiViewController.player = player
+        // Disable interaction when dialogs are showing to prevent focus stealing
+        uiViewController.view.isUserInteractionEnabled = isInteractionEnabled
     }
 
     private func createSpeedMenu(for player: AVPlayer, coordinator: Coordinator) -> UIMenu {
@@ -97,8 +100,11 @@ struct PlayerView: View {
                 errorView(error: error)
             } else if let player = viewModel.player {
                 // Native AVPlayerViewController for full tvOS controls including audio/subtitle selection
-                TVPlayerViewController(player: player)
-                    .ignoresSafeArea()
+                TVPlayerViewController(
+                    player: player,
+                    isInteractionEnabled: !viewModel.showingResumeDialog && !viewModel.showingUpNext
+                )
+                .ignoresSafeArea()
             }
 
             // Resume playback dialog


### PR DESCRIPTION
## Summary
- Disable player interaction when resume/up-next dialogs are showing (prevents seek bar from stealing focus)
- Deduplicate continue watching to show only the most recent episode per series
- Sort all items by lastPlayedDate before deduplication

## Test plan
- [ ] Start playing an episode with saved progress - verify resume dialog buttons can be selected
- [ ] Check continue watching row - should show only one episode per series (the most recent)

🤖 Generated with [Claude Code](https://claude.com/claude-code)