### PR TITLE
feat: Add theme constants, logo, and improve 10-foot UI

### DIFF
--- a/Sashimi/Theme/Theme.swift
+++ b/Sashimi/Theme/Theme.swift
@@ -1,0 +1,77 @@
+import SwiftUI
+
+// MARK: - Colors
+
+enum SashimiTheme {
+    static let background = Color(red: 0.07, green: 0.07, blue: 0.09)
+    static let cardBackground = Color(white: 0.12)
+    static let accent = Color(red: 0.36, green: 0.68, blue: 0.90)
+    static let accentSecondary = Color(red: 0.95, green: 0.65, blue: 0.25)
+    static let highlight = Color(red: 0.36, green: 0.68, blue: 0.90)
+    static let textPrimary = Color.white
+    static let textSecondary = Color(white: 0.75)
+    static let textTertiary = Color(white: 0.55)
+    static let focusGlow = Color(red: 0.36, green: 0.68, blue: 0.90).opacity(0.5)
+    static let progressBackground = Color(white: 0.25)
+}
+
+// MARK: - Spacing
+
+enum Spacing {
+    /// 80pt - Extra large spacing (screen edges, major sections)
+    static let xl: CGFloat = 80
+    /// 60pt - Large spacing (between sections)
+    static let lg: CGFloat = 60
+    /// 40pt - Medium spacing (between related elements)
+    static let md: CGFloat = 40
+    /// 20pt - Small spacing (within components)
+    static let sm: CGFloat = 20
+    /// 10pt - Extra small spacing (tight layouts)
+    static let xs: CGFloat = 10
+    /// 4pt - Minimal spacing
+    static let xxs: CGFloat = 4
+}
+
+// MARK: - Typography
+
+enum Typography {
+    // Display sizes - for hero sections
+    static let displayLarge: Font = .system(size: 76, weight: .bold)
+    static let displayMedium: Font = .system(size: 56, weight: .bold)
+
+    // Headlines - for section titles
+    static let headline: Font = .system(size: 40, weight: .bold)
+    static let headlineSmall: Font = .system(size: 32, weight: .semibold)
+
+    // Titles - for card titles, list items
+    static let title: Font = .system(size: 28, weight: .semibold)
+    static let titleSmall: Font = .system(size: 24, weight: .medium)
+
+    // Body - for descriptions, metadata
+    static let body: Font = .system(size: 24)
+    static let bodySmall: Font = .system(size: 20)
+
+    // Caption - for secondary info
+    static let caption: Font = .system(size: 18)
+    static let captionSmall: Font = .system(size: 16)
+}
+
+// MARK: - Sizing (10-foot UI minimums)
+
+enum Sizing {
+    /// Minimum focusable element width
+    static let minFocusableWidth: CGFloat = 120
+    /// Minimum focusable element height
+    static let minFocusableHeight: CGFloat = 80
+
+    // Card sizes
+    static let posterWidth: CGFloat = 220
+    static let posterHeight: CGFloat = 330
+    static let landscapeCardWidth: CGFloat = 320
+    static let landscapeCardHeight: CGFloat = 180
+
+    // Icon sizes
+    static let iconSmall: CGFloat = 24
+    static let iconMedium: CGFloat = 32
+    static let iconLarge: CGFloat = 48
+}

--- a/Sashimi/Views/Components/MediaRow.swift
+++ b/Sashimi/Views/Components/MediaRow.swift
@@ -1,15 +1,5 @@
 import SwiftUI
 
