### PR TITLE
fix: wire placebo playback settings, harden cert validation, header auth, dead code sweep

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,12 +23,12 @@ xcodegen generate
 
 ### MVVM Pattern
 - **Views** (`Sashimi/Views/`): SwiftUI views organized by feature (Home, Auth, Library, Detail, Player, Components)
-- **ViewModels** (`Sashimi/ViewModels/`): `@MainActor` `ObservableObject` classes managing view state
-- **Models** (`Sashimi/Models/`): Codable DTOs matching Jellyfin API responses
+- **ViewModels** (`Shared/ViewModels/`): `@MainActor` `ObservableObject` classes managing view state (shared between the tvOS and iOS targets)
+- **Models** (`Shared/Models/`): Codable DTOs matching Jellyfin API responses (shared between targets)
 
 ### Core Services
-- **JellyfinClient** (`Services/JellyfinClient.swift`): Swift `actor` handling all Jellyfin REST API communication. Singleton accessed via `JellyfinClient.shared`. Manages authentication headers, device identification, and playback URL generation.
-- **SessionManager** (`Services/SessionManager.swift`): `@MainActor` `ObservableObject` singleton managing auth state, token persistence via UserDefaults, and session restoration.
+- **JellyfinClient** (`Shared/Services/JellyfinClient.swift`): Swift `actor` handling all Jellyfin REST API communication. Singleton accessed via `JellyfinClient.shared`. Manages authentication headers, device identification, and playback URL generation.
+- **SessionManager** (`Shared/Services/SessionManager.swift`): `@MainActor` `ObservableObject` singleton managing auth state, token persistence via UserDefaults, and session restoration.
 
 ### Data Flow
 1. App entry (`SashimiApp.swift`) injects `SessionManager` as `@EnvironmentObject`
@@ -46,7 +46,7 @@ xcodegen generate
 `PlayerViewModel` handles playback via AVKit:
 - Fetches `PlaybackInfoResponse` to determine best stream URL (transcoding vs direct)
 - Reports playback progress to Jellyfin server every 5 seconds (and immediately on play/pause)
-- Shows resume dialog when video has saved progress (auto-resumes after 5 seconds)
+- Auto-resumes from saved progress when it exceeds the resume threshold setting (no dialog)
 - Supports Up Next feature for continuous episode playback
 
 ### Dependencies
@@ -180,7 +180,7 @@ magick source.png -trim +repage -resize 780x -background '#1a1a2e' \
 
 3. Uninstall and reinstall the app (install alone may use cached icon):
    ```bash
-   xcrun devicectl device uninstall app --device DEVICE_ID com.sashimi.app
+   xcrun devicectl device uninstall app --device DEVICE_ID com.mondominator.sashimi
    xcrun devicectl device install app --device DEVICE_ID \
      ~/Library/Developer/Xcode/DerivedData/Sashimi-*/Build/Products/Release-appletvos/Sashimi.app
    ```

