### PR TITLE
Improve UX: toast categorization, form validation, progress bars (#31, #34, #29)

### DIFF
--- a/Sashimi/Views/Auth/ServerConnectionView.swift
+++ b/Sashimi/Views/Auth/ServerConnectionView.swift
@@ -68,21 +68,28 @@ struct ServerConnectionView: View {
                 VStack(spacing: 16) {
                     // Server Address Field with validation
                     VStack(alignment: .leading, spacing: 6) {
-                        TextField("Server Address (e.g., http://192.168.1.100:8096)", text: $serverAddress)
-                            .textFieldStyle(.plain)
-                            .padding()
-                            .background(validationFieldBackground(for: serverAddressValidation))
-                            .clipShape(RoundedRectangle(cornerRadius: 12))
-                            .overlay(
-                                RoundedRectangle(cornerRadius: 12)
-                                    .stroke(validationBorderColor(for: serverAddressValidation), lineWidth: 2)
-                            )
-                            .focused($focusedField, equals: .serverAddress)
-                            .autocorrectionDisabled()
-                            .textInputAutocapitalization(.never)
-                            .onChange(of: serverAddress) { _, newValue in
-                                validateServerAddress(newValue)
+                        HStack(spacing: 12) {
+                            TextField("Server Address (e.g., http://192.168.1.100:8096)", text: $serverAddress)
+                                .textFieldStyle(.plain)
+                                .focused($focusedField, equals: .serverAddress)
+                                .autocorrectionDisabled()
+                                .textInputAutocapitalization(.never)
+                                .onChange(of: serverAddress) { _, newValue in
+                                    validateServerAddress(newValue)
+                                }
+
+                            // Validation status icon
+                            if !serverAddress.isEmpty {
+                                validationIcon(for: serverAddressValidation)
                             }
+                        }
+                        .padding()
+                        .background(validationFieldBackground(for: serverAddressValidation))
+                        .clipShape(RoundedRectangle(cornerRadius: 12))
+                        .overlay(
+                            RoundedRectangle(cornerRadius: 12)
+                                .stroke(validationBorderColor(for: serverAddressValidation), lineWidth: 2)
+                        )
 
                         // Inline validation message
                         if let error = serverAddressValidation.errorMessage, hasAttemptedSubmit || !serverAddress.isEmpty {
@@ -170,21 +177,28 @@ struct ServerConnectionView: View {
 
                 // Username Field with validation
                 VStack(alignment: .leading, spacing: 6) {
-                    TextField("Username", text: $username)
-                        .textFieldStyle(.plain)
-                        .padding()
-                        .background(validationFieldBackground(for: usernameValidation))
-                        .clipShape(RoundedRectangle(cornerRadius: 12))
-                        .overlay(
-                            RoundedRectangle(cornerRadius: 12)
-                                .stroke(validationBorderColor(for: usernameValidation), lineWidth: 2)
-                        )
-                        .focused($focusedField, equals: .username)
-                        .autocorrectionDisabled()
-                        .textInputAutocapitalization(.never)
-                        .onChange(of: username) { _, newValue in
-                            validateUsername(newValue)
+                    HStack(spacing: 12) {
+                        TextField("Username", text: $username)
+                            .textFieldStyle(.plain)
+                            .focused($focusedField, equals: .username)
+                            .autocorrectionDisabled()
+                            .textInputAutocapitalization(.never)
+                            .onChange(of: username) { _, newValue in
+                                validateUsername(newValue)
+                            }
+
+                        // Validation status icon
+                        if !username.isEmpty || hasAttemptedSubmit {
+                            validationIcon(for: usernameValidation)
                         }
+                    }
+                    .padding()
+                    .background(validationFieldBackground(for: usernameValidation))
+                    .clipShape(RoundedRectangle(cornerRadius: 12))
+                    .overlay(
+                        RoundedRectangle(cornerRadius: 12)
+                            .stroke(validationBorderColor(for: usernameValidation), lineWidth: 2)
+                    )
 
                     // Inline validation message
                     if let error = usernameValidation.errorMessage, hasAttemptedSubmit {
@@ -277,6 +291,22 @@ struct ServerConnectionView: View {
 
         // Valid!
         usernameValidation = .valid
+    }
+
+    @ViewBuilder
+    private func validationIcon(for state: ValidationState) -> some View {
+        switch state {
+        case .idle:
+            EmptyView()
+        case .valid:
+            Image(systemName: "checkmark.circle.fill")
+                .font(.system(size: 22))
+                .foregroundStyle(.green)
+        case .invalid:
+            Image(systemName: "xmark.circle.fill")
+                .font(.system(size: 22))
+                .foregroundStyle(.red)
+        }
     }
 
     private func validationFieldBackground(for state: ValidationState) -> Color {

--- a/Sashimi/Views/Components/StateViews.swift
+++ b/Sashimi/Views/Components/StateViews.swift
@@ -197,6 +197,7 @@ struct SashimiProgressBar: View {
     let progress: Double
     var height: CGFloat = 4
     var showBackground: Bool = true
+    var useGradient: Bool = false
 
     var body: some View {
         GeometryReader { geo in
@@ -207,10 +208,24 @@ struct SashimiProgressBar: View {
                 }
 
                 RoundedRectangle(cornerRadius: height / 2)
-                    .fill(SashimiTheme.accent)
+                    .fill(progressFill)
                     .frame(width: geo.size.width * min(max(progress, 0), 1))
             }
         }
         .frame(height: height)
+    }
+
+    private var progressFill: AnyShapeStyle {
+        if useGradient {
+            return AnyShapeStyle(
+                LinearGradient(
+                    colors: [SashimiTheme.accent, SashimiTheme.accent.opacity(0.7)],
+                    startPoint: .leading,
+                    endPoint: .trailing
+                )
+            )
+        } else {
+            return AnyShapeStyle(SashimiTheme.accent)
+        }
     }
 }

--- a/Sashimi/Views/Detail/MediaDetailView.swift
+++ b/Sashimi/Views/Detail/MediaDetailView.swift
@@ -178,7 +178,7 @@ struct MediaDetailView: View {
     private func deleteItem() async {
         do {
             try await JellyfinClient.shared.deleteItem(itemId: item.id)
-            ToastManager.shared.show("Item deleted")
+            ToastManager.shared.show("Item deleted", type: .success)
             // Small delay to let the toast appear before dismissing
             try? await Task.sleep(for: .milliseconds(500))
             await MainActor.run {
@@ -205,7 +205,7 @@ struct MediaDetailView: View {
         do {
             // Refresh metadata on server
             try await JellyfinClient.shared.refreshMetadata(itemId: item.id)
-            ToastManager.shared.show("Metadata refresh started")
+            ToastManager.shared.show("Metadata refresh started", type: .info)
 
             // Wait a moment for server to process
             try await Task.sleep(for: .seconds(2))
@@ -1028,13 +1028,9 @@ struct EpisodeCard: View {
                     }
 
                     if episode.progressPercent > 0 {
-                        GeometryReader { geo in
-                            VStack {
-                                Spacer()
-                                Rectangle()
-                                    .fill(SashimiTheme.highlight)
-                                    .frame(width: geo.size.width * episode.progressPercent, height: 3)
-                            }
+                        VStack {
+                            Spacer()
+                            SashimiProgressBar(progress: episode.progressPercent, height: 4, showBackground: false)
                         }
                     }
 

--- a/Sashimi/Views/Home/ContinueWatchingRow.swift
+++ b/Sashimi/Views/Home/ContinueWatchingRow.swift
@@ -125,8 +125,7 @@ struct ContinueWatchingCard: View {
                                 .foregroundStyle(SashimiTheme.textSecondary)
                         }
 
-                        ContinueProgressBar(progress: item.progressPercent)
-                            .frame(height: 5)
+                        SashimiProgressBar(progress: item.progressPercent, height: 5, useGradient: true)
                     }
                     .padding(.horizontal, 16)
                     .padding(.bottom, 14)
@@ -195,29 +194,6 @@ struct ContinueWatchingCard: View {
             return "\(hours)h \(minutes)m left"
         }
         return "\(minutes)m left"
-    }
-}
-
-struct ContinueProgressBar: View {
-    let progress: Double
-
-    var body: some View {
-        GeometryReader { geometry in
-            ZStack(alignment: .leading) {
-                RoundedRectangle(cornerRadius: 3)
-                    .fill(SashimiTheme.progressBackground)
-
-                RoundedRectangle(cornerRadius: 3)
-                    .fill(
-                        LinearGradient(
-                            colors: [SashimiTheme.accent, SashimiTheme.accent.opacity(0.7)],
-                            startPoint: .leading,
-                            endPoint: .trailing
-                        )
-                    )
-                    .frame(width: geometry.size.width * min(max(progress, 0), 1))
-            }
-        }
     }
 }
 


### PR DESCRIPTION
## Summary
- **Toast categorization (#31)**: Properly categorize toast messages by type (error, warning, info, success)
- **Inline form validation (#34)**: Add visual checkmark/x icons to server connection form fields
- **Standardize progress bars (#29)**: Create unified SashimiProgressBar component with gradient support

## Changes

### Toast categorization
- Update "Item deleted" to success type (green)
- Update "Metadata refresh started" to info type (blue)

### Form validation
- Add checkmark icon (green) when server address is valid
- Add X icon (red) when server address is invalid
- Same for username field

### Progress bars
- Enhance `SashimiProgressBar` with optional gradient support
- Update `ContinueWatchingRow` to use unified component
- Update `EpisodeCard` to use unified component
- Remove duplicate `ContinueProgressBar` struct

## Test plan
- [ ] Verify toast colors match their types (delete item = green, refresh = blue, errors = red)
- [ ] Verify form validation icons appear when typing
- [ ] Verify progress bars look consistent across Continue Watching and episode cards

Closes #31
Closes #34
Closes #29

🤖 Generated with [Claude Code](https://claude.com/claude-code)