### PR TITLE
fix: Update bundle ID to unique identifier

### DIFF
--- a/Sashimi/Info.plist
+++ b/Sashimi/Info.plist
@@ -22,7 +22,7 @@
 	<array>
 		<dict>
 			<key>CFBundleURLName</key>
-			<string>com.sashimi.app</string>
+			<string>com.mondominator.sashimi</string>
 			<key>CFBundleURLSchemes</key>
 			<array>
 				<string>sashimi</string>

--- a/Sashimi/Sashimi.entitlements
+++ b/Sashimi/Sashimi.entitlements
@@ -2,9 +2,9 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-    <key>com.apple.security.application-groups</key>
-    <array>
-        <string>group.com.sashimi.app</string>
-    </array>
+	<key>com.apple.security.application-groups</key>
+	<array>
+		<string>group.com.mondominator.sashimi</string>
+	</array>
 </dict>
 </plist>

--- a/TopShelf/TopShelf.entitlements
+++ b/TopShelf/TopShelf.entitlements
@@ -2,9 +2,9 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-    <key>com.apple.security.application-groups</key>
-    <array>
-        <string>group.com.sashimi.app</string>
-    </array>
+	<key>com.apple.security.application-groups</key>
+	<array>
+		<string>group.com.mondominator.sashimi</string>
+	</array>
 </dict>
 </plist>

--- a/project.yml
+++ b/project.yml
@@ -37,10 +37,10 @@ targets:
         CFBundleURLTypes:
           - CFBundleURLSchemes:
               - sashimi
-            CFBundleURLName: com.sashimi.app
+            CFBundleURLName: com.mondominator.sashimi
     settings:
       base:
-        PRODUCT_BUNDLE_IDENTIFIER: com.sashimi.app
+        PRODUCT_BUNDLE_IDENTIFIER: com.mondominator.sashimi
         MARKETING_VERSION: 1.0.0
         CURRENT_PROJECT_VERSION: 2
         SWIFT_VERSION: 5.9
@@ -60,7 +60,7 @@ targets:
       path: Sashimi/Sashimi.entitlements
       properties:
         com.apple.security.application-groups:
-          - group.com.sashimi.app
+          - group.com.mondominator.sashimi
     dependencies:
       - target: TopShelf
 
@@ -79,7 +79,7 @@ targets:
           NSExtensionPrincipalClass: $(PRODUCT_MODULE_NAME).ContentProvider
     settings:
       base:
-        PRODUCT_BUNDLE_IDENTIFIER: com.sashimi.app.topshelf
+        PRODUCT_BUNDLE_IDENTIFIER: com.mondominator.sashimi.topshelf
         MARKETING_VERSION: 1.0.0
         CURRENT_PROJECT_VERSION: 2
         SWIFT_VERSION: 5.9
@@ -93,7 +93,7 @@ targets:
       path: TopShelf/TopShelf.entitlements
       properties:
         com.apple.security.application-groups:
-          - group.com.sashimi.app
+          - group.com.mondominator.sashimi
     dependencies: []
 
   SashimiTests:
@@ -105,7 +105,7 @@ targets:
           - "**/.DS_Store"
     settings:
       base:
-        PRODUCT_BUNDLE_IDENTIFIER: com.sashimi.app.tests
+        PRODUCT_BUNDLE_IDENTIFIER: com.mondominator.sashimi.tests
         SWIFT_VERSION: 5.9
         SDKROOT: appletvos
         SUPPORTED_PLATFORMS: "appletvos appletvsimulator"


### PR DESCRIPTION
## Summary
- Change bundle ID from `com.sashimi.app` to `com.mondominator.sashimi`
- Avoids conflicts with globally registered identifiers

## Test plan
- [x] Build and install on Apple TV works

🤖 Generated with [Claude Code](https://claude.com/claude-code)