### PR TITLE
feat: Add Siri Remote swipe gestures for quick actions (#38)

### DIFF
--- a/Sashimi/Views/Components/MediaRow.swift
+++ b/Sashimi/Views/Components/MediaRow.swift
@@ -45,6 +45,7 @@ struct MediaPosterButton: View {
     var isCircular: Bool = false  // For YouTube channel-style circular covers
     var badgeCount: Int?  // Shows "X new" badge when > 1
     let onSelect: () -> Void
+    var onPlayPause: (() -> Void)?  // Optional: immediate playback on Play/Pause button
 
     @FocusState private var isFocused: Bool
 
@@ -300,6 +301,11 @@ struct MediaPosterButton: View {
                 }
             } label: {
                 Label("Refresh Metadata", systemImage: "arrow.triangle.2.circlepath")
+            }
+        }
+        .onPlayPauseCommand {
+            if let playPause = onPlayPause {
+                playPause()
             }
         }
     }

--- a/Sashimi/Views/Detail/MediaDetailView.swift
+++ b/Sashimi/Views/Detail/MediaDetailView.swift
@@ -33,6 +33,7 @@ struct MediaDetailView: View {
     @State private var showingDeleteConfirm = false
     @State private var isRefreshing = false
     @State private var refreshID = UUID()
+    @State private var showingFullCast = false
     @FocusState private var isMoreButtonFocused: Bool
 
     private var isSeries: Bool { item.type == .series }
@@ -144,6 +145,16 @@ struct MediaDetailView: View {
         }
         .fullScreenCover(item: $showingEpisodeDetail) { episode in
             MediaDetailView(item: episode, forceYouTubeStyle: forceYouTubeStyle)
+        }
+        .fullScreenCover(isPresented: $showingFullCast) {
+            if let people = item.people, !people.isEmpty {
+                FullCastView(people: people)
+            }
+        }
+        .onMoveCommand { direction in
+            if direction == .up, item.people?.isEmpty == false {
+                showingFullCast = true
+            }
         }
         .alert("File Info", isPresented: $showingFileInfo) {
             Button("OK", role: .cancel) { }
@@ -1145,5 +1156,149 @@ struct EpisodeCard: View {
         }
 
         return parts.joined(separator: ", ")
+    }
+}
+
+// MARK: - Full Cast View
+
+struct FullCastView: View {
+    let people: [PersonInfo]
+    @Environment(\.dismiss) private var dismiss
+
+    private var cast: [PersonInfo] {
+        people.filter { $0.type == "Actor" }
+    }
+
+    private var crew: [PersonInfo] {
+        people.filter { $0.type != "Actor" }
+    }
+
+    private var directors: [PersonInfo] {
+        crew.filter { $0.type == "Director" }
+    }
+
+    private var writers: [PersonInfo] {
+        crew.filter { $0.type == "Writer" }
+    }
+
+    private var otherCrew: [PersonInfo] {
+        crew.filter { $0.type != "Director" && $0.type != "Writer" }
+    }
+
+    var body: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: 40) {
+                // Header
+                HStack {
+                    Text("Cast & Crew")
+                        .font(.system(size: 48, weight: .bold))
+                        .foregroundStyle(SashimiTheme.textPrimary)
+                    Spacer()
+                    Text("Swipe down to close")
+                        .font(.subheadline)
+                        .foregroundStyle(SashimiTheme.textTertiary)
+                }
+                .padding(.horizontal, 80)
+                .padding(.top, 60)
+
+                // Cast section
+                if !cast.isEmpty {
+                    crewSection(title: "Cast", people: cast)
+                }
+
+                // Directors
+                if !directors.isEmpty {
+                    crewSection(title: "Directors", people: directors)
+                }
+
+                // Writers
+                if !writers.isEmpty {
+                    crewSection(title: "Writers", people: writers)
+                }
+
+                // Other crew
+                if !otherCrew.isEmpty {
+                    crewSection(title: "Crew", people: otherCrew)
+                }
+
+                Spacer().frame(height: 80)
+            }
+        }
+        .background(SashimiTheme.background.ignoresSafeArea())
+        .onExitCommand { dismiss() }
+        .onMoveCommand { direction in
+            if direction == .down {
+                dismiss()
+            }
+        }
+    }
+
+    private func crewSection(title: String, people: [PersonInfo]) -> some View {
+        VStack(alignment: .leading, spacing: 20) {
+            Text(title)
+                .font(.system(size: 32, weight: .semibold))
+                .foregroundStyle(SashimiTheme.textPrimary)
+                .padding(.horizontal, 80)
+
+            ScrollView(.horizontal, showsIndicators: false) {
+                LazyHStack(spacing: 24) {
+                    ForEach(people) { person in
+                        FullCastCard(person: person)
+                    }
+                }
+                .padding(.horizontal, 80)
+            }
+        }
+    }
+}
+
+struct FullCastCard: View {
+    let person: PersonInfo
+
+    var body: some View {
+        VStack(spacing: 12) {
+            if person.primaryImageTag != nil {
+                AsyncImage(url: JellyfinClient.shared.personImageURL(personId: person.id, maxWidth: 300)) { image in
+                    image.resizable().aspectRatio(contentMode: .fill)
+                } placeholder: {
+                    Circle().fill(SashimiTheme.cardBackground)
+                }
+                .frame(width: 150, height: 150)
+                .clipShape(Circle())
+            } else {
+                Circle()
+                    .fill(SashimiTheme.cardBackground)
+                    .frame(width: 150, height: 150)
+                    .overlay {
+                        Image(systemName: "person.fill")
+                            .font(.system(size: 50))
+                            .foregroundStyle(SashimiTheme.textTertiary)
+                    }
+            }
+
+            VStack(spacing: 4) {
+                Text(person.name)
+                    .font(.system(size: 20, weight: .medium))
+                    .foregroundStyle(SashimiTheme.textPrimary)
+                    .lineLimit(2)
+                    .multilineTextAlignment(.center)
+
+                if let role = person.role, !role.isEmpty {
+                    Text(role)
+                        .font(.system(size: 16))
+                        .foregroundStyle(SashimiTheme.textSecondary)
+                        .lineLimit(2)
+                        .multilineTextAlignment(.center)
+                } else if let type = person.type, type != "Actor" {
+                    Text(type)
+                        .font(.system(size: 16))
+                        .foregroundStyle(SashimiTheme.textTertiary)
+                        .lineLimit(1)
+                }
+            }
+        }
+        .frame(width: 160)
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel(person.role != nil ? "\(person.name) as \(person.role!)" : person.name)
     }
 }

