### PR TITLE
fix(ci): epoch-seconds build number

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -84,7 +84,7 @@ platform :tvos do
     # Build number from git commit count: always unique and monotonically
     # increasing. (latest_testflight_build_number queried the iOS platform and
     # returned 0 for this tvOS app, causing duplicate-build-number collisions.)
-    increment_build_number(build_number: number_of_commits)
+    increment_build_number(build_number: Time.now.to_i.to_s)
 
     # Sync certificates
     certificates

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -81,9 +81,9 @@ platform :tvos do
       is_key_content_base64: true
     )
 
-    # Build number from git commit count: always unique and monotonically
-    # increasing. (latest_testflight_build_number queried the iOS platform and
-    # returned 0 for this tvOS app, causing duplicate-build-number collisions.)
+    # Build number = Unix epoch seconds: always unique and monotonically
+    # increasing, with no dependency on ASC queries (wrong platform) or git
+    # history (shallow checkout). Under Apple's uint32 build-number limit until ~2106.
     increment_build_number(build_number: Time.now.to_i.to_s)
 
     # Sync certificates


### PR DESCRIPTION
number_of_commits returned 1 (shallow tag checkout) → collided with build 1. Use Time.now.to_i: guaranteed unique + increasing, under Apple's uint32 limit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)