### PR TITLE
Add UX improvements: exit hint, accessibility, finish time (#14, #11, #91)

### DIFF
--- a/Sashimi/Views/Components/StateViews.swift
+++ b/Sashimi/Views/Components/StateViews.swift
@@ -198,6 +198,12 @@ struct SashimiProgressBar: View {
     var height: CGFloat = 4
     var showBackground: Bool = true
     var useGradient: Bool = false
+    var accessibilityLabelPrefix: String = "Progress"
+
+    private var accessibilityText: String {
+        let percent = Int(min(max(progress, 0), 1) * 100)
+        return "\(accessibilityLabelPrefix): \(percent) percent"
+    }
 
     var body: some View {
         GeometryReader { geo in
@@ -213,6 +219,9 @@ struct SashimiProgressBar: View {
             }
         }
         .frame(height: height)
+        .accessibilityElement(children: .ignore)
+        .accessibilityLabel(accessibilityText)
+        .accessibilityValue("\(Int(progress * 100)) percent")
     }
 
     private var progressFill: AnyShapeStyle {

--- a/Sashimi/Views/Library/LibraryView.swift
+++ b/Sashimi/Views/Library/LibraryView.swift
@@ -134,6 +134,8 @@ struct LibraryCardButton: View {
         }
         .buttonStyle(PlainNoHighlightButtonStyle())
         .focused($isFocused)
+        .accessibilityLabel("\(library.name) library")
+        .accessibilityHint("Double-tap to browse")
     }
 }
 
@@ -180,6 +182,8 @@ struct LibraryRowButton: View {
         }
         .buttonStyle(PlainNoHighlightButtonStyle())
         .focused($isFocused)
+        .accessibilityLabel("\(library.name) library")
+        .accessibilityHint("Double-tap to browse")
     }
 }
 
@@ -672,6 +676,8 @@ struct SortOrderButton: View {
         }
         .buttonStyle(PlainNoHighlightButtonStyle())
         .focused($isFocused)
+        .accessibilityLabel("Sort order: \(sortOrder.displayName)")
+        .accessibilityHint("Double-tap to toggle sort direction")
     }
 }
 


### PR DESCRIPTION
## Summary
- **Issue #14**: Two-press exit behavior with toast hint "Press Menu again to exit"
- **Issue #11**: Comprehensive VoiceOver accessibility labels across all interactive elements
- **Issue #91**: Show estimated finish time ("Ends at 10:45 PM") in media detail view

## Changes

### Exit Hint (#14)
- Added two-press exit requirement when at Home tab default state
- Shows informative toast on first Menu press
- 2.5 second timeout before requiring double-press again

### Accessibility (#11)
| Component | Accessibility Added |
|-----------|---------------------|
| MediaPosterButton | Title, type, year, progress, watched/favorite status |
| HeroSection | Title, episode info, carousel navigation hints |
| ContinueWatchingCard | Title, episode, remaining time |
| SashimiProgressBar | Percentage value announcement |
| ActionButton | Button title, media session trait |
| SeasonTab | Season name, selection state |
| EpisodeCard | Episode number, name, progress, now playing |
| LibraryCardButton | Library name with hint |
| SortOrderButton | Current sort order |
| CastCard | Actor name and role |

### Finish Time (#91)
- Displays "Ends at X:XX PM" next to runtime in detail view
- Calculates based on remaining time for partially watched content
- Uses device locale for time formatting

## Test plan
- [x] Build succeeds
- [ ] CI passes
- [ ] Test two-press exit on Home tab
- [ ] Enable VoiceOver and navigate all screens
- [ ] Verify finish time displays correctly

Closes #14, closes #11, closes #91

🤖 Generated with [Claude Code](https://claude.com/claude-code)