### PR TITLE
feat: Modernize library section with improved UX

### DIFF
--- a/Sashimi/Views/Components/MediaRow.swift
+++ b/Sashimi/Views/Components/MediaRow.swift
@@ -120,19 +120,20 @@ struct MediaPosterButton: View {
                     .frame(width: cardWidth, height: cardHeight)
                     .clipShape(RoundedRectangle(cornerRadius: 12))
 
+                    // Watched indicator (small corner checkmark)
                     if item.userData?.played == true {
                         VStack {
                             HStack {
                                 Spacer()
                                 Image(systemName: "checkmark.circle.fill")
-                                    .font(.title3)
+                                    .font(.system(size: 20))
                                     .foregroundStyle(.green)
                                     .background(
                                         Circle()
-                                            .fill(.black.opacity(0.5))
+                                            .fill(.black.opacity(0.6))
                                             .padding(-2)
                                     )
-                                    .padding(8)
+                                    .padding(6)
                             }
                             Spacer()
                         }
@@ -172,8 +173,9 @@ struct MediaPosterButton: View {
                 .clipShape(RoundedRectangle(cornerRadius: 12))
                 .overlay(
                     RoundedRectangle(cornerRadius: 12)
-                        .stroke(Color.white.opacity(isFocused ? 0.6 : 0), lineWidth: 2)
+                        .stroke(isFocused ? SashimiTheme.accent : .clear, lineWidth: 4)
                 )
+                .shadow(color: isFocused ? SashimiTheme.accent.opacity(0.6) : .clear, radius: 20)
 
                 VStack(alignment: .leading, spacing: 2) {
                     MarqueeText(
@@ -193,8 +195,8 @@ struct MediaPosterButton: View {
                 }
                 .frame(width: cardWidth, alignment: .leading)
             }
-            .scaleEffect(isFocused ? 1.08 : 1.0)
-            .animation(.spring(response: 0.35, dampingFraction: 0.7), value: isFocused)
+            .scaleEffect(isFocused ? 1.05 : 1.0)
+            .animation(.spring(response: 0.3, dampingFraction: 0.7), value: isFocused)
         }
         .buttonStyle(PlainNoHighlightButtonStyle())
         .focused($isFocused)

--- a/Sashimi/Views/Library/LibraryView.swift
+++ b/Sashimi/Views/Library/LibraryView.swift
@@ -17,10 +17,9 @@ struct LibraryView: View {
                     if libraries.count <= 4 {
                         HStack(spacing: 40) {
                             ForEach(libraries) { library in
-                                NavigationLink(value: library) {
-                                    LibraryCard(library: library)
+                                LibraryCardButton(library: library) {
+                                    navigationPath.append(library)
                                 }
-                                .buttonStyle(.plain)
                             }
                         }
                         .frame(maxWidth: .infinity)
@@ -33,10 +32,9 @@ struct LibraryView: View {
                             GridItem(.flexible(), spacing: 40)
                         ], spacing: 40) {
                             ForEach(libraries) { library in
-                                NavigationLink(value: library) {
-                                    LibraryCard(library: library)
+                                LibraryCardButton(library: library) {
+                                    navigationPath.append(library)
                                 }
-                                .buttonStyle(.plain)
                             }
                         }
                         .padding(60)
@@ -90,55 +88,168 @@ struct LibraryView_Model: Identifiable, Hashable {
     }
 }
 
-struct LibraryCard: View {
+// MARK: - Library Card Button (with proper focus)
+struct LibraryCardButton: View {
     let library: LibraryView_Model
+    let onSelect: () -> Void
+    @FocusState private var isFocused: Bool
 
     var body: some View {
-        AsyncItemImage(
-            itemId: library.id,
-            imageType: "Primary",
-            maxWidth: 400
-        )
-        .frame(width: 300, height: 170)
-        .clipShape(RoundedRectangle(cornerRadius: 12))
+        Button(action: onSelect) {
+            VStack(alignment: .leading, spacing: 12) {
+                AsyncItemImage(
+                    itemId: library.id,
+                    imageType: "Primary",
+                    maxWidth: 400
+                )
+                .frame(width: 300, height: 170)
+                .clipShape(RoundedRectangle(cornerRadius: 12))
+                .overlay(
+                    RoundedRectangle(cornerRadius: 12)
+                        .stroke(isFocused ? SashimiTheme.accent : .clear, lineWidth: 4)
+                )
+                .shadow(color: isFocused ? SashimiTheme.accent.opacity(0.6) : .clear, radius: 20)
+
+                Text(library.name)
+                    .font(.system(size: 24, weight: .medium))
+                    .foregroundStyle(SashimiTheme.textPrimary)
+                    .lineLimit(1)
+            }
+            .scaleEffect(isFocused ? 1.05 : 1.0)
+            .animation(.spring(response: 0.3, dampingFraction: 0.7), value: isFocused)
+        }
+        .buttonStyle(PlainNoHighlightButtonStyle())
+        .focused($isFocused)
     }
 }
 
+// MARK: - Library Detail View
 struct LibraryDetailView: View {
+    enum FocusArea: Hashable {
+        case grid
+        case alphabet
+    }
+
     let library: LibraryView_Model
 
     @State private var items: [BaseItemDto] = []
     @State private var isLoading = true
+    @State private var isLoadingMore = false
     @State private var selectedItem: BaseItemDto?
+    @State private var totalCount = 0
+    @State private var selectedLetter: String?
+    @FocusState private var focusedArea: FocusArea?
+    private let pageSize = 50
+
+    // Alphabet for fast scroll
+    private let alphabet = ["#"] + "ABCDEFGHIJKLMNOPQRSTUVWXYZ".map { String($0) }
 
     // Detect YouTube library by name
     private var isYouTubeLibrary: Bool {
         library.name.lowercased().contains("youtube")
     }
 
-    private var gridColumns: [GridItem] {
-        if isYouTubeLibrary {
-            return [GridItem(.adaptive(minimum: 300, maximum: 340), spacing: 24)]
-        }
-        return [GridItem(.adaptive(minimum: 180, maximum: 220), spacing: 30)]
+    private var hasMore: Bool {
+        items.count < totalCount
     }
 
+    private var gridColumns: [GridItem] {
+        if isYouTubeLibrary {
+            return [GridItem(.adaptive(minimum: 300, maximum: 340), spacing: 40)]
+        }
+        return [GridItem(.adaptive(minimum: 180, maximum: 220), spacing: 50)]
+    }
+
+    @Namespace private var namespace
+
     var body: some View {
-        ScrollView {
-            if isLoading {
-                ProgressView()
-            } else {
-                LazyVGrid(columns: gridColumns, spacing: isYouTubeLibrary ? 30 : 40) {
-                    ForEach(items) { item in
-                        MediaPosterButton(item: item, isLandscape: isYouTubeLibrary) {
-                            selectedItem = item
+        HStack(spacing: 0) {
+            // Main content
+            ScrollViewReader { proxy in
+                ScrollView {
+                    LazyVStack(alignment: .leading, spacing: 30) {
+                        // Header with title and count
+                        HStack {
+                            Text(library.name)
+                                .font(.system(size: 48, weight: .bold))
+                                .foregroundStyle(SashimiTheme.textPrimary)
+
+                            Spacer()
+
+                            if totalCount > 0 {
+                                Text("\(totalCount) items")
+                                    .font(.system(size: 24))
+                                    .foregroundStyle(SashimiTheme.textSecondary)
+                            }
+                        }
+                        .padding(.horizontal, 80)
+                        .padding(.top, 40)
+
+                        if isLoading && items.isEmpty {
+                            ProgressView()
+                                .frame(maxWidth: .infinity)
+                                .padding(.top, 100)
+                                .transition(.opacity)
+                        } else {
+                            LazyVGrid(columns: gridColumns, spacing: isYouTubeLibrary ? 40 : 60) {
+                                ForEach(Array(items.enumerated()), id: \.element.id) { index, item in
+                                    MediaPosterButton(item: item, libraryName: library.name, isLandscape: isYouTubeLibrary) {
+                                        selectedItem = item
+                                    }
+                                    .id(item.id)
+                                    .prefersDefaultFocus(index == 0, in: namespace)
+                                    .transition(.opacity.combined(with: .scale(scale: 0.95)))
+                                    .onAppear {
+                                        // Load more when approaching the end
+                                        if item.id == items.last?.id && hasMore && !isLoadingMore {
+                                            Task { await loadMoreItems() }
+                                        }
+                                    }
+                                }
+                            }
+                            .padding(.horizontal, 60)
+                            .padding(.bottom, 60)
+                            .animation(.easeOut(duration: 0.3), value: items.count)
+
+                            // Loading indicator for infinite scroll
+                            if isLoadingMore {
+                                ProgressView()
+                                    .frame(maxWidth: .infinity)
+                                    .padding(.vertical, 20)
+                                    .transition(.opacity)
+                            }
                         }
                     }
                 }
-                .padding(60)
+                .onChange(of: selectedLetter) { _, letter in
+                    if let letter = letter {
+                        scrollToLetter(letter, proxy: proxy)
+                    }
+                }
+                .focusSection()
+                .focused($focusedArea, equals: .grid)
+            }
+
+            // Alphabet fast scroll bar (right side)
+            if !isLoading && !items.isEmpty {
+                ScrollView(showsIndicators: false) {
+                    AlphabetScrollBar(
+                        alphabet: alphabet,
+                        selectedLetter: $selectedLetter
+                    )
+                }
+                .focusSection()
+                .focused($focusedArea, equals: .alphabet)
+                .frame(maxHeight: .infinity)
+                .padding(.trailing, 20)
+                .padding(.vertical, 20)
+                .onExitCommand {
+                    focusedArea = .grid
+                }
             }
         }
-        .navigationTitle(library.name)
+        .focusScope(namespace)
+        .ignoresSafeArea(edges: .bottom)
         .task {
             await loadItems()
         }
@@ -146,13 +257,44 @@ struct LibraryDetailView: View {
             MediaDetailView(item: item, forceYouTubeStyle: isYouTubeLibrary)
         }
         .onChange(of: selectedItem) { oldValue, newValue in
+            // Refresh item data when returning from detail view
             if oldValue != nil && newValue == nil {
-                Task { await loadItems() }
+                Task { await refreshCurrentItems() }
+            }
+        }
+    }
+
+    private func scrollToLetter(_ letter: String, proxy: ScrollViewProxy) {
+        var targetItem: BaseItemDto?
+        if letter == "#" {
+            // Numbers and special characters
+            for item in items {
+                guard let firstChar = item.name.first else { continue }
+                if !firstChar.isLetter {
+                    targetItem = item
+                    break
+                }
+            }
+        } else {
+            for item in items {
+                if item.name.uppercased().hasPrefix(letter) {
+                    targetItem = item
+                    break
+                }
+            }
+        }
+
+        if let item = targetItem {
+            withAnimation(.easeOut(duration: 0.5)) {
+                proxy.scrollTo(item.id, anchor: .top)
             }
         }
     }
 
     private func loadItems() async {
+        guard items.isEmpty else { return }
+
+        isLoading = true
         do {
             let includeTypes: [ItemType]? = switch library.collectionType {
             case "tvshows": [.series]
@@ -164,12 +306,105 @@ struct LibraryDetailView: View {
                 parentId: library.id,
                 includeTypes: includeTypes,
                 sortBy: "SortName",
-                limit: 100
+                limit: pageSize,
+                startIndex: 0
             )
             items = response.items
+            totalCount = response.totalRecordCount
+        } catch is CancellationError {
+            // Ignore
         } catch {
             ToastManager.shared.show("Failed to load library items")
         }
         isLoading = false
+    }
+
+    private func loadMoreItems() async {
+        guard !isLoadingMore && hasMore else { return }
+
+        isLoadingMore = true
+        do {
+            let includeTypes: [ItemType]? = switch library.collectionType {
+            case "tvshows": [.series]
+            case "movies": [.movie]
+            default: nil
+            }
+
+            let response = try await JellyfinClient.shared.getItems(
+                parentId: library.id,
+                includeTypes: includeTypes,
+                sortBy: "SortName",
+                limit: pageSize,
+                startIndex: items.count
+            )
+            items.append(contentsOf: response.items)
+        } catch is CancellationError {
+            // Ignore
+        } catch {
+            ToastManager.shared.show("Failed to load more items")
+        }
+        isLoadingMore = false
+    }
+
+    private func refreshCurrentItems() async {
+        // Just refresh userData for watched status, don't reload all
+        do {
+            let includeTypes: [ItemType]? = switch library.collectionType {
+            case "tvshows": [.series]
+            case "movies": [.movie]
+            default: nil
+            }
+
+            let response = try await JellyfinClient.shared.getItems(
+                parentId: library.id,
+                includeTypes: includeTypes,
+                sortBy: "SortName",
+                limit: items.count,
+                startIndex: 0
+            )
+            items = response.items
+        } catch {
+            // Silent fail - non-critical refresh
+        }
+    }
+}
+
+// MARK: - Alphabet Scroll Bar
+struct AlphabetScrollBar: View {
+    let alphabet: [String]
+    @Binding var selectedLetter: String?
+    @FocusState private var focusedLetter: String?
+
+    var body: some View {
+        VStack(spacing: 0) {
+            ForEach(alphabet, id: \.self) { letter in
+                Button {
+                    selectedLetter = letter
+                } label: {
+                    Text(letter)
+                        .font(.system(size: 18, weight: focusedLetter == letter ? .bold : .medium))
+                        .foregroundStyle(focusedLetter == letter ? .white : SashimiTheme.textSecondary)
+                        .frame(width: 40, height: 28)
+                        .background(
+                            RoundedRectangle(cornerRadius: 5)
+                                .fill(focusedLetter == letter ? SashimiTheme.accent : .clear)
+                        )
+                        .animation(.easeOut(duration: 0.15), value: focusedLetter)
+                }
+                .buttonStyle(PlainNoHighlightButtonStyle())
+                .focused($focusedLetter, equals: letter)
+                .onChange(of: focusedLetter) { _, newLetter in
+                    if let newLetter = newLetter {
+                        selectedLetter = newLetter
+                    }
+                }
+            }
+        }
+        .padding(.vertical, 8)
+        .padding(.horizontal, 4)
+        .background(
+            RoundedRectangle(cornerRadius: 8)
+                .fill(SashimiTheme.cardBackground.opacity(0.85))
+        )
     }
 }


### PR DESCRIPTION
## Summary
- Add scale + blue glow focus effect (replaces harsh white border)
- Implement infinite scroll pagination (50 items at a time)
- Add alphabet fast-scroll bar for quick navigation
- Show item count in library header
- Reduce watched checkmark size to 20pt
- Embed title in scrollable content (removes fixed nav bar)
- Add focus styling to library cards
- Improve grid spacing (50pt horizontal, 60pt vertical)

## Known Issues
- Back button from alphabet bar doesn't return focus to grid (#78)

## Test Plan
- [ ] Navigate to Library tab, verify cards have scale + glow on focus
- [ ] Open a large library (100+ items), scroll to bottom, verify more items load
- [ ] Check watched items have smaller checkmark
- [ ] Verify title scrolls with grid content
- [ ] Test alphabet bar navigation

🤖 Generated with [Claude Code](https://claude.com/claude-code)