### PR TITLE
fix: Improve Continue Watching sorting and remove visual clutter

### DIFF
--- a/Sashimi/Views/Home/ContinueWatchingRow.swift
+++ b/Sashimi/Views/Home/ContinueWatchingRow.swift
@@ -7,16 +7,10 @@ struct ContinueWatchingRow: View {
 
     var body: some View {
         VStack(alignment: .leading, spacing: 20) {
-            HStack(alignment: .lastTextBaseline, spacing: 12) {
-                Text("Continue Watching")
-                    .font(.system(size: 40, weight: .bold))
-                    .foregroundStyle(SashimiTheme.textPrimary)
-
-                Image(systemName: "play.circle.fill")
-                    .font(.system(size: 38))
-                    .foregroundStyle(SashimiTheme.accent)
-            }
-            .padding(.horizontal, 80)
+            Text("Continue Watching")
+                .font(.system(size: 40, weight: .bold))
+                .foregroundStyle(SashimiTheme.textPrimary)
+                .padding(.horizontal, 80)
 
             ScrollView(.horizontal, showsIndicators: false) {
                 LazyHStack(spacing: 40) {
@@ -220,21 +214,11 @@ struct ContinueWatchingDetailView: View {
             ScrollView {
                 VStack(alignment: .leading, spacing: 30) {
                     // Header
-                    HStack {
-                        VStack(alignment: .leading, spacing: 8) {
-                            Text("Continue Watching")
-                                .font(.system(size: 48, weight: .bold))
-                                .foregroundStyle(SashimiTheme.textPrimary)
-
-                            Text("\(items.count) items in progress")
-                                .font(.system(size: 22))
-                                .foregroundStyle(SashimiTheme.textSecondary)
-                        }
-
-                        Spacer()
-                    }
-                    .padding(.horizontal, 80)
-                    .padding(.top, 40)
+                    Text("Continue Watching")
+                        .font(.system(size: 48, weight: .bold))
+                        .foregroundStyle(SashimiTheme.textPrimary)
+                        .padding(.horizontal, 80)
+                        .padding(.top, 40)
 
                     // Grid of items
                     LazyVGrid(columns: [


### PR DESCRIPTION
## Summary
- Remove play icon next to "Continue Watching" title
- Remove item count from "See All" view header
- Fix sorting to prioritize most recently watched items

## Changes

### Visual cleanup
- Removed play.circle.fill icon from Continue Watching row title
- Removed "X items in progress" count from ContinueWatchingDetailView

### Sorting fix
The issue: NextUp items don't have `lastPlayedDate` (they're the next episode, not yet played), so they were being sorted incorrectly.

New sorting logic:
1. Items with `lastPlayedDate` sorted by most recent first
2. Items without dates (NextUp) maintain original API order (Jellyfin already returns them sorted by series last activity)
3. Resume items take priority over NextUp when both lack dates
4. Deduplication by series remains unchanged

## Test plan
- [x] Build succeeds
- [ ] CI passes
- [ ] Verify most recently watched items appear first in Continue Watching
- [ ] Verify play icon removed from row title
- [ ] Verify count removed from See All view

🤖 Generated with [Claude Code](https://claude.com/claude-code)