### PR TITLE
feat: download indicator with bandwidth speed

### DIFF
--- a/SashimiMobile/Downloads/Services/DownloadManager.swift
+++ b/SashimiMobile/Downloads/Services/DownloadManager.swift
@@ -14,6 +14,7 @@ final class DownloadManager: NSObject, ObservableObject {
 
     @Published var activeDownloads: [String: Double] = [:] // itemId -> progress
     @Published var stateVersion: Int = 0 // bumped on any download state change
+    @Published var downloadSpeed: String = "" // human-readable bandwidth
 
     // swiftlint:disable:next implicitly_unwrapped_optional
     private var backgroundSession: URLSession!
@@ -40,11 +41,16 @@ final class DownloadManager: NSObject, ObservableObject {
     // Serial download queue
     private var downloadQueue: [(item: BaseItemDto, quality: DownloadQuality)] = []
     private var currentDownloadItemId: String?
+    var queuedCount: Int { downloadQueue.count }
 
     // Progress throttling
     private var pendingProgress: [String: Double] = [:]
     private var lastProgressSave: [String: Date] = [:]
     private var progressTimer: Timer?
+
+    // Bandwidth tracking
+    private var lastBytesWritten: Int64 = 0
+    private var lastSpeedCheck: Date = .distantPast
 
     // In-memory preparing state (items waiting for first bytes from server)
     @Published var preparingItems: Set<String> = []
@@ -150,8 +156,13 @@ final class DownloadManager: NSObject, ObservableObject {
         guard !downloadQueue.isEmpty else {
             currentDownloadItemId = nil
             stopProgressTimer()
+            downloadSpeed = ""
             return
         }
+
+        // Reset speed tracking for new download
+        lastBytesWritten = 0
+        lastSpeedCheck = .distantPast
 
         let (item, quality) = downloadQueue.removeFirst()
         let itemId = item.id
@@ -598,8 +609,22 @@ extension DownloadManager: URLSessionDownloadDelegate {
                 self.preparingItems.remove(itemId)
             }
 
-            // Throttle SwiftData writes to every 5s per item
+            // Bandwidth tracking
             let now = Date()
+            let elapsed = now.timeIntervalSince(self.lastSpeedCheck)
+            if elapsed >= 1.0 {
+                let bytesDelta = totalBytesWritten - self.lastBytesWritten
+                if bytesDelta > 0 {
+                    let bytesPerSecond = Double(bytesDelta) / elapsed
+                    self.downloadSpeed = ByteCountFormatter.string(
+                        fromByteCount: Int64(bytesPerSecond), countStyle: .file
+                    ) + "/s"
+                }
+                self.lastBytesWritten = totalBytesWritten
+                self.lastSpeedCheck = now
+            }
+
+            // Throttle SwiftData writes to every 5s per item
             let lastSave = self.lastProgressSave[itemId] ?? .distantPast
             if now.timeIntervalSince(lastSave) >= 5 {
                 self.lastProgressSave[itemId] = now

--- a/SashimiMobile/Views/Navigation/SidebarView.swift
+++ b/SashimiMobile/Views/Navigation/SidebarView.swift
@@ -321,11 +321,15 @@ struct MainNavigationView: View {
 
     @ViewBuilder
     private var downloadIndicator: some View {
-        let activeCount = downloadQueueCount()
+        // Use in-memory state for active (always current), SwiftData for completed/failed
+        let activeCount = downloadManager.activeDownloads.count
+            + downloadManager.preparingItems.count
+            + downloadManager.queuedCount
         let failedCount = downloadFailedCount()
         let completedCount = downloadCompletedCount()
+        let speed = downloadManager.downloadSpeed
 
-        HStack(spacing: 8) {
+        HStack(spacing: 6) {
             if activeCount > 0 {
                 HStack(spacing: 4) {
                     Image(systemName: "arrow.down.circle")
@@ -335,6 +339,11 @@ struct MainNavigationView: View {
                     Text("\(activeCount)")
                         .font(.system(size: 13, weight: .semibold))
                         .foregroundStyle(MobileColors.accent)
+                    if !speed.isEmpty {
+                        Text("(\(speed))")
+                            .font(.system(size: 11))
+                            .foregroundStyle(MobileColors.accent.opacity(0.8))
+                    }
                 }
                 .padding(.horizontal, 8)
                 .padding(.vertical, 5)
@@ -374,18 +383,6 @@ struct MainNavigationView: View {
             }
         }
         .onTapGesture { selection = .downloads }
-    }
-
-    private func downloadQueueCount() -> Int {
-        // Re-read on stateVersion changes
-        _ = downloadManager.stateVersion
-        guard let container = DownloadManager.shared.modelContainer else { return 0 }
-        let context = ModelContext(container)
-        let predicate = #Predicate<DownloadedItem> {
-            $0.statusRaw == "queued" || $0.statusRaw == "downloading" || $0.statusRaw == "preparing"
-        }
-        let descriptor = FetchDescriptor<DownloadedItem>(predicate: predicate)
-        return (try? context.fetchCount(descriptor)) ?? 0
     }
 
     private func downloadCompletedCount() -> Int {


### PR DESCRIPTION
## Summary
- Active count uses in-memory state (fixes stale count bug)
- Includes queued items in count
- Shows bandwidth speed e.g. "(12.3 MB/s)"
- Green completed + red failed always visible

🤖 Generated with [Claude Code](https://claude.com/claude-code)