### PR TITLE
fix: offline playback uses fullscreen player

### DIFF
--- a/SashimiMobile/Views/Offline/OfflineHomeView.swift
+++ b/SashimiMobile/Views/Offline/OfflineHomeView.swift
@@ -8,6 +8,7 @@ struct OfflineHomeView: View {
         sort: \DownloadedItem.dateCompleted,
         order: .reverse
     ) private var downloads: [DownloadedItem]
+    @State private var playingItem: BaseItemDto?
 
     var body: some View {
         ScrollView {
@@ -51,6 +52,7 @@ struct OfflineHomeView: View {
         }
         .background(MobileColors.background)
         .navigationTitle("Downloads")
+        .fullScreenPlayer(item: $playingItem)
     }
 
     private var offlineBanner: some View {
@@ -119,8 +121,8 @@ struct OfflineHomeView: View {
             remoteTrailers: nil
         )
 
-        return NavigationLink {
-            MobilePlayerView(item: playableItem)
+        return Button {
+            playingItem = playableItem
         } label: {
             VStack(alignment: .leading, spacing: MobileSpacing.xs) {
                 // Poster


### PR DESCRIPTION
## Summary
- OfflineHomeView now uses `.fullScreenPlayer(item:)` instead of `NavigationLink` to `MobilePlayerView`
- Player appears fullscreen with close button, matching online behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)