-private enum SashimiTheme {
-    static let background = Color(red: 0.07, green: 0.07, blue: 0.09)
-    static let cardBackground = Color(white: 0.12)
-    static let accent = Color(red: 0.36, green: 0.68, blue: 0.90)
-    static let textPrimary = Color.white
-    static let textSecondary = Color(white: 0.75)
-    static let textTertiary = Color(white: 0.55)
-    static let focusGlow = Color(red: 0.36, green: 0.68, blue: 0.90).opacity(0.5)
-}
-
 struct MediaRow: View {
     let title: String
     var subtitle: String?

--- a/Sashimi/Views/Detail/MediaDetailView.swift
+++ b/Sashimi/Views/Detail/MediaDetailView.swift
@@ -4,18 +4,6 @@ import SwiftUI
 // MediaDetailView is a complex view handling movies, series, seasons, and episodes
 // with multiple states and sub-views - splitting would reduce cohesion
 
-private enum SashimiTheme {
-    static let background = Color(red: 0.07, green: 0.07, blue: 0.09)
-    static let cardBackground = Color(white: 0.12)
-    static let accent = Color(red: 0.36, green: 0.68, blue: 0.90)
-    static let accentSecondary = Color(red: 0.95, green: 0.65, blue: 0.25)
-    static let highlight = Color(red: 0.36, green: 0.68, blue: 0.90) // Blue accent for highlights
-    static let textPrimary = Color.white
-    static let textSecondary = Color(white: 0.75)
-    static let textTertiary = Color(white: 0.55)
-    static let progressBackground = Color(white: 0.25)
-}
-
 struct MediaDetailView: View {
     let item: BaseItemDto
     var forceYouTubeStyle: Bool = false
@@ -862,11 +850,11 @@ struct SeasonTab: View {
     var body: some View {
         Button(action: action) {
             Text(season.name)
-                .font(.system(size: 20))
+                .font(.system(size: 24))
                 .fontWeight(isSelected ? .bold : .medium)
                 .foregroundStyle(isSelected || isFocused ? SashimiTheme.highlight : .white)
-                .padding(.horizontal, 16)
-                .padding(.vertical, 8)
+                .padding(.horizontal, 20)
+                .padding(.vertical, 12)
                 .background(
                     isSelected || isFocused ? SashimiTheme.highlight.opacity(0.2) : SashimiTheme.cardBackground
                 )
@@ -889,19 +877,20 @@ struct CastCard: View {
     var body: some View {
         VStack(spacing: 8) {
             if person.primaryImageTag != nil {
-                AsyncImage(url: JellyfinClient.shared.personImageURL(personId: person.id)) { image in
+                AsyncImage(url: JellyfinClient.shared.personImageURL(personId: person.id, maxWidth: 200)) { image in
                     image.resizable().aspectRatio(contentMode: .fill)
                 } placeholder: {
                     Circle().fill(SashimiTheme.cardBackground)
                 }
-                .frame(width: 80, height: 80)
+                .frame(width: 100, height: 100)
                 .clipShape(Circle())
             } else {
                 Circle()
                     .fill(SashimiTheme.cardBackground)
-                    .frame(width: 80, height: 80)
+                    .frame(width: 100, height: 100)
                     .overlay {
                         Image(systemName: "person.fill")
+                            .font(.system(size: 40))
                             .foregroundStyle(SashimiTheme.textTertiary)
                     }
             }
@@ -919,7 +908,7 @@ struct CastCard: View {
                     .lineLimit(1)
             }
         }
-        .frame(width: 90)
+        .frame(width: 120)
     }
 }
 

--- a/Sashimi/Views/Home/ContinueWatchingRow.swift
+++ b/Sashimi/Views/Home/ContinueWatchingRow.swift
@@ -1,16 +1,5 @@
 import SwiftUI
 
-private enum SashimiTheme {
-    static let background = Color(red: 0.07, green: 0.07, blue: 0.09)
-    static let cardBackground = Color(white: 0.12)
-    static let accent = Color(red: 0.36, green: 0.68, blue: 0.90)
-    static let textPrimary = Color.white
-    static let textSecondary = Color(white: 0.75)
-    static let textTertiary = Color(white: 0.55)
-    static let progressBackground = Color(white: 0.25)
-    static let focusGlow = Color(red: 0.36, green: 0.68, blue: 0.90).opacity(0.5)
-}
-
 struct ContinueWatchingRow: View {
     let items: [BaseItemDto]
     let onSelect: (BaseItemDto) -> Void

--- a/Sashimi/Views/Home/HomeView.swift
+++ b/Sashimi/Views/Home/HomeView.swift
@@ -8,18 +8,6 @@ private struct ScrollOffsetPreferenceKey: PreferenceKey {
     }
 }
 
-// MARK: - Theme Colors
-private enum SashimiTheme {
-    static let background = Color(red: 0.07, green: 0.07, blue: 0.09)
-    static let cardBackground = Color(white: 0.12)
-    static let accent = Color(red: 0.36, green: 0.68, blue: 0.90)
-    static let textPrimary = Color.white
-    static let textSecondary = Color(white: 0.75)
-    static let textTertiary = Color(white: 0.55)
-    static let progressBackground = Color(white: 0.25)
-    static let focusGlow = Color(red: 0.36, green: 0.68, blue: 0.90).opacity(0.5)
-}
-
 struct HomeView: View {
     @StateObject private var viewModel = HomeViewModel()
     @StateObject private var homeSettings = HomeScreenSettings.shared
@@ -127,6 +115,15 @@ struct HomeView: View {
                 LoadingOverlay()
                     .allowsHitTesting(false) // Allow navigation while loading
             }
+        }
+        .overlay(alignment: .topLeading) {
+            Image("Logo")
+                .resizable()
+                .aspectRatio(contentMode: .fit)
+                .frame(height: 50)
+                .padding(.leading, 80)
+                .padding(.top, 40)
+                .allowsHitTesting(false)
         }
     }
 

--- a/Sashimi/Views/Library/SearchView.swift
+++ b/Sashimi/Views/Library/SearchView.swift
@@ -3,15 +3,6 @@ import os
 
 private let logger = Logger(subsystem: "com.sashimi.app", category: "Search")
 
-private enum SashimiTheme {
-    static let background = Color(red: 0.07, green: 0.07, blue: 0.09)
-    static let cardBackground = Color(white: 0.12)
-    static let accent = Color(red: 0.36, green: 0.68, blue: 0.90)
-    static let textPrimary = Color.white
-    static let textSecondary = Color(white: 0.75)
-    static let textTertiary = Color(white: 0.55)
-}
-
 struct SearchView: View {
     var onBackAtRoot: (() -> Void)?
     @State private var searchText = ""

--- a/Sashimi/Views/Player/PlayerView.swift
+++ b/Sashimi/Views/Player/PlayerView.swift
@@ -2,11 +2,6 @@ import SwiftUI
 import AVKit
 import Combine
 
-private enum PlayerTheme {
-    static let accent = Color(red: 0.36, green: 0.68, blue: 0.90)
-    static let cardBackground = Color(white: 0.12)
-}
-
 // MARK: - AVPlayerViewController Wrapper
 // Uses native tvOS player controls including swipe-down info panel for audio/subtitle selection
 
@@ -417,7 +412,7 @@ struct ResumePlaybackOverlay: View {
                 VStack(spacing: 16) {
                     Image(systemName: "play.circle.fill")
                         .font(.system(size: 80))
-                        .foregroundStyle(PlayerTheme.accent)
+                        .foregroundStyle(SashimiTheme.accent)
 
                     Text("Resume Playback?")
                         .font(.title)
@@ -502,7 +497,7 @@ private struct ResumeDialogButton: View {
             .clipShape(Capsule())
             .overlay(
                 Capsule()
-                    .stroke(PlayerTheme.accent, lineWidth: isFocused ? 4 : 0)
+                    .stroke(SashimiTheme.accent, lineWidth: isFocused ? 4 : 0)
             )
             .scaleEffect(isFocused ? 1.05 : 1.0)
             .animation(.spring(response: 0.3), value: isFocused)
@@ -548,7 +543,7 @@ struct UpNextOverlay: View {
                 VStack(alignment: .leading, spacing: 24) {
                     Text("Up Next")
                         .font(.headline)
-                        .foregroundStyle(PlayerTheme.accent)
+                        .foregroundStyle(SashimiTheme.accent)
 
                     VStack(alignment: .leading, spacing: 8) {
                         if let seriesName = nextEpisode.seriesName {
@@ -655,7 +650,7 @@ struct SkipSegmentOverlay: View {
                     .clipShape(Capsule())
                     .overlay(
                         Capsule()
-                            .stroke(PlayerTheme.accent, lineWidth: isFocused ? 4 : 0)
+                            .stroke(SashimiTheme.accent, lineWidth: isFocused ? 4 : 0)
                     )
                     .scaleEffect(isFocused ? 1.05 : 1.0)
                     .shadow(color: .black.opacity(0.4), radius: 10, y: 5)


### PR DESCRIPTION
## Summary
- Create centralized `Theme.swift` with SashimiTheme colors, Spacing, Typography, and Sizing constants
- Remove duplicate SashimiTheme definitions from 6 view files (MediaRow, MediaDetailView, ContinueWatchingRow, HomeView, SearchView, PlayerView)
- Add app logo overlay to HomeView (top-left corner)
- Increase SeasonTab font size and padding for better 10-foot visibility
- Enlarge CastCard avatars (80x80 → 100x100) for readability

Closes #46, #37, #53

## Test plan
- [ ] App logo appears in top-left corner on Home screen
- [ ] Theme colors render correctly across all views
- [ ] Season tabs are readable on 10-foot display
- [ ] Cast member cards are visible and readable

🤖 Generated with [Claude Code](https://claude.com/claude-code)