### PR TITLE
fix(ios): keep player alive on Plus/Max rotation + bump to 1.0.1

### DIFF
--- a/SashimiMobile/App/SashimiMobileApp.swift
+++ b/SashimiMobile/App/SashimiMobileApp.swift
@@ -1,5 +1,6 @@
 import SwiftUI
 import SwiftData
+import UIKit
 
 class AppDelegate: NSObject, UIApplicationDelegate {
     func application(
@@ -40,16 +41,24 @@ struct SashimiMobileApp: App {
 
 struct ContentView: View {
     @EnvironmentObject var sessionManager: SessionManager
-    @Environment(\.horizontalSizeClass) private var sizeClass
+
+    // Pick the layout by DEVICE TYPE (stable), not horizontalSizeClass (transient).
+    // The size class flips .compact -> .regular when an iPhone Plus/Pro Max rotates
+    // to landscape, which would swap the entire root view (PhoneTabView <-> the iPad
+    // layout) and tear down its subtree — dismissing an active fullScreenCover video
+    // player. A phone stays on the phone UI in landscape; iPad always uses the iPad UI.
+    private var isPad: Bool {
+        UIDevice.current.userInterfaceIdiom == .pad
+    }
 
     var body: some View {
         Group {
             if sessionManager.isAuthenticated {
                 Group {
-                    if sizeClass == .compact {
-                        PhoneTabView()
-                    } else {
+                    if isPad {
                         MainNavigationView()
+                    } else {
+                        PhoneTabView()
                     }
                 }
                 .task {

--- a/SashimiMobile/Info.plist
+++ b/SashimiMobile/Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.0</string>
+	<string>$(MARKETING_VERSION)</string>
 	<key>CFBundleURLTypes</key>
 	<array>
 		<dict>

--- a/project.yml
+++ b/project.yml
@@ -102,6 +102,9 @@ targets:
       path: SashimiMobile/Info.plist
       properties:
         CFBundleDisplayName: Sashimi
+        # Marketing version flows from the MARKETING_VERSION build setting so it's
+        # a single source of truth (xcodegen otherwise hardcodes a default "1.0").
+        CFBundleShortVersionString: "$(MARKETING_VERSION)"
         # App uses only exempt encryption (standard HTTPS/TLS + Keychain) —
         # declares export compliance so TestFlight never prompts per-build.
         ITSAppUsesNonExemptEncryption: false
@@ -130,7 +133,7 @@ targets:
         # Shared bundle ID with the tvOS app for Universal Purchase (one "Sashimi"
         # app spanning Apple TV + iPhone + iPad). Distinguished by platform.
         PRODUCT_BUNDLE_IDENTIFIER: com.mondominator.sashimi
-        MARKETING_VERSION: 1.0.0
+        MARKETING_VERSION: 1.0.1
         CURRENT_PROJECT_VERSION: 1
         SWIFT_VERSION: 5.9
         SDKROOT: iphoneos


### PR DESCRIPTION
Rotation dismissed the video on iPhone Plus/Max because ContentView swapped the root layout on size class (which flips on big-iPhone rotation), tearing down the player's state. Switch to device-idiom-based layout (stable). Also bumps iOS to 1.0.1 and fixes CFBundleShortVersionString to flow from MARKETING_VERSION.

🤖 Generated with [Claude Code](https://claude.com/claude-code)