### PR TITLE
ci: wire TestFlight deploy pipeline

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -66,6 +66,7 @@ jobs:
         env:
           MATCH_PASSWORD: ${{ secrets.MATCH_PASSWORD }}
           MATCH_GIT_URL: ${{ secrets.MATCH_GIT_URL }}
+          MATCH_GIT_BASIC_AUTHORIZATION: ${{ secrets.MATCH_GIT_BASIC_AUTHORIZATION }}
           APP_STORE_CONNECT_KEY_ID: ${{ secrets.APP_STORE_CONNECT_KEY_ID }}
           APP_STORE_CONNECT_ISSUER_ID: ${{ secrets.APP_STORE_CONNECT_ISSUER_ID }}
           APP_STORE_CONNECT_KEY_CONTENT: ${{ secrets.APP_STORE_CONNECT_KEY_CONTENT }}
@@ -74,6 +75,9 @@ jobs:
       - name: Deploy to TestFlight
         if: github.event.inputs.environment == 'testflight' || contains(github.ref, 'beta') || contains(github.ref, 'rc')
         env:
+          MATCH_PASSWORD: ${{ secrets.MATCH_PASSWORD }}
+          MATCH_GIT_URL: ${{ secrets.MATCH_GIT_URL }}
+          MATCH_GIT_BASIC_AUTHORIZATION: ${{ secrets.MATCH_GIT_BASIC_AUTHORIZATION }}
           APP_STORE_CONNECT_KEY_ID: ${{ secrets.APP_STORE_CONNECT_KEY_ID }}
           APP_STORE_CONNECT_ISSUER_ID: ${{ secrets.APP_STORE_CONNECT_ISSUER_ID }}
           APP_STORE_CONNECT_KEY_CONTENT: ${{ secrets.APP_STORE_CONNECT_KEY_CONTENT }}
@@ -82,6 +86,9 @@ jobs:
       - name: Deploy to App Store
         if: github.event.inputs.environment == 'appstore'
         env:
+          MATCH_PASSWORD: ${{ secrets.MATCH_PASSWORD }}
+          MATCH_GIT_URL: ${{ secrets.MATCH_GIT_URL }}
+          MATCH_GIT_BASIC_AUTHORIZATION: ${{ secrets.MATCH_GIT_BASIC_AUTHORIZATION }}
           APP_STORE_CONNECT_KEY_ID: ${{ secrets.APP_STORE_CONNECT_KEY_ID }}
           APP_STORE_CONNECT_ISSUER_ID: ${{ secrets.APP_STORE_CONNECT_ISSUER_ID }}
           APP_STORE_CONNECT_KEY_CONTENT: ${{ secrets.APP_STORE_CONNECT_KEY_CONTENT }}

--- a/.gitignore
+++ b/.gitignore
@@ -63,3 +63,4 @@ Thumbs.db
 *.p12
 *.mobileprovision
 *.provisionprofile
+.aider*

--- a/fastlane/Matchfile
+++ b/fastlane/Matchfile
@@ -2,7 +2,7 @@
 # https://docs.fastlane.tools/actions/match/
 
 # Git repo for storing certificates (private repo recommended)
-# git_url "git@github.com:mondominator/certificates.git"
+git_url "https://github.com/mondominator/certificates.git"
 
 # Storage mode - git is most common, but can use google_cloud or s3
 storage_mode "git"


### PR DESCRIPTION
Wires the existing fastlane/match → TestFlight pipeline so a `v*-beta*` tag produces a signed tvOS build.

- **Matchfile**: point at the private `certificates` vault over HTTPS
- **deploy.yml**: pass `MATCH_GIT_BASIC_AUTHORIZATION` for cloning the private cert repo; add `MATCH_PASSWORD`/`MATCH_GIT_URL` to beta + release steps
- **.gitignore**: ignore local `.aider*` files

Secrets + cert vault + ASC app record ("SashimiTV") already set up out-of-band. tvOS only; iOS/iPad later.

🤖 Generated with [Claude Code](https://claude.com/claude-code)