### PR TITLE
Phase 3: Unified multi-server home screen

### DIFF
--- a/Sashimi/Views/Home/ContinueWatchingRow.swift
+++ b/Sashimi/Views/Home/ContinueWatchingRow.swift
@@ -3,12 +3,19 @@ import SwiftUI
 struct ContinueWatchingRow: View {
     let items: [MediaItem]
     var libraryNames: [String: String] = [:]  // rawId -> Library name mapping
+    var showServerBadges: Bool = false  // Whether to show server type badges on cards
     let onSelect: (MediaItem) -> Void
     var onPlay: ((MediaItem) -> Void)?  // Optional: immediate playback on Play button
 
     private func isYouTube(_ item: MediaItem) -> Bool {
         guard let libraryName = libraryNames[item.rawId] else { return false }
         return libraryName.lowercased().contains("youtube")
+    }
+
+    private func serverBadge(for item: MediaItem) -> String? {
+        guard showServerBadges,
+              let server = ServerManager.shared.server(forId: item.serverId) else { return nil }
+        return server.name
     }
 
     var body: some View {
@@ -24,6 +31,7 @@ struct ContinueWatchingRow: View {
                         ContinueWatchingCard(
                             item: item,
                             isYouTube: isYouTube(item),
+                            serverBadge: serverBadge(for: item),
                             onSelect: { onSelect(item) },
                             onPlayPause: onPlay != nil ? { onPlay?(item) } : nil
                         )
@@ -39,6 +47,7 @@ struct ContinueWatchingRow: View {
 struct ContinueWatchingCard: View {
     let item: MediaItem
     var isYouTube: Bool = false  // Whether this is YouTube content
+    var serverBadge: String?  // Short label when multiple servers connected (e.g. "J" or "P")
     let onSelect: () -> Void
     var onPlayPause: (() -> Void)?  // Optional: immediate playback on Play/Pause button
 
@@ -160,6 +169,17 @@ struct ContinueWatchingCard: View {
                     .frame(width: 440, alignment: .leading)
                 }
                 .clipShape(RoundedRectangle(cornerRadius: 16))
+                .overlay(alignment: .topTrailing) {
+                    if let badge = serverBadge {
+                        Text(badge)
+                            .font(.system(size: 14, weight: .bold))
+                            .foregroundStyle(.white)
+                            .padding(.horizontal, 8)
+                            .padding(.vertical, 4)
+                            .background(Capsule().fill(SashimiTheme.accent.opacity(0.85)))
+                            .padding(8)
+                    }
+                }
                 .overlay(
                     RoundedRectangle(cornerRadius: 16)
                         .stroke(isFocused ? SashimiTheme.accent : .clear, lineWidth: 4)

--- a/Sashimi/Views/Home/HomeView.swift
+++ b/Sashimi/Views/Home/HomeView.swift
@@ -42,6 +42,16 @@ struct HomeView: View {
         }
     }
 
+    /// When multiple servers are connected, append the server name to the library name
+    /// so users can distinguish "Movies -- JellyPal" from "Movies -- Plex".
+    private func libraryDisplayName(_ library: MediaLibrary) -> String {
+        if serverManager.servers.count > 1,
+           let server = serverManager.server(forId: library.serverId) {
+            return "\(library.name) \u{2014} \(server.name)"
+        }
+        return library.name
+    }
+
     var body: some View {
         NavigationStack {
             ZStack(alignment: .topLeading) {
@@ -169,6 +179,7 @@ struct HomeView: View {
                     ContinueWatchingRow(
                         items: viewModel.continueWatchingItems,
                         libraryNames: viewModel.continueWatchingLibraryNames,
+                        showServerBadges: serverManager.servers.count > 1,
                         onSelect: { item in
                             // Check if item comes from a library named YouTube
                             let libraryName = viewModel.continueWatchingLibraryNames[item.rawId] ?? ""
@@ -185,10 +196,14 @@ struct HomeView: View {
             }
         } else if let libraryId = config.libraryId,
                   let library = viewModel.libraries.first(where: { $0.rawId == libraryId }) {
-            RecentlyAddedLibraryRow(library: library, onSelect: { item in
-                selectedItemIsYouTube = library.name.lowercased().contains("youtube")
-                selectedItem = item
-            })
+            RecentlyAddedLibraryRow(
+                library: library,
+                displayName: libraryDisplayName(library),
+                onSelect: { item in
+                    selectedItemIsYouTube = library.name.lowercased().contains("youtube")
+                    selectedItem = item
+                }
+            )
             .focusSection()
         }
     }
@@ -557,6 +572,7 @@ struct HeroSection: View {
 // MARK: - Recently Added Library Row
 struct RecentlyAddedLibraryRow: View {
     let library: MediaLibrary
+    var displayName: String?  // Override for multi-server display (e.g. "Movies -- ServerName")
     let onSelect: (MediaItem) -> Void
     @State private var items: [MediaItem] = []
     @State private var episodeCounts: [String: Int] = [:]  // seriesId -> count of new episodes
@@ -564,7 +580,7 @@ struct RecentlyAddedLibraryRow: View {
     @State private var loadError = false
 
     private var sectionTitle: String {
-        "Recently Added \(library.name)".cleanedYouTubeTitle
+        "Recently Added \(displayName ?? library.name)".cleanedYouTubeTitle
     }
 
     // Detect YouTube library by name
@@ -648,29 +664,18 @@ struct RecentlyAddedLibraryRow: View {
         loadError = false
 
         do {
+            guard let server = ServerManager.shared.server(forId: library.serverId) else { return }
+
+            // Use the MediaServer protocol for multi-server support
+            let latestItems = try await server.getLatestMedia(libraryId: library.rawId, limit: 30)
+
+            // Deduplicate by series for TV libraries
             let isTVLibrary = library.collectionType?.lowercased() == "tvshows"
-            let fetchLimit = 30
+            items = deduplicateMediaItemsBySeries(latestItems)
 
-            let latestItems = try await JellyfinClient.shared.getLatestMedia(
-                parentId: library.rawId,
-                limit: fetchLimit,
-                includeWatched: true,
-                collectionType: library.collectionType,
-                isYouTubeLibrary: isYouTubeLibrary
-            )
-            let dedupedDtos = deduplicateBySeries(latestItems)
-
-            // Convert to MediaItem using the server
-            guard let server = ServerManager.shared.primaryServer else { return }
-            items = dedupedDtos.map { dto in
-                // Use raw mapping via the server's getItem for consistency
-                // But since we already have the DTOs, map locally
-                mapDtoToMediaItem(dto, serverId: server.id)
-            }
-
-            // Fetch actual unplayed counts from series (for TV shows)
-            if isTVLibrary {
-                await loadUnplayedCounts(for: dedupedDtos)
+            // Fetch actual unplayed counts from series (for Jellyfin TV shows)
+            if isTVLibrary && server.serverType == .jellyfin {
+                await loadUnplayedCounts(for: items)
             }
         } catch is CancellationError {
             // Ignore cancellation errors - expected during navigation
@@ -681,18 +686,18 @@ struct RecentlyAddedLibraryRow: View {
         isLoading = false
     }
 
-    private func loadUnplayedCounts(for dtos: [BaseItemDto]) async {
+    private func loadUnplayedCounts(for mediaItems: [MediaItem]) async {
         var counts: [String: Int] = [:]
 
         // Collect unique series IDs
-        let seriesIds = Set(dtos.compactMap { item -> String? in
+        let seriesIds = Set(mediaItems.compactMap { item -> String? in
             if item.type == .episode { return item.seriesId }
             if item.type == .video { return item.seriesId }
-            if item.type == .series { return item.id }
+            if item.type == .series { return item.rawId }
             return nil
         })
 
-        // Fetch each series to get its unplayed count
+        // Fetch each series to get its unplayed count (Jellyfin-specific)
         for seriesId in seriesIds {
             do {
                 let series = try await JellyfinClient.shared.getItem(itemId: seriesId)
@@ -707,16 +712,16 @@ struct RecentlyAddedLibraryRow: View {
         episodeCounts = counts
     }
 
-    private func deduplicateBySeries(_ items: [BaseItemDto]) -> [BaseItemDto] {
+    private func deduplicateMediaItemsBySeries(_ items: [MediaItem]) -> [MediaItem] {
         var seen = Set<String>()
-        var result: [BaseItemDto] = []
+        var result: [MediaItem] = []
 
         for item in items {
             let key: String
             if item.type == .episode || item.type == .video {
-                key = item.seriesId ?? item.id
+                key = item.seriesId ?? item.rawId
             } else {
-                key = item.id
+                key = item.rawId
             }
             if !seen.contains(key) {
                 seen.insert(key)
@@ -725,10 +730,6 @@ struct RecentlyAddedLibraryRow: View {
         }
 
         return Array(result.prefix(20))
-    }
-
-    private func mapDtoToMediaItem(_ dto: BaseItemDto, serverId: String) -> MediaItem {
-        MediaItemMapper.map(dto, serverId: serverId)
     }
 }
 

--- a/Sashimi/Views/Library/SettingsView.swift
+++ b/Sashimi/Views/Library/SettingsView.swift
@@ -8,6 +8,7 @@ struct SettingsView: View {
     var onBackAtRoot: (() -> Void)?
     @EnvironmentObject private var serverManager: ServerManager
     @State private var showingLogoutConfirmation = false
+    @State private var showingAddServer = false
     @State private var navigationPath = NavigationPath()
 
     var body: some View {
@@ -58,6 +59,12 @@ struct SettingsView: View {
                             ) {
                                 navigationPath.append(SettingsDestination.appIcon)
                             }
+
+                            // Connected Servers section
+                            ConnectedServersSection(
+                                showAddServer: $showingAddServer
+                            )
+                            .padding(.top, 20)
 
                             // About section
                             VStack(spacing: 12) {
@@ -113,6 +120,9 @@ struct SettingsView: View {
             } else {
                 onBackAtRoot?()
             }
+        }
+        .fullScreenCover(isPresented: $showingAddServer) {
+            ServerConnectionView()
         }
     }
 }
@@ -529,6 +539,153 @@ struct HomeRowToggleButton: View {
         )
         .scaleEffect(isFocused ? 1.02 : 1.0)
         .animation(.spring(response: 0.3, dampingFraction: 0.7), value: isFocused)
+        .focused($isFocused)
+    }
+}
+
+// MARK: - Connected Servers Section
+
+struct ConnectedServersSection: View {
+    @EnvironmentObject private var serverManager: ServerManager
+    @Binding var showAddServer: Bool
+    @State private var serverToRemove: ServerAccount?
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 16) {
+            Text("Connected Servers")
+                .font(Typography.headline)
+                .foregroundStyle(SashimiTheme.textPrimary)
+                .padding(.bottom, 4)
+
+            ForEach(serverManager.accounts) { account in
+                ConnectedServerRow(
+                    account: account,
+                    onRemove: { serverToRemove = account }
+                )
+            }
+
+            // Add Server button
+            ConnectedServerAddButton {
+                showAddServer = true
+            }
+        }
+        .confirmationDialog(
+            "Remove Server",
+            isPresented: Binding(
+                get: { serverToRemove != nil },
+                set: { if !$0 { serverToRemove = nil } }
+            ),
+            titleVisibility: .visible
+        ) {
+            if let account = serverToRemove {
+                Button("Remove \(account.serverName)", role: .destructive) {
+                    serverManager.removeServer(id: account.id)
+                    serverToRemove = nil
+                }
+                Button("Cancel", role: .cancel) {
+                    serverToRemove = nil
+                }
+            }
+        } message: {
+            Text("This will disconnect the server. You can add it back later.")
+        }
+    }
+}
+
+struct ConnectedServerRow: View {
+    let account: ServerAccount
+    let onRemove: () -> Void
+    @FocusState private var isFocused: Bool
+    @FocusState private var removeIsFocused: Bool
+
+    private var serverTypeIcon: String {
+        switch account.serverType {
+        case .jellyfin: return "server.rack"
+        case .plex: return "play.square.stack"
+        }
+    }
+
+    private var serverTypeName: String {
+        switch account.serverType {
+        case .jellyfin: return "Jellyfin"
+        case .plex: return "Plex"
+        }
+    }
+
+    var body: some View {
+        HStack(spacing: 16) {
+            Image(systemName: serverTypeIcon)
+                .font(Typography.title)
+                .foregroundStyle(SashimiTheme.accent)
+                .frame(width: 50)
+
+            VStack(alignment: .leading, spacing: 4) {
+                Text(account.serverName)
+                    .font(Typography.body)
+                    .foregroundStyle(SashimiTheme.textPrimary)
+
+                HStack(spacing: 8) {
+                    Text(serverTypeName)
+                        .font(Typography.captionSmall)
+                        .foregroundStyle(SashimiTheme.accent.opacity(0.8))
+                        .padding(.horizontal, 8)
+                        .padding(.vertical, 2)
+                        .background(Capsule().fill(SashimiTheme.accent.opacity(0.15)))
+
+                    Text(account.userName)
+                        .font(Typography.caption)
+                        .foregroundStyle(SashimiTheme.textTertiary)
+                }
+            }
+
+            Spacer()
+
+            Button(action: onRemove) {
+                Image(systemName: "trash")
+                    .font(Typography.bodySmall)
+                    .foregroundStyle(removeIsFocused ? .white : .red.opacity(0.7))
+                    .padding(10)
+                    .background(
+                        RoundedRectangle(cornerRadius: 10)
+                            .fill(removeIsFocused ? Color.red : Color.red.opacity(0.1))
+                    )
+            }
+            .buttonStyle(PlainNoHighlightButtonStyle())
+            .focused($removeIsFocused)
+        }
+        .padding(.horizontal, 24)
+        .padding(.vertical, 18)
+        .background(
+            RoundedRectangle(cornerRadius: 14)
+                .fill(isFocused ? SashimiTheme.accent.opacity(0.08) : SashimiTheme.cardBackground)
+        )
+        .focused($isFocused)
+    }
+}
+
+struct ConnectedServerAddButton: View {
+    let action: () -> Void
+    @FocusState private var isFocused: Bool
+
+    var body: some View {
+        Button(action: action) {
+            HStack(spacing: 12) {
+                Image(systemName: "plus.circle.fill")
+                    .font(Typography.titleSmall)
+                Text("Add Server")
+                    .font(Typography.titleSmall)
+            }
+            .foregroundStyle(isFocused ? .white : SashimiTheme.accent)
+            .frame(maxWidth: .infinity)
+            .padding(.vertical, 18)
+            .background(
+                RoundedRectangle(cornerRadius: 14)
+                    .fill(isFocused ? SashimiTheme.accent : SashimiTheme.accent.opacity(0.1))
+            )
+            .scaleEffect(isFocused ? 1.02 : 1.0)
+            .animation(.spring(response: 0.3, dampingFraction: 0.7), value: isFocused)
+        }
+        .buttonStyle(PlainNoHighlightButtonStyle())
         .focused($isFocused)
     }
 }

--- a/Shared/Services/ServerManager.swift
+++ b/Shared/Services/ServerManager.swift
@@ -191,6 +191,14 @@ final class ServerManager: ObservableObject {
         servers.first { $0.id == item.serverId }
     }
 
+    func server(forId id: String) -> (any MediaServer)? {
+        servers.first { $0.id == id }
+    }
+
+    func account(forId id: String) -> ServerAccount? {
+        accounts.first { $0.id == id }
+    }
+
     // MARK: - Multi-Server Aggregation
 
     func getAllResumeItems(limit: Int = 20) async -> [MediaItem] {

--- a/Shared/ViewModels/HomeViewModel.swift
+++ b/Shared/ViewModels/HomeViewModel.swift
@@ -32,22 +32,36 @@ final class HomeViewModel: ObservableObject {
     }()
 
     func loadContent() async {
-        guard let server = serverManager.primaryServer else { return }
+        guard !serverManager.servers.isEmpty else { return }
 
         isLoading = true
         error = nil
 
         do {
-            async let resumeItems = server.getResumeItems(limit: 20)
-            async let nextUpItems = server.getNextUp(limit: 50)
-            async let latestItems = server.getLatestMedia(libraryId: nil, limit: 30)
-            async let libraryViews = server.getLibraries()
+            // Continue watching merged from all servers
+            async let resumeTask = serverManager.getAllResumeItems()
+            async let nextUpTask = serverManager.getAllNextUp()
 
-            let (resume, nextUp, latest, libs) = try await (resumeItems, nextUpItems, latestItems, libraryViews)
+            let resumeItems = await resumeTask
+            let nextUpItems = await nextUpTask
 
-            continueWatchingItems = mergeAndSortContinueItems(resume: resume, nextUp: nextUp)
-            recentlyAddedItems = latest
-            libraries = libs.filter { isMediaLibrary($0) }
+            continueWatchingItems = mergeAndSortContinueItems(resume: resumeItems, nextUp: nextUpItems)
+
+            // Libraries from ALL servers
+            var allLibraries: [MediaLibrary] = []
+            for server in serverManager.servers {
+                let libs = (try? await server.getLibraries()) ?? []
+                allLibraries.append(contentsOf: libs)
+            }
+            libraries = allLibraries.filter { isMediaLibrary($0) }
+
+            // Recently added from all servers
+            var allLatest: [MediaItem] = []
+            for server in serverManager.servers {
+                let items = (try? await server.getLatestMedia(libraryId: nil, limit: 30)) ?? []
+                allLatest.append(contentsOf: items)
+            }
+            recentlyAddedItems = allLatest
 
             saveContinueWatchingForTopShelf()
             await loadContinueWatchingLibraryNames()
@@ -60,35 +74,50 @@ final class HomeViewModel: ObservableObject {
     }
 
     private func loadContinueWatchingLibraryNames() async {
-        guard let server = serverManager.primaryServer else { return }
         var libraryNames: [String: String] = [:]
 
-        let seriesIds = Set(continueWatchingItems.compactMap { item -> String? in
-            if item.type == .episode { return item.seriesId }
-            return item.rawId
-        })
+        // Group items by server so we can resolve ancestors per-server
+        var itemsByServer: [String: [MediaItem]] = [:]
+        for item in continueWatchingItems {
+            itemsByServer[item.serverId, default: []].append(item)
+        }
 
-        for seriesId in seriesIds {
-            do {
-                let ancestors = try await JellyfinClient.shared.getItemAncestors(itemId: seriesId)
-                if let library = ancestors.first(where: { $0.type == .collectionFolder }) {
-                    for item in continueWatchingItems {
-                        if item.seriesId == seriesId || item.rawId == seriesId {
-                            libraryNames[item.rawId] = library.name
+        for (serverId, items) in itemsByServer {
+            guard let server = serverManager.server(forId: serverId) else { continue }
+
+            // For Jellyfin servers, use ancestor lookup for library names
+            if server.serverType == .jellyfin {
+                let seriesIds = Set(items.compactMap { item -> String? in
+                    if item.type == .episode { return item.seriesId }
+                    return item.rawId
+                })
+
+                for seriesId in seriesIds {
+                    do {
+                        let ancestors = try await JellyfinClient.shared.getItemAncestors(itemId: seriesId)
+                        if let library = ancestors.first(where: { $0.type == .collectionFolder }) {
+                            for item in items {
+                                if item.seriesId == seriesId || item.rawId == seriesId {
+                                    libraryNames[item.rawId] = library.name
+                                }
+                            }
                         }
-                    }
+                    } catch { }
                 }
-            } catch { }
+            }
+            // For non-Jellyfin servers, library name resolution can be added later
         }
 
         continueWatchingLibraryNames = libraryNames
     }
 
     private func saveContinueWatchingForTopShelf() {
-        guard let defaults = UserDefaults(suiteName: appGroupIdentifier),
-              let serverURL = serverManager.primaryServer?.serverURL else { return }
+        guard let defaults = UserDefaults(suiteName: appGroupIdentifier) else { return }
 
         let items: [[String: Any]] = continueWatchingItems.prefix(10).compactMap { item in
+            guard let server = serverManager.server(forId: item.serverId) else { return nil }
+            let serverURL = server.serverURL
+
             let seriesHasBackdrop = item.parentBackdropImageTags?.isEmpty == false
             let imageId: String
             let imageType: String
@@ -114,7 +143,7 @@ final class HomeViewModel: ObservableObject {
                 let episode = item.episodeNumber ?? 1
                 subtitle = "S\(season):E\(episode)"
                 if let seriesName = item.seriesName {
-                    subtitle = "\(seriesName) • \(subtitle)"
+                    subtitle = "\(seriesName) \u{2022} \(subtitle)"
                 }
             }
 
@@ -135,20 +164,22 @@ final class HomeViewModel: ObservableObject {
     }
 
     private func loadHeroItems() async {
-        guard let server = serverManager.primaryServer else { return }
         var allHeroItems: [MediaItem] = []
         var libraryNames: [String: String] = [:]
         var itemsPerLibrary: [String: [MediaItem]] = [:]
 
-        for library in libraries {
-            do {
-                let items = try await server.getLatestMedia(libraryId: library.rawId, limit: 10)
-                itemsPerLibrary[library.rawId] = items
-                for item in items {
-                    libraryNames[item.rawId] = library.name
-                }
-                allHeroItems.append(contentsOf: items.prefix(5))
-            } catch { }
+        for server in serverManager.servers {
+            let serverLibs = libraries.filter { $0.serverId == server.id }
+            for library in serverLibs {
+                do {
+                    let items = try await server.getLatestMedia(libraryId: library.rawId, limit: 10)
+                    itemsPerLibrary[library.rawId] = items
+                    for item in items {
+                        libraryNames[item.rawId] = library.name
+                    }
+                    allHeroItems.append(contentsOf: items.prefix(5))
+                } catch { }
+            }
         }
 
         heroItems = allHeroItems.shuffled()


### PR DESCRIPTION
## Summary
Makes the home screen truly unified across all connected servers.

- **HomeViewModel**: merges Continue Watching, Next Up, libraries, hero items, and recently added from ALL servers
- **Library sections**: show server name suffix when 2+ servers connected (e.g., "Movies — JellyPal")
- **Server badges**: Continue Watching cards show which server content is from
- **Settings**: new Connected Servers section showing all accounts with add/remove
- **TopShelf**: resolves per-item server URLs correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)