### PR TITLE
fix(ci): install tvOS platform before archive in deploy

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -39,6 +39,20 @@ jobs:
         with:
           xcode-version: ${{ env.XCODE_VERSION }}
 
+      - name: Install tvOS Platform
+        run: |
+          # tvOS platform isn't preinstalled for Xcode 16 on the runner; archive needs it
+          if xcodebuild -showsdks | grep -q tvos; then
+            echo "tvOS SDK already installed"
+          else
+            echo "Downloading tvOS platform..."
+            for i in 1 2 3; do
+              xcodebuild -downloadPlatform tvOS && break
+              echo "Retry $i failed, waiting 10s..."
+              sleep 10
+            done
+          fi
+
       - name: Setup Ruby
         uses: ruby/setup-ruby@v1
         with:


### PR DESCRIPTION
Deploy run got past signing + build-number but failed at `build_app` with *'tvOS 18.0 is not installed'*. `ci.yml` already has an 'Install tvOS Platform' step (Xcode 16 doesn't preinstall it); `deploy.yml` was missing it. This mirrors that step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)