--- a/Sashimi/Views/Detail/MediaDetailView.swift
+++ b/Sashimi/Views/Detail/MediaDetailView.swift
@@ -9,7 +9,6 @@ private let trailerLogger = Logger(subsystem: "com.mondominator.sashimi", catego
 // with multiple states and sub-views - splitting would reduce cohesion
 
 struct MediaDetailView: View {
-    let initialItem: BaseItemDto
     var forceYouTubeStyle: Bool = false
     @Environment(\.dismiss) private var dismiss
     @State private var item: BaseItemDto
@@ -20,7 +19,6 @@ struct MediaDetailView: View {
     @State private var hasProgress: Bool = false
 
     init(item: BaseItemDto, forceYouTubeStyle: Bool = false) {
-        self.initialItem = item
         self.forceYouTubeStyle = forceYouTubeStyle
         self._item = State(initialValue: item)
     }
@@ -887,21 +885,6 @@ struct MediaDetailView: View {
         }
     }
 
-    private func mediaInfoPill(icon: String, text: String) -> some View {
-        HStack(spacing: 6) {
-            Image(systemName: icon)
-                .font(.caption)
-            Text(text)
-                .font(.caption)
-                .fontWeight(.medium)
-        }
-        .foregroundStyle(SashimiTheme.textSecondary)
-        .padding(.horizontal, 12)
-        .padding(.vertical, 6)
-        .background(SashimiTheme.cardBackground)
-        .clipShape(Capsule())
-    }
-
     // MARK: - Cast
     private func castSection(_ people: [PersonInfo]) -> some View {
         let cast = Array(people.filter { $0.type == "Actor" }.prefix(20))
@@ -1469,42 +1452,6 @@ struct EpisodeCard: View {
         }
 
         return parts.joined(separator: ", ")
-    }
-}
-
-struct TrailerRow: View {
-    let name: String
-    let url: String?
-    @FocusState private var isFocused: Bool
-    @State private var showingPlayer = false
-
-    var body: some View {
-        Button {
-            showingPlayer = true
-        } label: {
-            HStack(spacing: 16) {
-                Image(systemName: "play.circle.fill")
-                    .font(.title3)
-                    .foregroundStyle(isFocused ? .white : .gray)
-
-                Text(name)
-                    .font(.body)
-                    .foregroundStyle(.white)
-
-                Spacer()
-            }
-            .padding(.horizontal, 20)
-            .padding(.vertical, 14)
-            .background(isFocused ? SashimiTheme.accent : SashimiTheme.cardBackground)
-            .clipShape(RoundedRectangle(cornerRadius: 8))
-        }
-        .buttonStyle(PlainNoHighlightButtonStyle())
-        .focused($isFocused)
-        .fullScreenCover(isPresented: $showingPlayer) {
-            if let urlString = url {
-                TrailerPlayerView(urlString: urlString, name: name)
-            }
-        }
     }
 }
 

--- a/Sashimi/Views/Home/HomeView.swift
+++ b/Sashimi/Views/Home/HomeView.swift
@@ -95,9 +95,10 @@ struct HomeView: View {
             homeSettings.updateWithLibraries(viewModel.libraries)
         }
         .onAppear {
+            // Initial load happens in .task above (and .task re-runs when the
+            // view re-enters the hierarchy), so no extra refresh here — it
+            // used to double-fetch everything on first appearance.
             startAutoRefresh()
-            // Refresh immediately when view appears (e.g., switching tabs)
-            Task { await viewModel.refresh() }
         }
         .onDisappear {
             stopAutoRefresh()
@@ -193,6 +194,9 @@ struct HeroSection: View {
     @FocusState private var isFocused: Bool
     @State private var autoAdvanceTimer: Timer?
     @State private var progress: Double = 0
+
+    /// Seconds each hero item stays on screen before auto-advancing
+    private let slideDuration: Double = 6
 
     private var safeIndex: Int {
         guard !items.isEmpty else { return 0 }
@@ -473,23 +477,34 @@ struct HeroSection: View {
             stopAutoAdvance()
         }
         .onChange(of: currentIndex) { _, _ in
-            progress = 0
+            restartProgressAnimation()
         }
     }
 
     private func startAutoAdvance() {
         guard items.count > 1 else { return }
-        progress = 0
-        autoAdvanceTimer = Timer.scheduledTimer(withTimeInterval: 0.1, repeats: true) { _ in
+        restartProgressAnimation()
+        // One tick per slide; the progress bar fills via a single linear
+        // animation instead of a 10Hz timer mutating state.
+        autoAdvanceTimer = Timer.scheduledTimer(withTimeInterval: slideDuration, repeats: true) { _ in
             DispatchQueue.main.async {
-                progress += 0.1 / 6  // 6 seconds per item
-                if progress >= 1.0 {
-                    withAnimation(.easeInOut(duration: 0.6)) {
-                        currentIndex = (currentIndex + 1) % items.count
-                    }
-                    progress = 0
+                withAnimation(.easeInOut(duration: 0.6)) {
+                    currentIndex = (currentIndex + 1) % items.count
                 }
             }
+        }
+    }
+
+    /// Snap the progress bar back to empty (no animation), then animate it
+    /// full over the slide duration.
+    private func restartProgressAnimation() {
+        var snapBack = Transaction()
+        snapBack.disablesAnimations = true
+        withTransaction(snapBack) {
+            progress = 0
+        }
+        withAnimation(.linear(duration: slideDuration)) {
+            progress = 1
         }
     }
 

--- a/Sashimi/Views/Library/CertificateSettings.swift
+++ b/Sashimi/Views/Library/CertificateSettings.swift
@@ -57,7 +57,7 @@ struct CertificateSettingsView: View {
                     )
                 }
 
-                Text("Disabling certificate validation reduces security. Only enable if you trust your network.")
+                Text("These exceptions apply only to the current server. Enabling them reduces security — only do so if you trust your network.")
                     .font(Typography.captionSmall)
                     .foregroundStyle(SashimiTheme.textTertiary)
                     .padding(.horizontal, 8)
@@ -72,7 +72,7 @@ struct CertificateSettingsView: View {
                         }
                     }
 
-                    Text("These hosts have been manually trusted.")
+                    Text("These hosts are pinned to the certificate they presented when first trusted.")
                         .font(Typography.captionSmall)
                         .foregroundStyle(SashimiTheme.textTertiary)
                         .padding(.horizontal, 8)

--- a/Sashimi/Views/Library/ParentalControls.swift
+++ b/Sashimi/Views/Library/ParentalControls.swift
@@ -1,5 +1,8 @@
 import SwiftUI
 import CryptoKit
+import os
+
+private let logger = Logger(subsystem: "com.mondominator.sashimi", category: "ParentalControls")
 
 // MARK: - Parental Controls
 
@@ -9,50 +12,96 @@ class ParentalControlsManager: ObservableObject {
 
     private static let pinKeychainKey = "parentalPIN"
     private static let lockoutKey = "pinLockoutUntil"
+    private static let failedAttemptsKey = "pinFailedAttempts"
 
     @AppStorage("isPINEnabled") var isPINEnabled: Bool = false
     @AppStorage("maxContentRating") var maxContentRating: ContentRating = .any
     @AppStorage("kidsMode") var kidsMode: Bool = false
     @AppStorage("hideUnrated") var hideUnrated: Bool = false
-    @AppStorage("pinFailedAttempts") private var failedAttempts: Int = 0
+
+    init() {
+        // Lockout state used to live in UserDefaults, where deleting the app
+        // container (or editing the plist) reset it. Clear any stragglers now
+        // that it lives in the Keychain alongside the PIN.
+        UserDefaults.standard.removeObject(forKey: Self.lockoutKey)
+        UserDefaults.standard.removeObject(forKey: Self.failedAttemptsKey)
+    }
+
+    /// Failed-attempt counter kept in the Keychain (not UserDefaults) so the
+    /// lockout can't be reset by wiping preferences.
+    private var failedAttempts: Int {
+        get { Int(KeychainHelper.get(forKey: Self.failedAttemptsKey) ?? "") ?? 0 }
+        set {
+            if !KeychainHelper.save(String(newValue), forKey: Self.failedAttemptsKey) {
+                logger.error("Failed to persist PIN attempt counter to Keychain")
+            }
+        }
+    }
 
     var hasSetPIN: Bool {
         KeychainHelper.get(forKey: Self.pinKeychainKey) != nil
     }
 
     var isLockedOut: Bool {
-        if let until = UserDefaults.standard.object(forKey: Self.lockoutKey) as? Date {
-            return Date() < until
+        if let stored = KeychainHelper.get(forKey: Self.lockoutKey),
+           let until = TimeInterval(stored) {
+            return Date().timeIntervalSince1970 < until
         }
         return false
     }
 
-    func setPIN(_ pin: String) {
-        let hash = SHA256.hash(data: Data(pin.utf8))
-        let hashString = hash.compactMap { String(format: "%02x", $0) }.joined()
-        KeychainHelper.save(hashString, forKey: Self.pinKeychainKey)
+    /// Stores the PIN. Returns false (without enabling PIN lock) if the
+    /// Keychain write fails, so callers can surface the error.
+    ///
+    /// The PIN is stored raw: the Keychain itself is the secure store, and an
+    /// unsalted hash of a 4-digit PIN (10,000 possible values) is trivially
+    /// brute-forced by anyone who could read the Keychain anyway.
+    func setPIN(_ pin: String) -> Bool {
+        guard KeychainHelper.save(pin, forKey: Self.pinKeychainKey) else {
+            logger.error("Failed to save parental PIN to Keychain")
+            return false
+        }
         isPINEnabled = true
         failedAttempts = 0
+        KeychainHelper.delete(forKey: Self.lockoutKey)
+        return true
     }
 
     func verifyPIN(_ pin: String) -> Bool {
         guard !isLockedOut else { return false }
         guard let stored = KeychainHelper.get(forKey: Self.pinKeychainKey) else { return false }
-        let hash = SHA256.hash(data: Data(pin.utf8))
-        let hashString = hash.compactMap { String(format: "%02x", $0) }.joined()
-        if hashString == stored {
+
+        let matches: Bool
+        if stored.count == 4 {
+            matches = pin == stored
+        } else {
+            // Legacy format: older builds stored an unsalted SHA-256 hex
+            // digest. Keep verifying it so existing PINs still work; the
+            // entry upgrades to the raw format when the PIN is next set.
+            let hash = SHA256.hash(data: Data(pin.utf8))
+            let hashString = hash.map { String(format: "%02x", $0) }.joined()
+            matches = hashString == stored
+        }
+
+        if matches {
             failedAttempts = 0
+            KeychainHelper.delete(forKey: Self.lockoutKey)
             return true
         }
+
         failedAttempts += 1
         if failedAttempts >= 5 {
-            UserDefaults.standard.set(Date().addingTimeInterval(60), forKey: Self.lockoutKey)
+            let until = Date().addingTimeInterval(60).timeIntervalSince1970
+            if !KeychainHelper.save(String(until), forKey: Self.lockoutKey) {
+                logger.error("Failed to persist PIN lockout to Keychain")
+            }
         }
         return false
     }
 
     func disablePIN() {
         KeychainHelper.delete(forKey: Self.pinKeychainKey)
+        KeychainHelper.delete(forKey: Self.lockoutKey)
         isPINEnabled = false
         failedAttempts = 0
     }
@@ -209,7 +258,9 @@ struct ParentalControlsView: View {
         }
         .sheet(isPresented: $showPINSetup) {
             PINSetupView { pin in
-                controls.setPIN(pin)
+                if !controls.setPIN(pin) {
+                    ToastManager.shared.show("Couldn't save PIN. Try again.")
+                }
                 showPINSetup = false
             }
         }

--- a/Sashimi/Views/Library/ParentalControls.swift
+++ b/Sashimi/Views/Library/ParentalControls.swift
@@ -57,6 +57,12 @@ class ParentalControlsManager: ObservableObject {
     /// unsalted hash of a 4-digit PIN (10,000 possible values) is trivially
     /// brute-forced by anyone who could read the Keychain anyway.
     func setPIN(_ pin: String) -> Bool {
+        // verifyPIN distinguishes raw PINs from legacy SHA-256 hashes by
+        // length (4 vs 64), so only exactly-4-character PINs may be stored.
+        guard pin.count == 4 else {
+            logger.error("Rejected PIN of invalid length")
+            return false
+        }
         guard KeychainHelper.save(pin, forKey: Self.pinKeychainKey) else {
             logger.error("Failed to save parental PIN to Keychain")
             return false

--- a/Sashimi/Views/Library/SettingsView.swift
+++ b/Sashimi/Views/Library/SettingsView.swift
@@ -774,7 +774,8 @@ struct SettingsNavigationRow<Destination: View>: View {
 }
 
 struct VideoQualitySettingsView: View {
-    @AppStorage("maxBitrate") private var maxBitrate = 20_000_000
+    // Default must match PlaybackSettings.maxBitrate (0 = Auto).
+    @AppStorage("maxBitrate") private var maxBitrate = 0
 
     let bitrateOptions = [
         (label: "Auto", value: 0),

--- a/SashimiMobile/Downloads/Services/DownloadManager.swift
+++ b/SashimiMobile/Downloads/Services/DownloadManager.swift
@@ -181,7 +181,10 @@ final class DownloadManager: NSObject, ObservableObject {
             return
         }
 
-        guard let downloadURL = DownloadURLBuilder.downloadURL(itemId: itemId, quality: quality) else {
+        // URLRequest (not bare URL) so the token travels in a header and the
+        // background task keeps it across app relaunches.
+        guard let downloadURL = DownloadURLBuilder.downloadURL(itemId: itemId, quality: quality),
+              let downloadRequest = DownloadURLBuilder.authorizedRequest(for: downloadURL) else {
             persistence.updateStatus(itemId: itemId, status: .failed, errorMessage: "Could not build download URL")
             stateVersion += 1
             startNextDownload()
@@ -197,7 +200,7 @@ final class DownloadManager: NSObject, ObservableObject {
             return
         }
 
-        let task = backgroundSession.downloadTask(with: downloadURL)
+        let task = backgroundSession.downloadTask(with: downloadRequest)
         var map = taskIdMap
         map[taskKey(task.taskIdentifier)] = itemId
         taskIdMap = map
@@ -462,9 +465,9 @@ final class DownloadManager: NSObject, ObservableObject {
     }
 
     private func downloadImage(url: URL?, destination: URL, itemId: String, keyPath: String, fileName: String) async {
-        guard let url else { return }
+        guard let url, let request = DownloadURLBuilder.authorizedRequest(for: url) else { return }
         do {
-            let (tempURL, _) = try await URLSession.shared.download(from: url)
+            let (tempURL, _) = try await URLSession.shared.download(for: request)
             try DownloadFileManager.moveFile(from: tempURL, to: destination)
             if keyPath == "posterFileName" {
                 persistence.updatePosterFileName(itemId: itemId, fileName: fileName)
@@ -493,7 +496,8 @@ final class DownloadManager: NSObject, ObservableObject {
                 continue
             }
 
-            guard let url = DownloadURLBuilder.subtitleURL(itemId: itemId, subtitleIndex: index) else {
+            guard let url = DownloadURLBuilder.subtitleURL(itemId: itemId, subtitleIndex: index),
+                  let request = DownloadURLBuilder.authorizedRequest(for: url) else {
                 continue
             }
 
@@ -501,7 +505,7 @@ final class DownloadManager: NSObject, ObservableObject {
             let destination = DownloadFileManager.subtitlePath(for: itemId, index: index, language: language)
 
             do {
-                let (tempURL, _) = try await URLSession.shared.download(from: url)
+                let (tempURL, _) = try await URLSession.shared.download(for: request)
                 try DownloadFileManager.moveFile(from: tempURL, to: destination)
                 persistence.addSubtitle(
                     itemId: itemId,

--- a/SashimiMobile/Downloads/Services/DownloadManager.swift
+++ b/SashimiMobile/Downloads/Services/DownloadManager.swift
@@ -229,26 +229,6 @@ final class DownloadManager: NSObject, ObservableObject {
         }
     }
 
-    func pauseDownload(itemId: String) {
-        backgroundSession.getAllTasks { [weak self] tasks in
-            guard let self else { return }
-            for task in tasks where self.taskIdMap[self.taskKey(task.taskIdentifier)] == itemId {
-                if let downloadTask = task as? URLSessionDownloadTask {
-                    downloadTask.cancel(byProducingResumeData: { _ in })
-                } else {
-                    task.cancel()
-                }
-                Task { @MainActor in
-                    self.persistence.updateStatus(itemId: itemId, status: .paused)
-                    self.pendingProgress.removeValue(forKey: itemId)
-                    self.activeDownloads.removeValue(forKey: itemId)
-                    self.preparingItems.remove(itemId)
-                }
-                break
-            }
-        }
-    }
-
     func cancelDownload(itemId: String) async {
         let tasks = await backgroundSession.allTasks
         for task in tasks where taskIdMap[taskKey(task.taskIdentifier)] == itemId {

--- a/SashimiMobile/Downloads/Services/DownloadURLBuilder.swift
+++ b/SashimiMobile/Downloads/Services/DownloadURLBuilder.swift
@@ -1,6 +1,18 @@
 import Foundation
 
 enum DownloadURLBuilder {
+    /// Same persisted device id JellyfinClient uses (it writes this key on
+    /// first launch). Persist the fallback too so we never send a different
+    /// throwaway id per call, which would register phantom devices server-side.
+    private static var deviceId: String {
+        if let stored = UserDefaults.standard.string(forKey: "deviceId") {
+            return stored
+        }
+        let newId = UUID().uuidString
+        UserDefaults.standard.set(newId, forKey: "deviceId")
+        return newId
+    }
+
     // MARK: - Video Download URLs
 
     /// Build URL for downloading video at original quality (direct file download)
@@ -24,8 +36,6 @@ enum DownloadURLBuilder {
               let accessToken = KeychainHelper.get(forKey: "accessToken") else {
             return nil
         }
-
-        let deviceId = UserDefaults.standard.string(forKey: "deviceId") ?? UUID().uuidString
 
         var components = URLComponents(string: serverURL.trimmingCharacters(in: CharacterSet(charactersIn: "/")))
         components?.path += "/Videos/\(itemId)/stream.mp4"

--- a/SashimiMobile/Downloads/Services/DownloadURLBuilder.swift
+++ b/SashimiMobile/Downloads/Services/DownloadURLBuilder.swift
@@ -13,27 +13,38 @@ enum DownloadURLBuilder {
         return newId
     }
 
+    // MARK: - Authorization
+
+    /// Wraps a download URL in a URLRequest that carries the access token in
+    /// the X-Emby-Token header instead of an api_key query parameter, so the
+    /// token doesn't end up in server/proxy logs. Background download tasks
+    /// created from a URLRequest keep their headers across app relaunches,
+    /// so resumed downloads stay authenticated.
+    static func authorizedRequest(for url: URL) -> URLRequest? {
+        guard let accessToken = KeychainHelper.get(forKey: "accessToken") else {
+            return nil
+        }
+        var request = URLRequest(url: url)
+        request.setValue(accessToken, forHTTPHeaderField: "X-Emby-Token")
+        return request
+    }
+
     // MARK: - Video Download URLs
 
     /// Build URL for downloading video at original quality (direct file download)
     static func originalDownloadURL(itemId: String) -> URL? {
-        guard let serverURL = UserDefaults.standard.string(forKey: "serverURL"),
-              let accessToken = KeychainHelper.get(forKey: "accessToken") else {
+        guard let serverURL = UserDefaults.standard.string(forKey: "serverURL") else {
             return nil
         }
 
         var components = URLComponents(string: serverURL.trimmingCharacters(in: CharacterSet(charactersIn: "/")))
         components?.path += "/Items/\(itemId)/Download"
-        components?.queryItems = [
-            URLQueryItem(name: "api_key", value: accessToken)
-        ]
         return components?.url
     }
 
     /// Build URL for downloading video at a specific bitrate (transcoded to mp4)
     static func transcodedDownloadURL(itemId: String, maxBitrate: Int) -> URL? {
-        guard let serverURL = UserDefaults.standard.string(forKey: "serverURL"),
-              let accessToken = KeychainHelper.get(forKey: "accessToken") else {
+        guard let serverURL = UserDefaults.standard.string(forKey: "serverURL") else {
             return nil
         }
 
@@ -45,7 +56,6 @@ enum DownloadURLBuilder {
             URLQueryItem(name: "VideoCodec", value: "h264"),
             URLQueryItem(name: "AudioCodec", value: "aac"),
             URLQueryItem(name: "Container", value: "mp4"),
-            URLQueryItem(name: "api_key", value: accessToken),
             URLQueryItem(name: "DeviceId", value: deviceId)
         ]
         return components?.url
@@ -63,8 +73,7 @@ enum DownloadURLBuilder {
 
     /// Build URL for downloading a subtitle track as WebVTT
     static func subtitleURL(itemId: String, subtitleIndex: Int) -> URL? {
-        guard let serverURL = UserDefaults.standard.string(forKey: "serverURL"),
-              let accessToken = KeychainHelper.get(forKey: "accessToken") else {
+        guard let serverURL = UserDefaults.standard.string(forKey: "serverURL") else {
             return nil
         }
 
@@ -72,9 +81,6 @@ enum DownloadURLBuilder {
             string: serverURL.trimmingCharacters(in: CharacterSet(charactersIn: "/"))
         )
         components?.path += "/Videos/\(itemId)/\(itemId)/Subtitles/\(subtitleIndex)/Stream.vtt"
-        components?.queryItems = [
-            URLQueryItem(name: "api_key", value: accessToken)
-        ]
         return components?.url
     }
 

--- a/SashimiMobile/Views/Components/MobileContinueWatchingCard.swift
+++ b/SashimiMobile/Views/Components/MobileContinueWatchingCard.swift
@@ -225,7 +225,8 @@ struct MobileContinueWatchingCard: View {
                     .fill(MobileColors.progressBackground)
                 Capsule()
                     .fill(MobileColors.accent)
-                    .frame(width: geometry.size.width * CGFloat(item.progressPercent / 100))
+                    // progressPercent is a 0-1 fraction, not 0-100
+                    .frame(width: geometry.size.width * CGFloat(item.progressPercent))
             }
         }
         .frame(height: 4)

--- a/SashimiMobile/Views/Components/MobileMediaPosterButton.swift
+++ b/SashimiMobile/Views/Components/MobileMediaPosterButton.swift
@@ -170,7 +170,8 @@ struct MobilePosterCard: View {
                         .fill(MobileColors.progressBackground)
                     Rectangle()
                         .fill(MobileColors.accent)
-                        .frame(width: geometry.size.width * CGFloat(item.progressPercent / 100))
+                        // progressPercent is a 0-1 fraction, not 0-100
+                        .frame(width: geometry.size.width * CGFloat(item.progressPercent))
                 }
             }
             .frame(height: 4)

--- a/SashimiMobile/Views/Detail/MobileDetailView.swift
+++ b/SashimiMobile/Views/Detail/MobileDetailView.swift
@@ -1069,7 +1069,8 @@ struct MobileEpisodeCard: View {
                                         .fill(MobileColors.progressBackground)
                                     Rectangle()
                                         .fill(MobileColors.accent)
-                                        .frame(width: geo.size.width * CGFloat(episode.progressPercent / 100))
+                                        // progressPercent is a 0-1 fraction, not 0-100
+                                        .frame(width: geo.size.width * CGFloat(episode.progressPercent))
                                 }
                             }
                             .frame(height: 3)

--- a/SashimiTests/DeepLinkTests.swift
+++ b/SashimiTests/DeepLinkTests.swift
@@ -60,11 +60,8 @@ final class DeepLinkTests: XCTestCase {
 
     // MARK: - DeepLinkDestination identity
 
-    // Explicitly the app module's type: SashimiTests also compiles the Shared
-    // sources, so an unqualified BaseItemDto resolves to the test target's
-    // copy, which DeepLinkDestination (app module) won't accept.
-    private func makeItem(id: String) -> Sashimi.BaseItemDto {
-        Sashimi.BaseItemDto(
+    private func makeItem(id: String) -> BaseItemDto {
+        BaseItemDto(
             id: id, name: "Test", type: .movie,
             seriesName: nil, seriesId: nil, seasonId: nil, parentId: nil,
             indexNumber: nil, parentIndexNumber: nil, overview: nil,

--- a/SashimiTests/JellyfinClientTests.swift
+++ b/SashimiTests/JellyfinClientTests.swift
@@ -45,21 +45,6 @@ final class JellyfinClientTests: XCTestCase {
         XCTAssertTrue(playbackURL?.absoluteString.contains("source-456") ?? false)
     }
 
-    func testHLSStreamURLConstruction() async {
-        let client = JellyfinClient.shared
-        await client.configure(serverURL: URL(string: "http://localhost:8096")!, accessToken: "test-token")
-
-        let hlsURL = await client.getHLSStreamURL(
-            itemId: "movie-789",
-            mediaSourceId: "source-123",
-            subtitleStreamIndex: 1
-        )
-
-        XCTAssertNotNil(hlsURL)
-        XCTAssertTrue(hlsURL?.absoluteString.contains("master.m3u8") ?? false)
-        XCTAssertTrue(hlsURL?.absoluteString.contains("movie-789") ?? false)
-    }
-
     // MARK: - Response Parsing Tests
 
     func testAuthenticationResultDecoding() throws {
@@ -236,32 +221,6 @@ final class JellyfinClientTests: XCTestCase {
 
         XCTAssertEqual(segment.start, 0.0, accuracy: 0.001)
         XCTAssertEqual(segment.end, 90.5, accuracy: 0.001)
-    }
-
-    // MARK: - Virtual Folder Tests
-
-    func testVirtualFolderDecoding() throws {
-        let json = """
-        [
-            {
-                "Name": "Movies",
-                "CollectionType": "movies",
-                "ItemId": "folder-1"
-            },
-            {
-                "Name": "TV Shows",
-                "CollectionType": "tvshows",
-                "ItemId": "folder-2"
-            }
-        ]
-        """.data(using: .utf8)!
-
-        let decoder = JSONDecoder()
-        let folders = try decoder.decode([VirtualFolderInfo].self, from: json)
-
-        XCTAssertEqual(folders.count, 2)
-        XCTAssertEqual(folders[0].name, "Movies")
-        XCTAssertEqual(folders[1].name, "TV Shows")
     }
 
     // MARK: - Chapter Tests

--- a/SashimiTests/PlaybackSelectionTests.swift
+++ b/SashimiTests/PlaybackSelectionTests.swift
@@ -1,0 +1,151 @@
+import XCTest
+@testable import Sashimi
+
+final class PlaybackSelectionTests: XCTestCase {
+    // MARK: - Helpers
+
+    private func subtitleStream(
+        language: String?,
+        index: Int,
+        isDefault: Bool? = nil,
+        isExternal: Bool? = nil
+    ) -> MediaStream {
+        MediaStream(
+            type: "Subtitle",
+            codec: "subrip",
+            language: language,
+            displayTitle: language,
+            title: nil,
+            height: nil,
+            width: nil,
+            channels: nil,
+            index: index,
+            isDefault: isDefault,
+            isExternal: isExternal
+        )
+    }
+
+    // MARK: - effectiveMaxBitrate
+
+    func testSessionOverrideWinsOverSettings() {
+        XCTAssertEqual(
+            PlaybackSelection.effectiveMaxBitrate(sessionOverride: 8_000_000, settingsMaxBitrate: 20_000_000),
+            8_000_000
+        )
+    }
+
+    func testSettingsBitrateUsedWithoutOverride() {
+        XCTAssertEqual(
+            PlaybackSelection.effectiveMaxBitrate(sessionOverride: nil, settingsMaxBitrate: 20_000_000),
+            20_000_000
+        )
+    }
+
+    func testAutoSettingsBitrateMeansNoCap() {
+        XCTAssertNil(PlaybackSelection.effectiveMaxBitrate(sessionOverride: nil, settingsMaxBitrate: 0))
+    }
+
+    // MARK: - languagesMatch
+
+    func testMatchesIso639TwoVsThreeLetterCodes() {
+        XCTAssertTrue(PlaybackSelection.languagesMatch("eng", "en"))
+        XCTAssertTrue(PlaybackSelection.languagesMatch("en", "eng"))
+        XCTAssertTrue(PlaybackSelection.languagesMatch("spa", "es"))
+        XCTAssertTrue(PlaybackSelection.languagesMatch("fra", "fr"))
+        XCTAssertTrue(PlaybackSelection.languagesMatch("jpn", "ja"))
+    }
+
+    func testMatchIsCaseInsensitive() {
+        XCTAssertTrue(PlaybackSelection.languagesMatch("ENG", "en"))
+        XCTAssertTrue(PlaybackSelection.languagesMatch("En", "eN"))
+    }
+
+    func testDifferentLanguagesDoNotMatch() {
+        XCTAssertFalse(PlaybackSelection.languagesMatch("eng", "es"))
+        XCTAssertFalse(PlaybackSelection.languagesMatch("fra", "de"))
+    }
+
+    func testNilOrEmptyCodesNeverMatch() {
+        XCTAssertFalse(PlaybackSelection.languagesMatch(nil, "en"))
+        XCTAssertFalse(PlaybackSelection.languagesMatch("en", nil))
+        XCTAssertFalse(PlaybackSelection.languagesMatch(nil, nil))
+        XCTAssertFalse(PlaybackSelection.languagesMatch("", "en"))
+        XCTAssertFalse(PlaybackSelection.languagesMatch("en", ""))
+    }
+
+    func testUnmappableCodesFallBackToLiteralComparison() {
+        XCTAssertTrue(PlaybackSelection.languagesMatch("und", "UND"))
+        XCTAssertFalse(PlaybackSelection.languagesMatch("und", "en"))
+    }
+
+    // MARK: - preferredSubtitleStream
+
+    func testNoSubtitleWhenDisabled() {
+        let streams = [subtitleStream(language: "eng", index: 1, isDefault: true)]
+        XCTAssertNil(
+            PlaybackSelection.preferredSubtitleStream(from: streams, preferredLanguage: "en", subtitlesEnabled: false)
+        )
+    }
+
+    func testNoSubtitleWhenNoStreams() {
+        XCTAssertNil(
+            PlaybackSelection.preferredSubtitleStream(from: [], preferredLanguage: "en", subtitlesEnabled: true)
+        )
+    }
+
+    func testPreferredLanguageWinsOverDefaultFlag() {
+        let streams = [
+            subtitleStream(language: "fre", index: 1, isDefault: true),
+            subtitleStream(language: "eng", index: 2)
+        ]
+        let selected = PlaybackSelection.preferredSubtitleStream(
+            from: streams,
+            preferredLanguage: "en",
+            subtitlesEnabled: true
+        )
+        XCTAssertEqual(selected?.index, 2)
+    }
+
+    func testFallsBackToDefaultFlaggedStreamWhenLanguageUnavailable() {
+        let streams = [
+            subtitleStream(language: "fre", index: 1),
+            subtitleStream(language: "ger", index: 2, isDefault: true)
+        ]
+        let selected = PlaybackSelection.preferredSubtitleStream(
+            from: streams,
+            preferredLanguage: "ja",
+            subtitlesEnabled: true
+        )
+        XCTAssertEqual(selected?.index, 2)
+    }
+
+    func testFallsBackToFirstStreamWithoutDefaultFlag() {
+        let streams = [
+            subtitleStream(language: "fre", index: 3),
+            subtitleStream(language: "ger", index: 4)
+        ]
+        let selected = PlaybackSelection.preferredSubtitleStream(
+            from: streams,
+            preferredLanguage: "",
+            subtitlesEnabled: true
+        )
+        XCTAssertEqual(selected?.index, 3)
+    }
+
+    // MARK: - preferredAudioOptionIndex
+
+    func testAudioIndexMatchesPreferredLanguage() {
+        // AVFoundation reports two-letter codes; the setting stores two-letter too
+        let codes: [String?] = ["ja", "en", "es"]
+        XCTAssertEqual(PlaybackSelection.preferredAudioOptionIndex(languageCodes: codes, preferredLanguage: "en"), 1)
+    }
+
+    func testAudioIndexNilWithoutPreference() {
+        XCTAssertNil(PlaybackSelection.preferredAudioOptionIndex(languageCodes: ["en"], preferredLanguage: ""))
+    }
+
+    func testAudioIndexNilWhenNoMatch() {
+        let codes: [String?] = ["ja", nil, "es"]
+        XCTAssertNil(PlaybackSelection.preferredAudioOptionIndex(languageCodes: codes, preferredLanguage: "de"))
+    }
+}

--- a/SashimiTests/SettingsTests.swift
+++ b/SashimiTests/SettingsTests.swift
@@ -93,7 +93,11 @@ final class SettingsTests: XCTestCase {
 
         // Restore original state
         certSettings.trustedHosts = originalHosts
-        defaults.set(originalPins ?? [:], forKey: CertificateTrustKeys.fingerprints)
+        if let originalPins {
+            defaults.set(originalPins, forKey: CertificateTrustKeys.fingerprints)
+        } else {
+            defaults.removeObject(forKey: CertificateTrustKeys.fingerprints)
+        }
     }
 
     func testLegacyGlobalAllowanceMigratesToChallengedHost() {

--- a/SashimiTests/SettingsTests.swift
+++ b/SashimiTests/SettingsTests.swift
@@ -73,6 +73,59 @@ final class SettingsTests: XCTestCase {
         certSettings.trustedHosts = originalHosts
     }
 
+    @MainActor
+    func testUntrustHostDropsPinnedFingerprint() {
+        let certSettings = CertificateTrustSettings.shared
+        let defaults = UserDefaults.standard
+        let testHost = "pinned.local.server"
+
+        let originalHosts = certSettings.trustedHosts
+        let originalPins = defaults.dictionary(forKey: CertificateTrustKeys.fingerprints) as? [String: String]
+
+        certSettings.trustHost(testHost)
+        var pins = originalPins ?? [:]
+        pins[testHost] = "abc123"
+        defaults.set(pins, forKey: CertificateTrustKeys.fingerprints)
+
+        certSettings.untrustHost(testHost)
+        let remaining = defaults.dictionary(forKey: CertificateTrustKeys.fingerprints) as? [String: String]
+        XCTAssertNil(remaining?[testHost])
+
+        // Restore original state
+        certSettings.trustedHosts = originalHosts
+        defaults.set(originalPins ?? [:], forKey: CertificateTrustKeys.fingerprints)
+    }
+
+    func testLegacyGlobalAllowanceMigratesToChallengedHost() {
+        let defaults = UserDefaults.standard
+        let listKey = "test_selfSignedAllowedHosts"
+        let legacyKey = "test_allowSelfSignedCerts"
+        defaults.removeObject(forKey: listKey)
+        defaults.set(true, forKey: legacyKey)
+
+        // Legacy global flag is honored once and migrated to the host
+        XCTAssertTrue(CertificateValidationDelegate.hostAllowance(host: "server.test", listKey: listKey, legacyKey: legacyKey))
+        XCTAssertFalse(defaults.bool(forKey: legacyKey), "legacy flag should be cleared after migration")
+        XCTAssertEqual(defaults.array(forKey: listKey) as? [String], ["server.test"])
+
+        // After migration the allowance is scoped: same host yes, others no
+        XCTAssertTrue(CertificateValidationDelegate.hostAllowance(host: "server.test", listKey: listKey, legacyKey: legacyKey))
+        XCTAssertFalse(CertificateValidationDelegate.hostAllowance(host: "other.test", listKey: listKey, legacyKey: legacyKey))
+
+        defaults.removeObject(forKey: listKey)
+        defaults.removeObject(forKey: legacyKey)
+    }
+
+    func testHostAllowanceFalseWithoutEntryOrLegacyFlag() {
+        let defaults = UserDefaults.standard
+        let listKey = "test_expiredAllowedHosts"
+        let legacyKey = "test_allowExpiredCerts"
+        defaults.removeObject(forKey: listKey)
+        defaults.removeObject(forKey: legacyKey)
+
+        XCTAssertFalse(CertificateValidationDelegate.hostAllowance(host: "server.test", listKey: listKey, legacyKey: legacyKey))
+    }
+
     // MARK: - LibrarySortOption Tests
 
     func testLibrarySortOptionRawValues() {

--- a/Shared/Models/JellyfinModels.swift
+++ b/Shared/Models/JellyfinModels.swift
@@ -15,13 +15,6 @@ extension String {
 // swiftlint:disable discouraged_optional_boolean
 // Jellyfin API models use optional booleans - this matches the server response structure
 
-struct ServerConfiguration: Codable {
-    var serverURL: URL
-    var accessToken: String?
-    var userId: String?
-    var serverName: String?
-}
-
 struct AuthenticationResult: Codable {
     let user: UserDto
     let accessToken: String
@@ -335,18 +328,6 @@ struct LibraryViewsResponse: Codable {
 
     enum CodingKeys: String, CodingKey {
         case items = "Items"
-    }
-}
-
-struct VirtualFolderInfo: Codable {
-    let name: String
-    let itemId: String
-    let collectionType: String?
-
-    enum CodingKeys: String, CodingKey {
-        case name = "Name"
-        case itemId = "ItemId"
-        case collectionType = "CollectionType"
     }
 }
 

--- a/Shared/Services/JellyfinClient.swift
+++ b/Shared/Services/JellyfinClient.swift
@@ -483,7 +483,11 @@ actor JellyfinClient {
         return try JSONDecoder().decode(ItemsResponse.self, from: data)
     }
 
-    func getPlaybackInfo(itemId: String, maxBitrate: Int? = nil) async throws -> PlaybackInfoResponse {
+    func getPlaybackInfo(
+        itemId: String,
+        maxBitrate: Int? = nil,
+        forceDirectPlay: Bool = false
+    ) async throws -> PlaybackInfoResponse {
         guard let userId else { throw JellyfinError.notConfigured }
 
         // Default to 120 Mbps (essentially unlimited), or use specified bitrate
@@ -518,12 +522,16 @@ actor JellyfinClient {
             ]
         ]
 
+        // Jellyfin's PlaybackInfo API has no "force direct play" flag.
+        // Disabling DirectStream and Transcoding leaves direct play as the
+        // only option, so the server either returns the original file or
+        // reports the item unplayable (rather than silently remuxing).
         let body: [String: Any] = [
             "UserId": userId,
             "DeviceProfile": deviceProfile,
             "EnableDirectPlay": true,
-            "EnableDirectStream": true,
-            "EnableTranscoding": true,
+            "EnableDirectStream": !forceDirectPlay,
+            "EnableTranscoding": !forceDirectPlay,
             "AllowVideoStreamCopy": true,
             "AllowAudioStreamCopy": true,
             "AutoOpenLiveStream": true

--- a/Shared/Services/JellyfinClient.swift
+++ b/Shared/Services/JellyfinClient.swift
@@ -1,35 +1,113 @@
 import Foundation
 import Security
+import CryptoKit
+import os
 
 // swiftlint:disable type_body_length file_length
 // JellyfinClient handles all Jellyfin API endpoints - splitting would fragment the API layer
 
 // MARK: - Certificate Trust Settings
 
+/// UserDefaults keys shared between the main-actor settings object and the
+/// (background-queue) URLSession certificate delegate.
+enum CertificateTrustKeys {
+    static let selfSignedHosts = "selfSignedAllowedHosts"
+    static let expiredHosts = "expiredAllowedHosts"
+    static let trustedHosts = "trustedHosts"
+    static let fingerprints = "trustedHostCertFingerprints"
+    // Older builds stored the allowances as single global Bools that applied
+    // to every host. These keys only exist until migration runs.
+    static let legacySelfSigned = "allowSelfSignedCerts"
+    static let legacyExpired = "allowExpiredCerts"
+}
+
 @MainActor
 class CertificateTrustSettings: ObservableObject {
     static let shared = CertificateTrustSettings()
 
-    @Published var allowSelfSigned: Bool {
-        didSet { UserDefaults.standard.set(allowSelfSigned, forKey: "allowSelfSignedCerts") }
+    /// Hosts allowed to present certificates that fail system trust because
+    /// of an unknown (self-signed) root.
+    @Published var selfSignedAllowedHosts: Set<String> {
+        didSet { UserDefaults.standard.set(Array(selfSignedAllowedHosts), forKey: CertificateTrustKeys.selfSignedHosts) }
     }
-    @Published var allowExpiredCerts: Bool {
-        didSet { UserDefaults.standard.set(allowExpiredCerts, forKey: "allowExpiredCerts") }
+    /// Hosts allowed to present expired certificates.
+    @Published var expiredAllowedHosts: Set<String> {
+        didSet { UserDefaults.standard.set(Array(expiredAllowedHosts), forKey: CertificateTrustKeys.expiredHosts) }
     }
+    /// Manually trusted hosts. These are pinned to the SHA-256 fingerprint of
+    /// the leaf certificate they present on first acceptance.
     @Published var trustedHosts: Set<String> {
-        didSet {
-            UserDefaults.standard.set(Array(trustedHosts), forKey: "trustedHosts")
+        didSet { UserDefaults.standard.set(Array(trustedHosts), forKey: CertificateTrustKeys.trustedHosts) }
+    }
+
+    /// Host of the currently configured server; the per-host toggles in the
+    /// Settings UI apply to this host.
+    var currentHost: String? {
+        UserDefaults.standard.string(forKey: "serverURL")
+            .flatMap { URL(string: $0) }?
+            .host
+    }
+
+    /// Whether the current server's host may use a self-signed certificate.
+    /// (Settings-UI convenience over the per-host set.)
+    var allowSelfSigned: Bool {
+        get {
+            guard let host = currentHost else { return false }
+            return selfSignedAllowedHosts.contains(host)
+        }
+        set {
+            guard let host = currentHost else { return }
+            if newValue {
+                selfSignedAllowedHosts.insert(host)
+            } else {
+                selfSignedAllowedHosts.remove(host)
+            }
+        }
+    }
+
+    /// Whether the current server's host may use an expired certificate.
+    var allowExpiredCerts: Bool {
+        get {
+            guard let host = currentHost else { return false }
+            return expiredAllowedHosts.contains(host)
+        }
+        set {
+            guard let host = currentHost else { return }
+            if newValue {
+                expiredAllowedHosts.insert(host)
+            } else {
+                expiredAllowedHosts.remove(host)
+            }
         }
     }
 
     init() {
-        self.allowSelfSigned = UserDefaults.standard.bool(forKey: "allowSelfSignedCerts")
-        self.allowExpiredCerts = UserDefaults.standard.bool(forKey: "allowExpiredCerts")
-        if let hosts = UserDefaults.standard.array(forKey: "trustedHosts") as? [String] {
-            self.trustedHosts = Set(hosts)
-        } else {
-            self.trustedHosts = []
+        let defaults = UserDefaults.standard
+        self.selfSignedAllowedHosts = Set((defaults.array(forKey: CertificateTrustKeys.selfSignedHosts) as? [String]) ?? [])
+        self.expiredAllowedHosts = Set((defaults.array(forKey: CertificateTrustKeys.expiredHosts) as? [String]) ?? [])
+        self.trustedHosts = Set((defaults.array(forKey: CertificateTrustKeys.trustedHosts) as? [String]) ?? [])
+        migrateLegacyGlobalFlags()
+    }
+
+    /// Folds the old global allow-flags into the current server's host (the
+    /// only server the app can have been talking to) so existing connections
+    /// keep working, then clears them. If no server is configured yet the
+    /// flags stay put and CertificateValidationDelegate migrates them on the
+    /// first challenge instead.
+    private func migrateLegacyGlobalFlags() {
+        let defaults = UserDefaults.standard
+        let legacySelfSigned = defaults.bool(forKey: CertificateTrustKeys.legacySelfSigned)
+        let legacyExpired = defaults.bool(forKey: CertificateTrustKeys.legacyExpired)
+        guard legacySelfSigned || legacyExpired, let host = currentHost else { return }
+
+        if legacySelfSigned {
+            selfSignedAllowedHosts.insert(host)
         }
+        if legacyExpired {
+            expiredAllowedHosts.insert(host)
+        }
+        defaults.removeObject(forKey: CertificateTrustKeys.legacySelfSigned)
+        defaults.removeObject(forKey: CertificateTrustKeys.legacyExpired)
     }
 
     func trustHost(_ host: String) {
@@ -38,6 +116,11 @@ class CertificateTrustSettings: ObservableObject {
 
     func untrustHost(_ host: String) {
         trustedHosts.remove(host)
+        // Drop the pinned fingerprint so re-trusting the host later pins
+        // whatever certificate it presents then.
+        var pins = (UserDefaults.standard.dictionary(forKey: CertificateTrustKeys.fingerprints) as? [String: String]) ?? [:]
+        pins.removeValue(forKey: host)
+        UserDefaults.standard.set(pins, forKey: CertificateTrustKeys.fingerprints)
     }
 
     func isHostTrusted(_ host: String) -> Bool {
@@ -48,18 +131,43 @@ class CertificateTrustSettings: ObservableObject {
 // MARK: - URLSession Delegate for Certificate Validation
 
 final class CertificateValidationDelegate: NSObject, URLSessionDelegate, @unchecked Sendable {
-    private let allowSelfSigned: () -> Bool
-    private let allowExpired: () -> Bool
+    private let allowSelfSigned: (String) -> Bool
+    private let allowExpired: (String) -> Bool
     private let isHostTrusted: (String) -> Bool
+    private let pinnedFingerprint: (String) -> String?
+    private let storePinnedFingerprint: (String, String) -> Void
+    private let logger = Logger(subsystem: "com.mondominator.sashimi", category: "CertificateValidation")
 
     init(
-        allowSelfSigned: @escaping () -> Bool,
-        allowExpired: @escaping () -> Bool,
-        isHostTrusted: @escaping (String) -> Bool
+        allowSelfSigned: @escaping (String) -> Bool,
+        allowExpired: @escaping (String) -> Bool,
+        isHostTrusted: @escaping (String) -> Bool,
+        pinnedFingerprint: @escaping (String) -> String?,
+        storePinnedFingerprint: @escaping (String, String) -> Void
     ) {
         self.allowSelfSigned = allowSelfSigned
         self.allowExpired = allowExpired
         self.isHostTrusted = isHostTrusted
+        self.pinnedFingerprint = pinnedFingerprint
+        self.storePinnedFingerprint = storePinnedFingerprint
+    }
+
+    /// Per-host allowance lookup with legacy fallback: if the old global Bool
+    /// is still set (settings object never initialized to migrate it), honor
+    /// it once and migrate it to this host so it becomes host-scoped.
+    static func hostAllowance(host: String, listKey: String, legacyKey: String) -> Bool {
+        let defaults = UserDefaults.standard
+        var hosts = (defaults.array(forKey: listKey) as? [String]) ?? []
+        if hosts.contains(host) {
+            return true
+        }
+        if defaults.bool(forKey: legacyKey) {
+            hosts.append(host)
+            defaults.set(hosts, forKey: listKey)
+            defaults.removeObject(forKey: legacyKey)
+            return true
+        }
+        return false
     }
 
     func urlSession(
@@ -75,52 +183,82 @@ final class CertificateValidationDelegate: NSObject, URLSessionDelegate, @unchec
 
         let host = challenge.protectionSpace.host
 
-        // If host is explicitly trusted, accept the certificate
-        if isHostTrusted(host) {
-            let credential = URLCredential(trust: serverTrust)
-            completionHandler(.useCredential, credential)
-            return
-        }
-
-        // Evaluate the certificate chain
         var error: CFError?
         let isValid = SecTrustEvaluateWithError(serverTrust, &error)
 
-        if isValid {
-            // Certificate is valid through system trust
-            let credential = URLCredential(trust: serverTrust)
-            completionHandler(.useCredential, credential)
+        // Manually trusted hosts are accepted only while they present the
+        // leaf certificate pinned when the host was first accepted —
+        // trusting a host is not a blanket pass for whatever cert appears.
+        if isHostTrusted(host) {
+            if leafMatchesPin(serverTrust, host: host) {
+                completionHandler(.useCredential, URLCredential(trust: serverTrust))
+            } else {
+                completionHandler(.cancelAuthenticationChallenge, nil)
+            }
             return
         }
 
-        // Check for recoverable errors
-        if let cfError = error {
-            let errorCode = CFErrorGetCode(cfError)
+        if isValid {
+            // Certificate chain is valid through system trust
+            completionHandler(.useCredential, URLCredential(trust: serverTrust))
+            return
+        }
 
-            // Self-signed certificate: only accept if the error is a trust failure
-            // (not revoked, not wrong host, etc.)
-            // Trust failure codes that indicate self-signed or untrusted root
-            let selfSignedCodes: Set<Int> = [
-                3,     // kSecTrustResultRecoverableTrustFailure
-                5,     // kSecTrustResultFatalTrustFailure (self-signed root)
-                -9807  // errSSLXCertChainInvalid (no root CA in chain)
-            ]
-            if allowSelfSigned() && selfSignedCodes.contains(errorCode) {
-                let credential = URLCredential(trust: serverTrust)
-                completionHandler(.useCredential, credential)
-                return
-            }
-
-            // Expired certificate
-            if allowExpired() && errorCode == errSecCertificateExpired {
-                let credential = URLCredential(trust: serverTrust)
-                completionHandler(.useCredential, credential)
-                return
+        // Classify the failure by error domain + Security framework codes.
+        // (The old check compared SecTrustResultType constants (3, 5) against
+        // CFError codes, which are OSStatus values — they never matched.)
+        if let nsError = error.map({ $0 as Error as NSError }),
+           nsError.domain == NSOSStatusErrorDomain {
+            switch OSStatus(truncatingIfNeeded: nsError.code) {
+            case errSecNotTrusted, errSecCreateChainFailed, errSSLXCertChainInvalid:
+                // Untrusted or incomplete chain — the self-signed case.
+                if allowSelfSigned(host) {
+                    logger.warning("Accepting untrusted-root certificate for \(host, privacy: .public) (self-signed allowance)")
+                    completionHandler(.useCredential, URLCredential(trust: serverTrust))
+                    return
+                }
+            case errSecCertificateExpired:
+                if allowExpired(host) {
+                    logger.warning("Accepting expired certificate for \(host, privacy: .public) (expired allowance)")
+                    completionHandler(.useCredential, URLCredential(trust: serverTrust))
+                    return
+                }
+            default:
+                break
             }
         }
 
-        // Certificate validation failed
+        logger.error("Rejecting certificate for \(host, privacy: .public): \(error.map { String(describing: $0) } ?? "trust evaluation failed", privacy: .public)")
         completionHandler(.cancelAuthenticationChallenge, nil)
+    }
+
+    /// True when the presented leaf certificate matches the fingerprint
+    /// pinned for this host. The first successful challenge after a host is
+    /// trusted records the pin.
+    private func leafMatchesPin(_ trust: SecTrust, host: String) -> Bool {
+        guard let fingerprint = Self.leafCertificateFingerprint(of: trust) else {
+            logger.error("Rejecting \(host, privacy: .public): could not read leaf certificate")
+            return false
+        }
+        if let pinned = pinnedFingerprint(host) {
+            if pinned == fingerprint {
+                return true
+            }
+            logger.error("Rejecting \(host, privacy: .public): certificate changed since the host was trusted (fingerprint mismatch)")
+            return false
+        }
+        storePinnedFingerprint(host, fingerprint)
+        return true
+    }
+
+    /// SHA-256 of the leaf certificate's DER encoding, as lowercase hex.
+    static func leafCertificateFingerprint(of trust: SecTrust) -> String? {
+        guard let chain = SecTrustCopyCertificateChain(trust) as? [SecCertificate],
+              let leaf = chain.first else {
+            return nil
+        }
+        let der = SecCertificateCopyData(leaf) as Data
+        return SHA256.hash(data: der).map { String(format: "%02x", $0) }.joined()
     }
 }
 
@@ -156,15 +294,34 @@ actor JellyfinClient {
             self.deviceId = newId
         }
 
-        // Create certificate validation delegate
+        // Create certificate validation delegate. Closures read UserDefaults
+        // directly (thread-safe) because challenges arrive on the session's
+        // delegate queue, not the main actor.
         self.certificateDelegate = CertificateValidationDelegate(
-            allowSelfSigned: { UserDefaults.standard.bool(forKey: "allowSelfSignedCerts") },
-            allowExpired: { UserDefaults.standard.bool(forKey: "allowExpiredCerts") },
+            allowSelfSigned: { host in
+                CertificateValidationDelegate.hostAllowance(
+                    host: host,
+                    listKey: CertificateTrustKeys.selfSignedHosts,
+                    legacyKey: CertificateTrustKeys.legacySelfSigned
+                )
+            },
+            allowExpired: { host in
+                CertificateValidationDelegate.hostAllowance(
+                    host: host,
+                    listKey: CertificateTrustKeys.expiredHosts,
+                    legacyKey: CertificateTrustKeys.legacyExpired
+                )
+            },
             isHostTrusted: { host in
-                if let hosts = UserDefaults.standard.array(forKey: "trustedHosts") as? [String] {
-                    return hosts.contains(host)
-                }
-                return false
+                ((UserDefaults.standard.array(forKey: CertificateTrustKeys.trustedHosts) as? [String]) ?? []).contains(host)
+            },
+            pinnedFingerprint: { host in
+                (UserDefaults.standard.dictionary(forKey: CertificateTrustKeys.fingerprints) as? [String: String])?[host]
+            },
+            storePinnedFingerprint: { host, fingerprint in
+                var pins = (UserDefaults.standard.dictionary(forKey: CertificateTrustKeys.fingerprints) as? [String: String]) ?? [:]
+                pins[host] = fingerprint
+                UserDefaults.standard.set(pins, forKey: CertificateTrustKeys.fingerprints)
             }
         )
 

--- a/Shared/Services/JellyfinClient.swift
+++ b/Shared/Services/JellyfinClient.swift
@@ -568,37 +568,6 @@ actor JellyfinClient {
         return components?.url
     }
 
-    /// Get HLS transcoding URL with optional subtitle track
-    func getHLSStreamURL(itemId: String, mediaSourceId: String, subtitleStreamIndex: Int? = nil) -> URL? {
-        guard let serverURL, let accessToken else {
-            return nil
-        }
-
-        var components = URLComponents(string: serverURL.absoluteString.trimmingCharacters(in: CharacterSet(charactersIn: "/")))
-        components?.path += "/Videos/\(itemId)/master.m3u8"
-
-        var queryItems = [
-            URLQueryItem(name: "MediaSourceId", value: mediaSourceId),
-            URLQueryItem(name: "api_key", value: accessToken),
-            URLQueryItem(name: "DeviceId", value: deviceId),
-            URLQueryItem(name: "VideoCodec", value: "h264"),
-            URLQueryItem(name: "AudioCodec", value: "aac"),
-            URLQueryItem(name: "TranscodingMaxAudioChannels", value: "6"),
-            URLQueryItem(name: "SegmentContainer", value: "ts"),
-            URLQueryItem(name: "MinSegments", value: "2"),
-            URLQueryItem(name: "BreakOnNonKeyFrames", value: "true"),
-            URLQueryItem(name: "TranscodeReasons", value: "SubtitleCodecNotSupported")
-        ]
-
-        if let subIndex = subtitleStreamIndex {
-            queryItems.append(URLQueryItem(name: "SubtitleStreamIndex", value: "\(subIndex)"))
-            queryItems.append(URLQueryItem(name: "SubtitleMethod", value: "Hls"))
-        }
-
-        components?.queryItems = queryItems
-        return components?.url
-    }
-
     func imageURL(itemId: String, imageType: String = "Primary", maxWidth: Int = 400) -> URL? {
         guard let serverURL else { return nil }
 

--- a/Shared/Services/JellyfinClient.swift
+++ b/Shared/Services/JellyfinClient.swift
@@ -569,6 +569,10 @@ actor JellyfinClient {
             URLQueryItem(name: "Static", value: "true"),
             URLQueryItem(name: "MediaSourceId", value: mediaSourceId),
             URLQueryItem(name: "Container", value: ext),
+            // api_key stays in the URL here on purpose: this URL is handed to
+            // AVPlayer, which fetches the stream (and HLS sub-requests) itself
+            // and has no supported way to attach auth headers. Everywhere we
+            // control the fetch (URLSession), the token goes in X-Emby-Token.
             URLQueryItem(name: "api_key", value: accessToken),
             URLQueryItem(name: "DeviceId", value: deviceId)
         ]

--- a/Shared/Services/KeychainHelper.swift
+++ b/Shared/Services/KeychainHelper.swift
@@ -7,18 +7,24 @@ enum KeychainHelper {
     static func save(_ value: String, forKey key: String) -> Bool {
         guard let data = value.data(using: .utf8) else { return false }
 
-        // Delete any existing item first
-        delete(forKey: key)
-
         let query: [String: Any] = [
             kSecClass as String: kSecClassGenericPassword,
             kSecAttrService as String: service,
-            kSecAttrAccount as String: key,
-            kSecValueData as String: data,
-            kSecAttrAccessible as String: kSecAttrAccessibleAfterFirstUnlock
+            kSecAttrAccount as String: key
         ]
 
-        let status = SecItemAdd(query as CFDictionary, nil)
+        var addAttributes = query
+        addAttributes[kSecValueData as String] = data
+        addAttributes[kSecAttrAccessible as String] = kSecAttrAccessibleAfterFirstUnlock
+
+        let status = SecItemAdd(addAttributes as CFDictionary, nil)
+        if status == errSecDuplicateItem {
+            // Update in place rather than delete-then-add so a failed write
+            // can't destroy the existing value (e.g. the parental PIN, whose
+            // loss would lock the user out of parental settings).
+            let update: [String: Any] = [kSecValueData as String: data]
+            return SecItemUpdate(query as CFDictionary, update as CFDictionary) == errSecSuccess
+        }
         return status == errSecSuccess
     }
 

--- a/Shared/Services/PlaybackSelection.swift
+++ b/Shared/Services/PlaybackSelection.swift
@@ -1,0 +1,61 @@
+import Foundation
+
+/// Pure selection logic for playback: bitrate caps and track matching.
+/// Kept free of AVFoundation/UI types so it can be unit tested directly.
+enum PlaybackSelection {
+    /// Resolves the bitrate cap sent to the server.
+    ///
+    /// Precedence: a per-session override (the player's quality menu) wins
+    /// over the global Settings value. A settings value of 0 means
+    /// "Auto" — no cap — and maps to nil.
+    static func effectiveMaxBitrate(sessionOverride: Int?, settingsMaxBitrate: Int) -> Int? {
+        if let sessionOverride {
+            return sessionOverride
+        }
+        return settingsMaxBitrate > 0 ? settingsMaxBitrate : nil
+    }
+
+    /// Case-insensitive language comparison tolerant of ISO 639-1 vs 639-2
+    /// codes: Jellyfin streams report three-letter codes ("eng"), while the
+    /// settings picker and AVFoundation locales use two-letter codes ("en").
+    static func languagesMatch(_ first: String?, _ second: String?) -> Bool {
+        guard let first, let second, !first.isEmpty, !second.isEmpty else { return false }
+        return normalizedLanguageCode(first) == normalizedLanguageCode(second)
+    }
+
+    /// Which subtitle stream to pre-select when playback starts, or nil for
+    /// no subtitles. Preference order: the user's preferred language, then
+    /// the stream the server flags as default, then the first stream.
+    static func preferredSubtitleStream(
+        from streams: [MediaStream],
+        preferredLanguage: String,
+        subtitlesEnabled: Bool
+    ) -> MediaStream? {
+        guard subtitlesEnabled, !streams.isEmpty else { return nil }
+
+        if !preferredLanguage.isEmpty,
+           let match = streams.first(where: { languagesMatch($0.language, preferredLanguage) }) {
+            return match
+        }
+        return streams.first { $0.isDefault == true } ?? streams.first
+    }
+
+    /// Index of the audio option matching the preferred language, given the
+    /// language codes of the available options (in order). Returns nil when
+    /// no preference is set or nothing matches, so the player's default
+    /// audio selection stands.
+    static func preferredAudioOptionIndex(languageCodes: [String?], preferredLanguage: String) -> Int? {
+        guard !preferredLanguage.isEmpty else { return nil }
+        return languageCodes.firstIndex { languagesMatch($0, preferredLanguage) }
+    }
+
+    /// Normalizes a language code to ISO 639-1 (alpha-2) where possible,
+    /// falling back to the lowercased input for codes Foundation can't map.
+    private static func normalizedLanguageCode(_ code: String) -> String {
+        let lowered = code.lowercased()
+        if let alpha2 = Locale.LanguageCode(lowered).identifier(.alpha2) {
+            return alpha2
+        }
+        return lowered
+    }
+}

--- a/Shared/Services/PlaybackSettings.swift
+++ b/Shared/Services/PlaybackSettings.swift
@@ -4,7 +4,10 @@ import SwiftUI
 class PlaybackSettings: ObservableObject {
     static let shared = PlaybackSettings()
 
-    @AppStorage("maxBitrate") var maxBitrate = 20_000_000
+    // 0 = Auto (no cap). Must stay the default: before this setting was wired
+    // into playback it was cosmetic, so a nonzero default would silently cap
+    // users who never opened Video Quality settings.
+    @AppStorage("maxBitrate") var maxBitrate = 0
     @AppStorage("autoPlayNextEpisode") var autoPlayNextEpisode = true
     @AppStorage("autoSkipIntro") var autoSkipIntro = false
     @AppStorage("autoSkipCredits") var autoSkipCredits = false

--- a/Shared/Services/ServerDiscovery.swift
+++ b/Shared/Services/ServerDiscovery.swift
@@ -15,6 +15,10 @@ final class ServerDiscovery: ObservableObject {
         let address: String
         let port: Int
 
+        // Discovered servers are addressed over plain HTTP on purpose: mDNS
+        // discovery only finds servers on the local network, where Jellyfin's
+        // default setup is HTTP, and a self-signed HTTPS guess would fail
+        // validation anyway. Users can still type an https:// URL manually.
         var url: URL? {
             URL(string: "http://\(address):\(port)")
         }
@@ -53,10 +57,11 @@ final class ServerDiscovery: ObservableObject {
 
         browser?.start(queue: .main)
 
-        // Stop after 10 seconds
-        Task {
+        // Stop after 10 seconds (weak self so the timeout doesn't keep a
+        // dismissed discovery screen's object alive for the full window)
+        Task { [weak self] in
             try? await Task.sleep(for: .seconds(10))
-            stopDiscovery()
+            self?.stopDiscovery()
         }
     }
 

--- a/Shared/Services/SubtitleManager.swift
+++ b/Shared/Services/SubtitleManager.swift
@@ -1,5 +1,8 @@
 import SwiftUI
 import AVFoundation
+import os
+
+private let logger = Logger(subsystem: "com.mondominator.sashimi", category: "SubtitleManager")
 
 // MARK: - Subtitle Cue
 
@@ -52,6 +55,7 @@ class SubtitleManager: ObservableObject {
             }
         } catch {
             // Subtitle loading failed — no subtitles will be shown
+            logger.error("Failed to load subtitles for item \(itemId, privacy: .public) index \(subtitleIndex): \(error.localizedDescription, privacy: .public)")
         }
 
         isLoading = false

--- a/Shared/ViewModels/HomeViewModel.swift
+++ b/Shared/ViewModels/HomeViewModel.swift
@@ -1,8 +1,11 @@
 import Foundation
 import Combine
+import os
 #if os(tvOS)
 import TVServices
 #endif
+
+private let logger = Logger(subsystem: "com.mondominator.sashimi", category: "HomeViewModel")
 
 @MainActor
 final class HomeViewModel: ObservableObject {
@@ -75,7 +78,10 @@ final class HomeViewModel: ObservableObject {
                         }
                     }
                 }
-            } catch { }
+            } catch {
+                // Non-fatal: the row just renders without a library name
+                logger.error("Failed to load ancestors for \(seriesId, privacy: .public): \(error.localizedDescription, privacy: .public)")
+            }
         }
 
         continueWatchingLibraryNames = libraryNames
@@ -144,7 +150,10 @@ final class HomeViewModel: ObservableObject {
                     libraryNames[item.id] = library.name
                 }
                 allHeroItems.append(contentsOf: items.prefix(5))
-            } catch { }
+            } catch {
+                // Non-fatal: this library is just missing from the hero rotation
+                logger.error("Failed to load latest media for library \(library.name, privacy: .public): \(error.localizedDescription, privacy: .public)")
+            }
         }
 
         heroItems = allHeroItems.shuffled()

--- a/Shared/ViewModels/PlayerViewModel.swift
+++ b/Shared/ViewModels/PlayerViewModel.swift
@@ -327,9 +327,13 @@ final class PlayerViewModel: ObservableObject {
 
             // Re-apply the session's subtitle selection on the rebuilt
             // player — the overlay was cleared along with the old player.
+            // Rebuild the track from the media source rather than looking it
+            // up in subtitleTracks, which is only populated once the subtitle
+            // menu UI has appeared (never, on iOS).
             if let selectedId = selectedSubtitleTrackId, selectedId != "off",
-               let track = subtitleTracks.first(where: { $0.id == selectedId }) {
-                selectSubtitleTrack(track)
+               let stream = currentMediaSource?.subtitleStreams
+                   .first(where: { "\($0.index ?? 0)" == selectedId }) {
+                selectSubtitleTrack(Self.subtitleTrackOption(for: stream))
             }
 
             // Resume playback and tracking
@@ -542,16 +546,21 @@ final class PlayerViewModel: ObservableObject {
                 subtitlesEnabled: playbackSettings.subtitlesEnabled
               ) else { return }
 
-        // Same id/display scheme as loadSubtitleTracks() so the subtitle menu
-        // shows this selection when it's opened later.
-        selectSubtitleTrack(SubtitleTrackOption(
+        selectSubtitleTrack(Self.subtitleTrackOption(for: stream))
+    }
+
+    /// Builds a menu option for a Jellyfin subtitle stream using the same
+    /// id/display scheme as loadSubtitleTracks(), so selections made through
+    /// any path stay consistent with the subtitle menu.
+    private static func subtitleTrackOption(for stream: MediaStream) -> SubtitleTrackOption {
+        SubtitleTrackOption(
             id: "\(stream.index ?? 0)",
             displayName: stream.displayTitle ?? stream.language ?? "Unknown",
             languageCode: stream.language,
             index: stream.index ?? 0,
             isOffOption: false,
             isExternal: stream.isExternal ?? false
-        ))
+        )
     }
 
     func loadSubtitleTracks() {

--- a/Shared/ViewModels/PlayerViewModel.swift
+++ b/Shared/ViewModels/PlayerViewModel.swift
@@ -135,6 +135,7 @@ final class PlayerViewModel: ObservableObject {
                 try audioSession.setActive(true)
 
                 try await setupPlayer(for: freshItem)
+                await applyPreferredTracks()
             }
 
             // Set up remote control commands for Bluetooth headsets/remotes
@@ -324,6 +325,13 @@ final class PlayerViewModel: ObservableObject {
                 await player?.seek(to: seekTime)
             }
 
+            // Re-apply the session's subtitle selection on the rebuilt
+            // player — the overlay was cleared along with the old player.
+            if let selectedId = selectedSubtitleTrackId, selectedId != "off",
+               let track = subtitleTracks.first(where: { $0.id == selectedId }) {
+                selectSubtitleTrack(track)
+            }
+
             // Resume playback and tracking
             startProgressReporting()
             setupSegmentTracking()
@@ -337,7 +345,18 @@ final class PlayerViewModel: ObservableObject {
 
     /// Shared player setup: resolves stream URL, creates AVPlayer with observers.
     private func setupPlayer(for item: BaseItemDto, maxBitrate: Int? = nil) async throws {
-        let playbackInfo = try await client.getPlaybackInfo(itemId: item.id, maxBitrate: maxBitrate ?? selectedQuality.maxBitrate)
+        // Bitrate precedence: explicit override (quality menu change) →
+        // session quality selection → global Settings cap. QualityOption.auto
+        // has a nil bitrate, so "Auto" defers to Settings, where 0 = no cap.
+        let effectiveBitrate = PlaybackSelection.effectiveMaxBitrate(
+            sessionOverride: maxBitrate ?? selectedQuality.maxBitrate,
+            settingsMaxBitrate: playbackSettings.maxBitrate
+        )
+        let playbackInfo = try await client.getPlaybackInfo(
+            itemId: item.id,
+            maxBitrate: effectiveBitrate,
+            forceDirectPlay: playbackSettings.forceDirectPlay
+        )
 
         guard let mediaSource = playbackInfo.mediaSources?.first else {
             throw PlayerError.noMediaSource
@@ -490,6 +509,51 @@ final class PlayerViewModel: ObservableObject {
         selectedAudioTrackId = track.id
     }
 
+    // MARK: - Settings-based track preferences
+
+    /// Applies the Settings-preferred audio/subtitle languages when playback
+    /// starts. Selections made later in the player UI naturally override
+    /// these because they happen afterwards.
+    private func applyPreferredTracks() async {
+        await applyPreferredAudioLanguage()
+        applyPreferredSubtitles()
+    }
+
+    private func applyPreferredAudioLanguage() async {
+        let preferred = playbackSettings.preferredAudioLanguage
+        guard !preferred.isEmpty, let playerItem = player?.currentItem else { return }
+
+        // appliesMediaSelectionCriteriaAutomatically is false, so the default
+        // track plays unless we pick one explicitly.
+        guard let audioGroup = try? await playerItem.asset.loadMediaSelectionGroup(for: .audible) else { return }
+
+        let codes = audioGroup.options.map { $0.locale?.language.languageCode?.identifier }
+        if let index = PlaybackSelection.preferredAudioOptionIndex(languageCodes: codes, preferredLanguage: preferred) {
+            playerItem.select(audioGroup.options[index], in: audioGroup)
+            selectedAudioTrackId = "\(index)"
+        }
+    }
+
+    private func applyPreferredSubtitles() {
+        guard let mediaSource = currentMediaSource,
+              let stream = PlaybackSelection.preferredSubtitleStream(
+                from: mediaSource.subtitleStreams,
+                preferredLanguage: playbackSettings.preferredSubtitleLanguage,
+                subtitlesEnabled: playbackSettings.subtitlesEnabled
+              ) else { return }
+
+        // Same id/display scheme as loadSubtitleTracks() so the subtitle menu
+        // shows this selection when it's opened later.
+        selectSubtitleTrack(SubtitleTrackOption(
+            id: "\(stream.index ?? 0)",
+            displayName: stream.displayTitle ?? stream.language ?? "Unknown",
+            languageCode: stream.language,
+            index: stream.index ?? 0,
+            isOffOption: false,
+            isExternal: stream.isExternal ?? false
+        ))
+    }
+
     func loadSubtitleTracks() {
         var tracks: [SubtitleTrackOption] = []
 
@@ -519,7 +583,13 @@ final class PlayerViewModel: ObservableObject {
         }
 
         subtitleTracks = tracks
-        selectedSubtitleTrackId = "off"
+        // Keep a still-valid selection (e.g. the Settings-based pre-selection
+        // applied when playback started) — this runs from the player UI's
+        // onAppear and used to unconditionally reset the menu to "Off" even
+        // while subtitles were showing.
+        if !tracks.contains(where: { $0.id == selectedSubtitleTrackId }) {
+            selectedSubtitleTrackId = "off"
+        }
     }
 
     func selectSubtitleTrack(_ track: SubtitleTrackOption) {

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -145,39 +145,6 @@ platform :tvos do
     push_git_tags unless is_ci
   end
 
-  # ============================================
-  # UTILITIES
-  # ============================================
-
-  desc "Increment version number (patch)"
-  lane :bump_patch do
-    increment_version_number(bump_type: "patch")
-    commit_version_bump(message: "chore: bump version to #{get_version_number}")
-  end
-
-  desc "Increment version number (minor)"
-  lane :bump_minor do
-    increment_version_number(bump_type: "minor")
-    commit_version_bump(message: "chore: bump version to #{get_version_number}")
-  end
-
-  desc "Increment version number (major)"
-  lane :bump_major do
-    increment_version_number(bump_type: "major")
-    commit_version_bump(message: "chore: bump version to #{get_version_number}")
-  end
-
-  # ============================================
-  # ERROR HANDLING
-  # ============================================
-
-  error do |lane, exception|
-    # Slack notification on failure (optional)
-    # slack(
-    #   message: "Fastlane failed: #{exception.message}",
-    #   success: false
-    # )
-  end
 end
 
 # ============================================================================

--- a/fastlane/README.md
+++ b/fastlane/README.md
@@ -47,30 +47,6 @@ Push a new build to TestFlight
 
 Deploy a new version to the App Store
 
-### tvos bump_patch
-
-```sh
-[bundle exec] fastlane tvos bump_patch
-```
-
-Increment version number (patch)
-
-### tvos bump_minor
-
-```sh
-[bundle exec] fastlane tvos bump_minor
-```
-
-Increment version number (minor)
-
-### tvos bump_major
-
-```sh
-[bundle exec] fastlane tvos bump_major
-```
-
-Increment version number (major)
-
 ### tvos create_app_record
 
 ```sh

--- a/project.yml
+++ b/project.yml
@@ -191,11 +191,12 @@ targets:
   SashimiTests:
     type: bundle.unit-test
     platform: tvOS
+    # Shared/ is deliberately NOT compiled into the test bundle: the host app
+    # (TEST_HOST/BUNDLE_LOADER below) already provides those symbols via
+    # `@testable import Sashimi`. Compiling Shared/ twice created duplicate
+    # classes/singletons at runtime.
     sources:
       - path: SashimiTests
-        excludes:
-          - "**/.DS_Store"
-      - path: Shared
         excludes:
           - "**/.DS_Store"
     settings:

--- a/scripts/bump-version.sh
+++ b/scripts/bump-version.sh
@@ -48,7 +48,10 @@ NEW_VERSION="$MAJOR.$MINOR.$PATCH"
 
 echo "Bumping version: $CURRENT_VERSION -> $NEW_VERSION"
 
-# Update project.yml (both targets)
+# Update project.yml. This bumps every target whose MARKETING_VERSION matches
+# the tvOS app's current version (Sashimi + TopShelf, which are kept in sync).
+# The iOS target (SashimiMobile) has an independently-managed MARKETING_VERSION
+# and is intentionally NOT touched here.
 sed -i '' "s/MARKETING_VERSION: $CURRENT_VERSION/MARKETING_VERSION: $NEW_VERSION/g" "$PROJECT_FILE"
 
 # Get current build number and increment
@@ -57,6 +60,7 @@ NEW_BUILD=$((CURRENT_BUILD + 1))
 
 echo "Bumping build: $CURRENT_BUILD -> $NEW_BUILD"
 
+# Same match-based behavior as above: bumps Sashimi + TopShelf, not SashimiMobile.
 sed -i '' "s/CURRENT_PROJECT_VERSION: $CURRENT_BUILD/CURRENT_PROJECT_VERSION: $NEW_BUILD/g" "$PROJECT_FILE"
 
 # Regenerate Xcode project


### PR DESCRIPTION
Closes #178

## What's in this PR

Nine commits covering the remaining medium/low audit findings:

### M1 — Playback settings actually wired into playback
- New `Shared/Services/PlaybackSelection.swift`: pure, testable bitrate precedence (session override → quality menu → Settings, where 0 = Auto = no cap) and ISO 639-1/2 language matching for audio/subtitle pre-selection
- `PlayerViewModel.applyPreferredTracks()` applies Settings-preferred audio/subtitle languages at playback start; mid-session quality changes preserve the subtitle selection (rebuilt from the media source, not the lazily-populated menu list)
- `forceDirectPlay` now disables `EnableDirectStream`/`EnableTranscoding` in PlaybackInfo requests
- **Default `maxBitrate` changed to 0 (Auto)** — the old 20 Mbps default was cosmetic before this wiring; keeping it nonzero would have silently capped 4K playback for anyone who never opened Video Quality settings

### M3 — Certificate validation hardening
- Fixed pre-existing bug: `SecTrustResultType` constants were compared against `CFError` OSStatus codes (never matched). Classification now uses `NSOSStatusErrorDomain` codes
- Per-host allowances for self-signed/expired certs (lazy migration from legacy global flags)
- SHA-256 leaf-cert TOFU pinning for trusted hosts; `untrustHost` drops the pin

### M4 — Access token moved from URL queries to headers
- `X-Emby-Token` header via `DownloadURLBuilder.authorizedRequest(for:)` for downloads/subtitles/images; background `downloadTask(with: URLRequest)` persists headers across relaunch
- Sole surviving `api_key` query param: AVPlayer asset URLs (HLS sub-requests can't carry custom headers — commented in code)

### M8 — Test target no longer double-compiles Shared/
`SashimiTests` compiled `Shared/` sources while `TEST_HOST` loaded the app → duplicate classes/singletons at runtime. Removed from project.yml.

### Parental controls hardening
- Raw PIN in Keychain (legacy SHA-256 hashes still verify, discriminated by length); lockout + attempt counters moved to Keychain
- `KeychainHelper.save` is now non-destructive (add-then-update) so a failed PIN change can't destroy the existing PIN
- `setPIN` returns Bool with toast on failure; 4-character guard

### Cleanup
- Dead code removal: `pauseDownload`, `getHLSStreamURL`, `ServerConfiguration`, `VirtualFolderInfo`, `TrailerRow`, `mediaInfoPill`, `MediaDetailView.initialItem`, Fastfile bump lanes
- 3 iOS progress views stopped dividing the 0–1 `progressPercent` by 100
- HomeView: removed duplicate `.onAppear` load; 10 Hz hero-rotation timer → one 6 s tick with linear animation
- `os.Logger` adoption in HomeViewModel/SubtitleManager; `ServerDiscovery` `[weak self]`; persisted deviceId in DownloadURLBuilder; CLAUDE.md drift fixes

## Verification
- SwiftLint strict: clean
- tvOS suite: 126 tests, 0 failures
- iOS build: succeeded

## Needs hardware / real-server testing before tagging a release
- **M3**: TLS challenge paths untested against real self-signed/expired/rotated certs; note a pinned host whose cert legitimately rotates will hard-fail until untrust/retrust in Settings
- **M4**: background download header persistence is per-API-contract but unverified on device
- **M1**: track pre-selection and bitrate capping need real playback verification

🤖 Generated with [Claude Code](https://claude.com/claude-code)