### PR TITLE
fix: iPad search bar visibility

### DIFF
--- a/SashimiMobile/Views/Navigation/SidebarView.swift
+++ b/SashimiMobile/Views/Navigation/SidebarView.swift
@@ -57,7 +57,7 @@ struct MainNavigationView: View {
                     // Content area
                     NavigationStack {
                         detailView
-                            .navigationBarHidden(true)
+                            .navigationBarHidden(selection == .search ? false : true)
                     }
                     .id("\(selection)-\(navigationResetId)")
                 }


### PR DESCRIPTION
## Summary
- Show navigation bar when on Search screen so `.searchable` works
- Keep it hidden for all other screens (custom header bar)

Refs #126

🤖 Generated with [Claude Code](https://claude.com/claude-code)