### PR TITLE
Add episode count badge to Recently Added rows

### DIFF
--- a/Sashimi/Views/Components/MediaRow.swift
+++ b/Sashimi/Views/Components/MediaRow.swift
@@ -52,6 +52,7 @@ struct MediaPosterButton: View {
     var libraryType: String?
     var libraryName: String?
     var isLandscape: Bool = false
+    var badgeCount: Int?  // Shows "X new" badge when > 1
     let onSelect: () -> Void
 
     @FocusState private var isFocused: Bool
@@ -142,6 +143,24 @@ struct MediaPosterButton: View {
                                             .padding(-2)
                                     )
                                     .padding(8)
+                            }
+                            Spacer()
+                        }
+                    }
+
+                    // "X new" badge for multiple episodes
+                    if let count = badgeCount, count > 1 {
+                        VStack {
+                            HStack {
+                                Text("\(count) new")
+                                    .font(.system(size: 14, weight: .bold))
+                                    .foregroundStyle(.white)
+                                    .padding(.horizontal, 8)
+                                    .padding(.vertical, 4)
+                                    .background(SashimiTheme.accent)
+                                    .clipShape(Capsule())
+                                    .padding(8)
+                                Spacer()
                             }
                             Spacer()
                         }


### PR DESCRIPTION
## Summary
- Show "X new" badge on series posters when multiple episodes added
- Badge appears top-left with accent color capsule
- Tracks episode counts during deduplication

Fixes #43

## Test plan
- [ ] Check a Recently Added row for a series with multiple new episodes
- [ ] Should show "X new" badge (e.g., "3 new") in top-left corner
- [ ] Single episodes should not show a badge

🤖 Generated with [Claude Code](https://claude.com/claude-code)