### PR TITLE
chore: declare export compliance (ITSAppUsesNonExemptEncryption=false)

### DIFF
--- a/Sashimi/Info.plist
+++ b/Sashimi/Info.plist
@@ -31,6 +31,8 @@
 	</array>
 	<key>CFBundleVersion</key>
 	<string>1</string>
+	<key>ITSAppUsesNonExemptEncryption</key>
+	<false/>
 	<key>NSAppTransportSecurity</key>
 	<dict>
 		<key>NSAllowsLocalNetworking</key>

--- a/project.yml
+++ b/project.yml
@@ -55,6 +55,9 @@ targets:
           - CFBundleURLSchemes:
               - sashimi
             CFBundleURLName: com.mondominator.sashimi
+        # App uses only exempt encryption (standard HTTPS/TLS + Keychain) —
+        # declares export compliance so TestFlight never prompts per-build.
+        ITSAppUsesNonExemptEncryption: false
         # Alternate icons temporarily disabled for the first TestFlight beta
         # (each needs a 1280x768 App Store variant); re-add post-beta.
     settings:


### PR DESCRIPTION
App uses only exempt encryption (standard HTTPS/TLS + Keychain). Declaring it in Info.plist stops TestFlight from prompting for export compliance on every build. Takes effect on the next build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)