### PR TITLE
fix(ci): always download tvOS platform for archive

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -41,17 +41,15 @@ jobs:
 
       - name: Install tvOS Platform
         run: |
-          # tvOS platform isn't preinstalled for Xcode 16 on the runner; archive needs it
-          if xcodebuild -showsdks | grep -q tvos; then
-            echo "tvOS SDK already installed"
-          else
-            echo "Downloading tvOS platform..."
-            for i in 1 2 3; do
-              xcodebuild -downloadPlatform tvOS && break
-              echo "Retry $i failed, waiting 10s..."
-              sleep 10
-            done
-          fi
+          # Always ensure the tvOS DEVICE platform is installed (idempotent).
+          # A conditional grep on -showsdks matches the simulator SDK and wrongly
+          # skips the download, but archiving for generic/platform=tvOS needs the
+          # full device platform — so download unconditionally.
+          for i in 1 2 3; do
+            xcodebuild -downloadPlatform tvOS && break
+            echo "Retry $i failed, waiting 10s..."
+            sleep 10
+          done
 
       - name: Setup Ruby
         uses: ruby/setup-ruby@v1


### PR DESCRIPTION
Signing fix (#159) worked, but the archive then intermittently failed with *'tvOS 18.0 is not installed'*. The 'Install tvOS Platform' step's conditional grep matched the simulator SDK and skipped the device-platform download. Make it unconditional (idempotent).

🤖 Generated with [Claude Code](https://claude.com/claude-code)