### PR TITLE
feat(ios): unified Sashimi iOS/iPad app + TestFlight pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,6 +89,38 @@ jobs:
             CODE_SIGNING_ALLOWED=NO \
             | xcpretty --color
 
+  build-ios:
+    name: Build iOS App
+    runs-on: macos-15
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Xcode
+        uses: maxim-lobanov/setup-xcode@v1
+        with:
+          xcode-version: 'latest-stable'
+
+      - name: Install XcodeGen
+        run: brew install xcodegen
+
+      - name: Generate Xcode Project
+        run: xcodegen generate
+
+      - name: Resolve Dependencies
+        run: xcodebuild -resolvePackageDependencies -project Sashimi.xcodeproj -scheme SashimiMobile
+
+      - name: Build for iOS Simulator
+        run: |
+          xcodebuild build \
+            -project Sashimi.xcodeproj \
+            -scheme SashimiMobile \
+            -destination 'platform=iOS Simulator,name=iPhone 16' \
+            -configuration Debug \
+            CODE_SIGNING_ALLOWED=NO \
+            | xcpretty --color
+
   swiftlint:
     name: SwiftLint
     runs-on: macos-15

--- a/.github/workflows/deploy-ios.yml
+++ b/.github/workflows/deploy-ios.yml
@@ -1,0 +1,103 @@
+name: Deploy iOS
+
+on:
+  # Manual trigger with environment selection
+  workflow_dispatch:
+    inputs:
+      environment:
+        description: 'Deployment target'
+        required: true
+        default: 'testflight'
+        type: choice
+        options:
+          - testflight
+          - appstore
+
+  # Auto-deploy to TestFlight on iOS release tags
+  push:
+    tags:
+      - 'ios-v*-beta*'
+      - 'ios-v*-rc*'
+
+env:
+  XCODE_VERSION: 'latest-stable'  # Apple requires the current iOS SDK (Xcode 26+)
+
+jobs:
+  deploy:
+    name: Deploy iOS to ${{ github.event.inputs.environment || 'testflight' }}
+    runs-on: macos-15
+    environment: ${{ github.event.inputs.environment || 'testflight' }}
+    timeout-minutes: 40
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0  # Full history for changelog
+
+      - name: Setup Xcode
+        uses: maxim-lobanov/setup-xcode@v1
+        with:
+          xcode-version: ${{ env.XCODE_VERSION }}
+
+      - name: Install iOS Platform
+        run: |
+          # Ensure the iOS platform/SDK is installed for the selected Xcode (idempotent).
+          for i in 1 2 3; do
+            xcodebuild -downloadPlatform iOS && break
+            echo "Retry $i failed, waiting 10s..."
+            sleep 10
+          done || echo "iOS platform already present — continuing"
+
+      - name: Setup Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '3.2'
+          bundler-cache: true
+
+      - name: Install XcodeGen
+        run: brew install xcodegen
+
+      - name: Generate Xcode Project
+        run: xcodegen generate
+
+      - name: Install Fastlane
+        run: bundle install
+
+      - name: Setup App Store Connect API Key
+        env:
+          APP_STORE_CONNECT_KEY_CONTENT: ${{ secrets.APP_STORE_CONNECT_KEY_CONTENT }}
+          APP_STORE_CONNECT_KEY_ID: ${{ secrets.APP_STORE_CONNECT_KEY_ID }}
+        run: |
+          mkdir -p ~/.appstoreconnect/private_keys
+          echo "$APP_STORE_CONNECT_KEY_CONTENT" | base64 --decode > ~/.appstoreconnect/private_keys/AuthKey_"$APP_STORE_CONNECT_KEY_ID".p8
+
+      - name: Install Certificates
+        env:
+          MATCH_PASSWORD: ${{ secrets.MATCH_PASSWORD }}
+          MATCH_GIT_URL: ${{ secrets.MATCH_GIT_URL }}
+          MATCH_GIT_BASIC_AUTHORIZATION: ${{ secrets.MATCH_GIT_BASIC_AUTHORIZATION }}
+          APP_STORE_CONNECT_KEY_ID: ${{ secrets.APP_STORE_CONNECT_KEY_ID }}
+          APP_STORE_CONNECT_ISSUER_ID: ${{ secrets.APP_STORE_CONNECT_ISSUER_ID }}
+          APP_STORE_CONNECT_KEY_CONTENT: ${{ secrets.APP_STORE_CONNECT_KEY_CONTENT }}
+        run: bundle exec fastlane ios certificates
+
+      - name: Deploy to TestFlight
+        if: github.event.inputs.environment == 'testflight' || contains(github.ref, 'beta') || contains(github.ref, 'rc')
+        env:
+          MATCH_PASSWORD: ${{ secrets.MATCH_PASSWORD }}
+          MATCH_GIT_URL: ${{ secrets.MATCH_GIT_URL }}
+          MATCH_GIT_BASIC_AUTHORIZATION: ${{ secrets.MATCH_GIT_BASIC_AUTHORIZATION }}
+          APP_STORE_CONNECT_KEY_ID: ${{ secrets.APP_STORE_CONNECT_KEY_ID }}
+          APP_STORE_CONNECT_ISSUER_ID: ${{ secrets.APP_STORE_CONNECT_ISSUER_ID }}
+          APP_STORE_CONNECT_KEY_CONTENT: ${{ secrets.APP_STORE_CONNECT_KEY_CONTENT }}
+        run: bundle exec fastlane ios beta
+
+      - name: Upload Build Artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: SashimiMobile-build
+          path: |
+            fastlane/build/*.ipa
+            fastlane/build/*.dSYM.zip
+          retention-days: 30

--- a/SashimiMobile/Info.plist
+++ b/SashimiMobile/Info.plist
@@ -22,7 +22,7 @@
 	<array>
 		<dict>
 			<key>CFBundleURLName</key>
-			<string>com.mondominator.sashimi.mobile</string>
+			<string>com.mondominator.sashimi</string>
 			<key>CFBundleURLSchemes</key>
 			<array>
 				<string>sashimi</string>
@@ -31,11 +31,17 @@
 	</array>
 	<key>CFBundleVersion</key>
 	<string>1</string>
+	<key>ITSAppUsesNonExemptEncryption</key>
+	<false/>
 	<key>NSAppTransportSecurity</key>
 	<dict>
 		<key>NSAllowsLocalNetworking</key>
 		<true/>
 	</dict>
+	<key>UIBackgroundModes</key>
+	<array>
+		<string>audio</string>
+	</array>
 	<key>UILaunchScreen</key>
 	<dict/>
 	<key>UIRequiresFullScreen</key>

--- a/SashimiMobile/PrivacyInfo.xcprivacy
+++ b/SashimiMobile/PrivacyInfo.xcprivacy
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>NSPrivacyTracking</key>
+	<false/>
+	<key>NSPrivacyTrackingDomains</key>
+	<array/>
+	<key>NSPrivacyCollectedDataTypes</key>
+	<array/>
+	<key>NSPrivacyAccessedAPITypes</key>
+	<array>
+		<dict>
+			<key>NSPrivacyAccessedAPIType</key>
+			<string>NSPrivacyAccessedAPICategoryUserDefaults</string>
+			<key>NSPrivacyAccessedAPITypeReasons</key>
+			<array>
+				<string>CA92.1</string>
+			</array>
+		</dict>
+		<dict>
+			<key>NSPrivacyAccessedAPIType</key>
+			<string>NSPrivacyAccessedAPICategoryFileTimestamp</string>
+			<key>NSPrivacyAccessedAPITypeReasons</key>
+			<array>
+				<string>C617.1</string>
+			</array>
+		</dict>
+		<dict>
+			<key>NSPrivacyAccessedAPIType</key>
+			<string>NSPrivacyAccessedAPICategoryDiskSpace</string>
+			<key>NSPrivacyAccessedAPITypeReasons</key>
+			<array>
+				<string>E174.1</string>
+			</array>
+		</dict>
+	</array>
+</dict>
+</plist>

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -179,3 +179,81 @@ platform :tvos do
     # )
   end
 end
+
+# ============================================================================
+# iOS / iPad (SashimiMobile) — shares the bundle id com.mondominator.sashimi
+# with tvOS (Universal Purchase). Mirrors the tvOS lanes; same hard-won fixes.
+# ============================================================================
+platform :ios do
+  desc "Sync iOS certificates and profiles from App Store Connect"
+  lane :certificates do
+    # Temporary unlocked keychain so codesign doesn't hang on CI.
+    setup_ci
+
+    app_store_connect_api_key(
+      key_id: ENV["APP_STORE_CONNECT_KEY_ID"],
+      issuer_id: ENV["APP_STORE_CONNECT_ISSUER_ID"],
+      key_content: ENV["APP_STORE_CONNECT_KEY_CONTENT"],
+      is_key_content_base64: true
+    )
+
+    match(
+      type: "appstore",
+      app_identifier: "com.mondominator.sashimi",
+      platform: "ios",
+      readonly: is_ci
+    )
+  end
+
+  desc "Build the iOS app"
+  lane :build do
+    # Do NOT run xcodegen here — the CI workflow already generated the project,
+    # and regenerating would reset CFBundleVersion (see tvOS build lane note).
+
+    # Force manual signing with the match iOS profile for the Release archive.
+    update_code_signing_settings(
+      path: "Sashimi.xcodeproj",
+      use_automatic_signing: false,
+      team_id: "S6WU9SVVDW",
+      targets: ["SashimiMobile"],
+      code_sign_identity: "Apple Distribution",
+      profile_name: "match AppStore com.mondominator.sashimi",
+      build_configurations: ["Release"]
+    )
+
+    build_app(
+      project: "Sashimi.xcodeproj",
+      scheme: "SashimiMobile",
+      destination: "generic/platform=iOS",
+      configuration: "Release",
+      export_method: "app-store",
+      output_directory: "./build",
+      output_name: "SashimiMobile.ipa"
+    )
+  end
+
+  desc "Push a new iOS build to TestFlight"
+  lane :beta do
+    ensure_git_status_clean unless is_ci
+
+    api_key = app_store_connect_api_key(
+      key_id: ENV["APP_STORE_CONNECT_KEY_ID"],
+      issuer_id: ENV["APP_STORE_CONNECT_ISSUER_ID"],
+      key_content: ENV["APP_STORE_CONNECT_KEY_CONTENT"],
+      is_key_content_base64: true
+    )
+
+    # Epoch-seconds build number: unique + increasing, no git/ASC dependency.
+    increment_build_number(build_number: Time.now.to_i.to_s)
+
+    certificates
+    build
+
+    upload_to_testflight(
+      api_key: api_key,
+      app_identifier: "com.mondominator.sashimi",
+      skip_waiting_for_build_processing: true,
+      changelog: changelog_from_git_commits(commits_count: 10, pretty: "- %s")
+    )
+  end
+end

--- a/fastlane/README.md
+++ b/fastlane/README.md
@@ -1,0 +1,88 @@
+fastlane documentation
+----
+
+# Installation
+
+Make sure you have the latest version of the Xcode command line tools installed:
+
+```sh
+xcode-select --install
+```
+
+For _fastlane_ installation instructions, see [Installing _fastlane_](https://docs.fastlane.tools/#installing-fastlane)
+
+# Available Actions
+
+## tvos
+
+### tvos certificates
+
+```sh
+[bundle exec] fastlane tvos certificates
+```
+
+Sync certificates and profiles from App Store Connect
+
+### tvos build
+
+```sh
+[bundle exec] fastlane tvos build
+```
+
+Build the app
+
+### tvos beta
+
+```sh
+[bundle exec] fastlane tvos beta
+```
+
+Push a new build to TestFlight
+
+### tvos release
+
+```sh
+[bundle exec] fastlane tvos release
+```
+
+Deploy a new version to the App Store
+
+### tvos bump_patch
+
+```sh
+[bundle exec] fastlane tvos bump_patch
+```
+
+Increment version number (patch)
+
+### tvos bump_minor
+
+```sh
+[bundle exec] fastlane tvos bump_minor
+```
+
+Increment version number (minor)
+
+### tvos bump_major
+
+```sh
+[bundle exec] fastlane tvos bump_major
+```
+
+Increment version number (major)
+
+### tvos create_app_record
+
+```sh
+[bundle exec] fastlane tvos create_app_record
+```
+
+TEMP: create ASC app record
+
+----
+
+This README.md is auto-generated and will be re-generated every time [_fastlane_](https://fastlane.tools) is run.
+
+More information about _fastlane_ can be found on [fastlane.tools](https://fastlane.tools).
+
+The documentation of _fastlane_ can be found on [docs.fastlane.tools](https://docs.fastlane.tools).

--- a/project.yml
+++ b/project.yml
@@ -102,13 +102,19 @@ targets:
       path: SashimiMobile/Info.plist
       properties:
         CFBundleDisplayName: Sashimi
+        # App uses only exempt encryption (standard HTTPS/TLS + Keychain) —
+        # declares export compliance so TestFlight never prompts per-build.
+        ITSAppUsesNonExemptEncryption: false
+        # Background audio so Picture-in-Picture keeps playing in the background.
+        UIBackgroundModes:
+          - audio
         UILaunchScreen: {}
         NSAppTransportSecurity:
           NSAllowsLocalNetworking: true
         CFBundleURLTypes:
           - CFBundleURLSchemes:
               - sashimi
-            CFBundleURLName: com.mondominator.sashimi.mobile
+            CFBundleURLName: com.mondominator.sashimi
         UISupportedInterfaceOrientations~ipad:
           - UIInterfaceOrientationLandscapeLeft
           - UIInterfaceOrientationLandscapeRight
@@ -121,7 +127,9 @@ targets:
         UIRequiresFullScreen: false
     settings:
       base:
-        PRODUCT_BUNDLE_IDENTIFIER: com.mondominator.sashimi.mobile
+        # Shared bundle ID with the tvOS app for Universal Purchase (one "Sashimi"
+        # app spanning Apple TV + iPhone + iPad). Distinguished by platform.
+        PRODUCT_BUNDLE_IDENTIFIER: com.mondominator.sashimi
         MARKETING_VERSION: 1.0.0
         CURRENT_PROJECT_VERSION: 1
         SWIFT_VERSION: 5.9


### PR DESCRIPTION
Brings SashimiMobile (iPhone+iPad) into the unified Sashimi app (shared bundle id com.mondominator.sashimi, Universal Purchase) and adds its TestFlight pipeline, reusing all the tvOS fixes. New 'Build iOS App' CI job is the first compile of the iOS target. 🤖 Generated with [Claude Code](https://claude.com/claude-code)