--- a/Sashimi/Views/Home/ContinueWatchingRow.swift
+++ b/Sashimi/Views/Home/ContinueWatchingRow.swift
@@ -3,6 +3,7 @@ import SwiftUI
 struct ContinueWatchingRow: View {
     let items: [BaseItemDto]
     let onSelect: (BaseItemDto) -> Void
+    var onPlay: ((BaseItemDto) -> Void)?  // Optional: immediate playback on Play button
 
     var body: some View {
         VStack(alignment: .leading, spacing: 20) {
@@ -20,9 +21,11 @@ struct ContinueWatchingRow: View {
             ScrollView(.horizontal, showsIndicators: false) {
                 LazyHStack(spacing: 40) {
                     ForEach(items) { item in
-                        ContinueWatchingCard(item: item) {
-                            onSelect(item)
-                        }
+                        ContinueWatchingCard(
+                            item: item,
+                            onSelect: { onSelect(item) },
+                            onPlayPause: onPlay != nil ? { onPlay?(item) } : nil
+                        )
                     }
                 }
                 .padding(.horizontal, 80)
@@ -35,6 +38,7 @@ struct ContinueWatchingRow: View {
 struct ContinueWatchingCard: View {
     let item: BaseItemDto
     let onSelect: () -> Void
+    var onPlayPause: (() -> Void)?  // Optional: immediate playback on Play/Pause button
 
     @FocusState private var isFocused: Bool
 
@@ -167,7 +171,12 @@ struct ContinueWatchingCard: View {
         .focused($isFocused)
         .accessibilityElement(children: .combine)
         .accessibilityLabel(accessibilityDescription)
-        .accessibilityHint("Double-tap to resume playback")
+        .accessibilityHint("Double-tap to resume playback, or press Play to start immediately")
+        .onPlayPauseCommand {
+            if let playPause = onPlayPause {
+                playPause()
+            }
+        }
     }
 
     private var accessibilityDescription: String {

--- a/Sashimi/Views/Home/HomeView.swift
+++ b/Sashimi/Views/Home/HomeView.swift
@@ -17,6 +17,7 @@ struct HomeView: View {
     @State private var refreshTimer: Timer?
     @State private var heroIndex: Int = 0
     @State private var showContinueWatchingDetail = false
+    @State private var playingItem: BaseItemDto?  // For immediate playback via Play button
     @Binding var resetTrigger: Bool
     @Binding var isAtDefaultState: Bool
 
@@ -84,6 +85,9 @@ struct HomeView: View {
             .fullScreenCover(item: $selectedItem) { item in
                 MediaDetailView(item: item, forceYouTubeStyle: selectedItemIsYouTube)
             }
+            .fullScreenCover(item: $playingItem) { item in
+                PlayerView(item: item, startFromBeginning: false)
+            }
             .fullScreenCover(isPresented: $showContinueWatchingDetail) {
                 ContinueWatchingDetailView(
                     items: viewModel.continueWatchingItems,
@@ -97,6 +101,11 @@ struct HomeView: View {
                 )
             }
             .onChange(of: selectedItem) { oldValue, newValue in
+                if oldValue != nil && newValue == nil {
+                    Task { await viewModel.refresh() }
+                }
+            }
+            .onChange(of: playingItem) { oldValue, newValue in
                 if oldValue != nil && newValue == nil {
                     Task { await viewModel.refresh() }
                 }
@@ -155,6 +164,9 @@ struct HomeView: View {
                         onSelect: { item in
                             selectedItemIsYouTube = false
                             selectedItem = item
+                        },
+                        onPlay: { item in
+                            playingItem = item
                         }
                     )
                     .focusSection()


### PR DESCRIPTION
## Summary
Adds Siri Remote swipe gestures for faster navigation:
- **Swipe up** on media detail: Show full cast & crew
- **Swipe down** on modals: Dismiss (more intuitive than Menu)
- **Play/Pause button** on Continue Watching: Immediate playback

## Changes

### Swipe Up - Full Cast/Crew View
- New `FullCastView` with sections for Cast, Directors, Writers, Crew
- Larger profile images (150px) and role information
- Accessible via swipe up gesture on MediaDetailView
- Swipe down or Menu button to dismiss

### Swipe Down - Modal Dismiss
- Added to FullCastView as alternative to Menu button
- More intuitive gesture for dismissing sheets

### Play/Pause Immediate Playback
- `MediaPosterButton`: Added optional `onPlayPause` callback
- `ContinueWatchingCard`: Triggers immediate playback
- `ContinueWatchingRow`: New `onPlay` callback
- `HomeView`: Opens PlayerView directly when Play pressed on Continue Watching

## Test plan
- [x] Build succeeds
- [ ] CI passes
- [ ] Swipe up on movie/series detail to see full cast
- [ ] Swipe down to dismiss cast view
- [ ] Focus Continue Watching item, press Play button → immediate playback

Closes #38

🤖 Generated with [Claude Code](https://claude.com/claude-code)