### PR TITLE
Security: Restrict App Transport Security to local networking

### DIFF
--- a/Sashimi/Info.plist
+++ b/Sashimi/Info.plist
@@ -33,11 +33,7 @@
 	<string>1</string>
 	<key>NSAppTransportSecurity</key>
 	<dict>
-		<key>NSAllowsArbitraryLoads</key>
-		<true/>
-		<key>NSAllowsArbitraryLoadsForMedia</key>
-		<true/>
-		<key>NSAllowsArbitraryLoadsInWebContent</key>
+		<key>NSAllowsLocalNetworking</key>
 		<true/>
 	</dict>
 	<key>UILaunchScreen</key>


### PR DESCRIPTION
## Summary
- Remove blanket HTTP permissions that allowed connections anywhere
- Keep `NSAllowsLocalNetworking` for local Jellyfin servers

## Changes
- ❌ `NSAllowsArbitraryLoads` - removed
- ❌ `NSAllowsArbitraryLoadsForMedia` - removed  
- ❌ `NSAllowsArbitraryLoadsInWebContent` - removed
- ✅ `NSAllowsLocalNetworking` - kept for local servers

## Impact
- **Local servers** (192.168.x.x, 10.x.x.x): HTTP still works
- **Remote servers**: HTTPS required

Closes #1

🤖 Generated with [Claude Code](https://claude.com/claude-code)