### PR TITLE
fix(ci): prevent codesign hang with setup_ci + job timeout

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -27,6 +27,7 @@ jobs:
     name: Deploy to ${{ github.event.inputs.environment || 'testflight' }}
     runs-on: macos-15
     environment: ${{ github.event.inputs.environment || 'testflight' }}
+    timeout-minutes: 40
 
     steps:
       - name: Checkout

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -10,6 +10,10 @@ platform :tvos do
 
   desc "Sync certificates and profiles from App Store Connect"
   lane :certificates do
+    # On CI, create a temporary unlocked keychain with the proper partition list
+    # so codesign doesn't hang waiting for a keychain-access prompt.
+    setup_ci
+
     app_store_connect_api_key(
       key_id: ENV["APP_STORE_CONNECT_KEY_ID"],
       issuer_id: ENV["APP_STORE_CONNECT_ISSUER_ID"],


### PR DESCRIPTION
Deploy hung ~39min at 'Signing TopShelf.appex' — codesign waiting on a keychain prompt no one can answer on a headless runner. Add `setup_ci` (temporary unlocked keychain, the documented match+CI fix) and a `timeout-minutes` safety net.

🤖 Generated with [Claude Code](https://claude.com/claude-code)