### PR TITLE
fix(player): quality switching, observer crashes, subtitle persistence, single subtitle control

### DIFF
--- a/Sashimi/Info.plist
+++ b/Sashimi/Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.0</string>
+	<string>$(MARKETING_VERSION)</string>
 	<key>CFBundleURLTypes</key>
 	<array>
 		<dict>

--- a/Sashimi/Views/Player/TVPlayerViewController.swift
+++ b/Sashimi/Views/Player/TVPlayerViewController.swift
@@ -18,6 +18,14 @@ struct TVPlayerView: UIViewControllerRepresentable {
         playerVC.showsPlaybackControls = true
         playerVC.delegate = context.coordinator
 
+        // Subtitles are rendered by our own overlay and selected through the
+        // custom captions.bubble menu below, but AVPlayerViewController also
+        // shows its native subtitle panel whenever the player item exposes
+        // legible options — a second, non-functional subtitle control. The
+        // no-match language sentinel empties the native subtitle tab while
+        // keeping the native AUDIO tab (the only audio control on tvOS).
+        playerVC.allowedSubtitleOptionLanguages = [""]
+
         playerVC.transportBarCustomMenuItems = buildMenus()
 
         // Embed AVPVC as child VC (not modal — avoids dismiss lifecycle issues)

--- a/SashimiTests/PlaybackSelectionTests.swift
+++ b/SashimiTests/PlaybackSelectionTests.swift
@@ -6,15 +6,16 @@ final class PlaybackSelectionTests: XCTestCase {
 
     private func subtitleStream(
         language: String?,
-        index: Int,
+        index: Int?,
         isDefault: Bool? = nil,
-        isExternal: Bool? = nil
+        isExternal: Bool? = nil,
+        displayTitle: String? = nil
     ) -> MediaStream {
         MediaStream(
             type: "Subtitle",
             codec: "subrip",
             language: language,
-            displayTitle: language,
+            displayTitle: displayTitle ?? language,
             title: nil,
             height: nil,
             width: nil,
@@ -130,6 +131,115 @@ final class PlaybackSelectionTests: XCTestCase {
             subtitlesEnabled: true
         )
         XCTAssertEqual(selected?.index, 3)
+    }
+
+    // MARK: - matchingSubtitleStream
+
+    func testMatchesByLanguageWhenIndexesShift() {
+        // Same track, but the new media source numbers its streams differently
+        let streams = [
+            subtitleStream(language: "fre", index: 4),
+            subtitleStream(language: "eng", index: 7)
+        ]
+        let match = PlaybackSelection.matchingSubtitleStream(
+            in: streams,
+            language: "eng",
+            displayTitle: "eng",
+            isExternal: false
+        )
+        XCTAssertEqual(match?.index, 7)
+    }
+
+    func testMatchesToleratesTwoVsThreeLetterLanguageCodes() {
+        let streams = [subtitleStream(language: "eng", index: 3)]
+        let match = PlaybackSelection.matchingSubtitleStream(
+            in: streams,
+            language: "en",
+            displayTitle: nil,
+            isExternal: false
+        )
+        XCTAssertEqual(match?.index, 3)
+    }
+
+    func testPrefersDisplayTitleMatchAmongSameLanguageStreams() {
+        let streams = [
+            subtitleStream(language: "eng", index: 2, displayTitle: "English"),
+            subtitleStream(language: "eng", index: 3, displayTitle: "English (SDH)")
+        ]
+        let match = PlaybackSelection.matchingSubtitleStream(
+            in: streams,
+            language: "eng",
+            displayTitle: "English (SDH)",
+            isExternal: false
+        )
+        XCTAssertEqual(match?.index, 3)
+    }
+
+    func testPrefersMatchingExternalFlagWhenTitleDiffers() {
+        let streams = [
+            subtitleStream(language: "eng", index: 2, isExternal: false, displayTitle: "English (embedded)"),
+            subtitleStream(language: "eng", index: 5, isExternal: true, displayTitle: "English (SRT)")
+        ]
+        let match = PlaybackSelection.matchingSubtitleStream(
+            in: streams,
+            language: "eng",
+            displayTitle: "English",
+            isExternal: true
+        )
+        XCTAssertEqual(match?.index, 5)
+    }
+
+    func testFallsBackToLanguageOnlyWhenExternalFlagDiffers() {
+        let streams = [
+            subtitleStream(language: "eng", index: 2, isExternal: false, displayTitle: "English")
+        ]
+        let match = PlaybackSelection.matchingSubtitleStream(
+            in: streams,
+            language: "eng",
+            displayTitle: "English (SRT)",
+            isExternal: true
+        )
+        XCTAssertEqual(match?.index, 2)
+    }
+
+    func testSkipsStreamsWithoutAnIndex() {
+        // A stream with no index can't be addressed for playback — matching
+        // it would previously collapse to index 0 and silently fail.
+        let streams = [
+            subtitleStream(language: "eng", index: nil),
+            subtitleStream(language: "eng", index: 6)
+        ]
+        let match = PlaybackSelection.matchingSubtitleStream(
+            in: streams,
+            language: "eng",
+            displayTitle: "eng",
+            isExternal: false
+        )
+        XCTAssertEqual(match?.index, 6)
+    }
+
+    func testNoMatchWhenLanguageMissingFromNewSource() {
+        let streams = [subtitleStream(language: "fre", index: 1)]
+        XCTAssertNil(
+            PlaybackSelection.matchingSubtitleStream(
+                in: streams,
+                language: "eng",
+                displayTitle: "eng",
+                isExternal: false
+            )
+        )
+    }
+
+    func testNoMatchForNilLanguagePreference() {
+        let streams = [subtitleStream(language: "eng", index: 1)]
+        XCTAssertNil(
+            PlaybackSelection.matchingSubtitleStream(
+                in: streams,
+                language: nil,
+                displayTitle: "Unknown",
+                isExternal: false
+            )
+        )
     }
 
     // MARK: - preferredAudioOptionIndex

--- a/Shared/Services/JellyfinClient.swift
+++ b/Shared/Services/JellyfinClient.swift
@@ -808,12 +808,12 @@ actor JellyfinClient {
         return components.url
     }
 
-    func reportPlaybackStart(itemId: String, positionTicks: Int64 = 0, playSessionId: String? = nil) async throws {
+    func reportPlaybackStart(itemId: String, positionTicks: Int64 = 0, playSessionId: String? = nil, playMethod: String = "DirectStream") async throws {
         var body: [String: Any] = [
             "ItemId": itemId,
             "PositionTicks": positionTicks,
             "IsPaused": false,
-            "PlayMethod": "DirectStream"
+            "PlayMethod": playMethod
         ]
         if let playSessionId {
             body["PlaySessionId"] = playSessionId

--- a/Shared/Services/JellyfinClient.swift
+++ b/Shared/Services/JellyfinClient.swift
@@ -643,12 +643,18 @@ actor JellyfinClient {
     func getPlaybackInfo(
         itemId: String,
         maxBitrate: Int? = nil,
-        forceDirectPlay: Bool = false
+        forceDirectPlay: Bool = false,
+        forceTranscode: Bool = false
     ) async throws -> PlaybackInfoResponse {
         guard let userId else { throw JellyfinError.notConfigured }
 
         // Default to 120 Mbps (essentially unlimited), or use specified bitrate
         let streamingBitrate = maxBitrate ?? 120_000_000
+
+        // An explicit quality pick (forceTranscode) beats the global Force
+        // Direct Play setting for this request — otherwise the pick could
+        // never take effect.
+        let effectiveForceDirectPlay = forceDirectPlay && !forceTranscode
 
         let deviceProfile: [String: Any] = [
             "MaxStreamingBitrate": streamingBitrate,
@@ -683,12 +689,21 @@ actor JellyfinClient {
         // Disabling DirectStream and Transcoding leaves direct play as the
         // only option, so the server either returns the original file or
         // reports the item unplayable (rather than silently remuxing).
+        //
+        // Conversely, forceTranscode disables DirectPlay and DirectStream so
+        // the server MUST return a transcodingUrl that honors the bitrate
+        // cap — the quality tiers are caps, not targets, so a direct-played
+        // source under the cap would otherwise make the pick a no-op.
+        //
+        // MaxStreamingBitrate is sent both top-level and inside the device
+        // profile: which one the server honors is version-dependent.
         let body: [String: Any] = [
             "UserId": userId,
+            "MaxStreamingBitrate": streamingBitrate,
             "DeviceProfile": deviceProfile,
-            "EnableDirectPlay": true,
-            "EnableDirectStream": !forceDirectPlay,
-            "EnableTranscoding": !forceDirectPlay,
+            "EnableDirectPlay": !forceTranscode,
+            "EnableDirectStream": !effectiveForceDirectPlay && !forceTranscode,
+            "EnableTranscoding": !effectiveForceDirectPlay,
             "AllowVideoStreamCopy": true,
             "AllowAudioStreamCopy": true,
             "AutoOpenLiveStream": true
@@ -793,13 +808,16 @@ actor JellyfinClient {
         return components.url
     }
 
-    func reportPlaybackStart(itemId: String, positionTicks: Int64 = 0) async throws {
-        let body: [String: Any] = [
+    func reportPlaybackStart(itemId: String, positionTicks: Int64 = 0, playSessionId: String? = nil) async throws {
+        var body: [String: Any] = [
             "ItemId": itemId,
             "PositionTicks": positionTicks,
             "IsPaused": false,
             "PlayMethod": "DirectStream"
         ]
+        if let playSessionId {
+            body["PlaySessionId"] = playSessionId
+        }
 
         let bodyData = try JSONSerialization.data(withJSONObject: body)
 
@@ -810,12 +828,15 @@ actor JellyfinClient {
         )
     }
 
-    func reportPlaybackProgress(itemId: String, positionTicks: Int64, isPaused: Bool) async throws {
-        let body: [String: Any] = [
+    func reportPlaybackProgress(itemId: String, positionTicks: Int64, isPaused: Bool, playSessionId: String? = nil) async throws {
+        var body: [String: Any] = [
             "ItemId": itemId,
             "PositionTicks": positionTicks,
             "IsPaused": isPaused
         ]
+        if let playSessionId {
+            body["PlaySessionId"] = playSessionId
+        }
 
         let bodyData = try JSONSerialization.data(withJSONObject: body)
 
@@ -826,11 +847,14 @@ actor JellyfinClient {
         )
     }
 
-    func reportPlaybackStopped(itemId: String, positionTicks: Int64) async throws {
-        let body: [String: Any] = [
+    func reportPlaybackStopped(itemId: String, positionTicks: Int64, playSessionId: String? = nil) async throws {
+        var body: [String: Any] = [
             "ItemId": itemId,
             "PositionTicks": positionTicks
         ]
+        if let playSessionId {
+            body["PlaySessionId"] = playSessionId
+        }
 
         let bodyData = try JSONSerialization.data(withJSONObject: body)
 
@@ -838,6 +862,20 @@ actor JellyfinClient {
             path: "/Sessions/Playing/Stopped",
             method: "POST",
             body: bodyData
+        )
+    }
+
+    /// Tells the server to kill the ffmpeg transcode belonging to a play
+    /// session. Without this, changing quality (or leaving the player) left
+    /// the old transcode running server-side.
+    func stopActiveEncoding(playSessionId: String) async throws {
+        _ = try await request(
+            path: "/Videos/ActiveEncodings",
+            method: "DELETE",
+            queryItems: [
+                URLQueryItem(name: "deviceId", value: deviceId),
+                URLQueryItem(name: "playSessionId", value: playSessionId)
+            ]
         )
     }
 

--- a/Shared/Services/PlaybackSelection.swift
+++ b/Shared/Services/PlaybackSelection.swift
@@ -40,6 +40,31 @@ enum PlaybackSelection {
         return streams.first { $0.isDefault == true } ?? streams.first
     }
 
+    /// Finds the stream in a (possibly new) media source that corresponds to
+    /// a previously selected subtitle track. Stream indexes are NOT stable
+    /// across media sources (a quality change or next episode returns a new
+    /// source), so matching is by content, strictest first:
+    /// language + external flag + display title, then language + external
+    /// flag, then language alone. Streams without an index are skipped —
+    /// they can't be addressed for playback.
+    static func matchingSubtitleStream(
+        in streams: [MediaStream],
+        language: String?,
+        displayTitle: String?,
+        isExternal: Bool
+    ) -> MediaStream? {
+        let candidates = streams.filter { $0.index != nil && languagesMatch($0.language, language) }
+
+        if let displayTitle,
+           let match = candidates.first(where: { ($0.isExternal ?? false) == isExternal && $0.displayTitle == displayTitle }) {
+            return match
+        }
+        if let match = candidates.first(where: { ($0.isExternal ?? false) == isExternal }) {
+            return match
+        }
+        return candidates.first
+    }
+
     /// Index of the audio option matching the preferred language, given the
     /// language codes of the available options (in order). Returns nil when
     /// no preference is set or nothing matches, so the player's default

--- a/Shared/Services/SubtitleManager.swift
+++ b/Shared/Services/SubtitleManager.swift
@@ -21,8 +21,12 @@ class SubtitleManager: ObservableObject {
     @Published var isLoading = false
 
     private var cues: [SubtitleCue] = []
-    private var timeObserver: Any?
-    private weak var player: AVPlayer?
+    // The observer token is stored together with a strong reference to the
+    // player it was created on: removeTimeObserver must be called on that
+    // exact player (calling it on a different player throws
+    // NSInvalidArgumentException, and letting the player dealloc with a live
+    // observer throws NSInternalInconsistencyException).
+    private var timeObservation: (token: Any, player: AVPlayer)?
 
     func loadSubtitles(itemId: String, subtitleIndex: Int) async {
         isLoading = true
@@ -68,20 +72,23 @@ class SubtitleManager: ObservableObject {
     }
 
     func startTracking(player: AVPlayer) {
-        self.player = player
+        // Remove any observer from the previous player FIRST — tearing down
+        // after switching players would pair the old token with the new
+        // player and crash (see timeObservation).
         stopTracking()
 
         let interval = CMTime(seconds: 0.1, preferredTimescale: CMTimeScale(NSEC_PER_SEC))
-        timeObserver = player.addPeriodicTimeObserver(forInterval: interval, queue: .main) { [weak self] time in
+        let token = player.addPeriodicTimeObserver(forInterval: interval, queue: .main) { [weak self] time in
             self?.updateCurrentCue(at: time.seconds)
         }
+        timeObservation = (token: token, player: player)
     }
 
     func stopTracking() {
-        if let observer = timeObserver, let player = player {
-            player.removeTimeObserver(observer)
+        if let observation = timeObservation {
+            observation.player.removeTimeObserver(observation.token)
         }
-        timeObserver = nil
+        timeObservation = nil
     }
 
     private func updateCurrentCue(at time: Double) {

--- a/Shared/Services/SubtitleManager.swift
+++ b/Shared/Services/SubtitleManager.swift
@@ -91,6 +91,16 @@ class SubtitleManager: ObservableObject {
         timeObservation = nil
     }
 
+    deinit {
+        // Safety net: the tuple holds the last strong reference to the
+        // player, so dropping it with a live observer would dealloc the
+        // player mid-observation and crash. Normal teardown goes through
+        // clear()/stopTracking() before this ever matters.
+        if let observation = timeObservation {
+            observation.player.removeTimeObserver(observation.token)
+        }
+    }
+
     private func updateCurrentCue(at time: Double) {
         let activeCue = cues.first { cue in
             time >= cue.startTime && time < cue.endTime

--- a/Shared/ViewModels/PlayerViewModel.swift
+++ b/Shared/ViewModels/PlayerViewModel.swift
@@ -106,12 +106,17 @@ final class PlayerViewModel: ObservableObject {
     // is torn down or rebuilt.
     private var playSessionId: String?
 
+    /// Play method reported to the server — keeps the dashboard honest now
+    /// that explicit quality picks force transcodes.
+    private var currentPlayMethod: String {
+        currentMediaSource?.transcodingUrl != nil ? "Transcode" : "DirectStream"
+    }
+
     // Skip intro/credits
     @Published var segments: [MediaSegmentDto] = []
     @Published var currentSegment: MediaSegmentDto?
     @Published var showingSkipButton = false
 
-    private var timeObserver: Any?
     private var segmentObserver: Any?
     private var progressReportTask: Task<Void, Never>?
     private var subtitleLoadTask: Task<Void, Never>?
@@ -137,6 +142,13 @@ final class PlayerViewModel: ObservableObject {
         if let endObserver {
             NotificationCenter.default.removeObserver(endObserver)
             self.endObserver = nil
+        }
+
+        // Kill the previous episode's transcode session, same as
+        // changeQuality — auto-play-next otherwise leaves the old encode
+        // running until the server times it out.
+        if let playSessionId, currentMediaSource?.transcodingUrl != nil {
+            try? await client.stopActiveEncoding(playSessionId: playSessionId)
         }
 
         isLoading = true
@@ -194,7 +206,7 @@ final class PlayerViewModel: ObservableObject {
                 // User explicitly chose to start over - play from beginning
                 resumePositionTicks = 0
                 if !isOffline {
-                    try? await client.reportPlaybackStart(itemId: freshItem.id, positionTicks: 0, playSessionId: playSessionId)
+                    try? await client.reportPlaybackStart(itemId: freshItem.id, positionTicks: 0, playSessionId: playSessionId, playMethod: currentPlayMethod)
                     startProgressReporting()
                 }
                 setupSegmentTracking()
@@ -206,7 +218,7 @@ final class PlayerViewModel: ObservableObject {
                 let startTime = CMTime(value: startTicks / 10000, timescale: 1000)
                 await player?.seek(to: startTime)
                 if !isOffline {
-                    try? await client.reportPlaybackStart(itemId: freshItem.id, positionTicks: startTicks, playSessionId: playSessionId)
+                    try? await client.reportPlaybackStart(itemId: freshItem.id, positionTicks: startTicks, playSessionId: playSessionId, playMethod: currentPlayMethod)
                     startProgressReporting()
                 }
                 setupSegmentTracking()
@@ -216,7 +228,7 @@ final class PlayerViewModel: ObservableObject {
                 // No saved progress - start playing immediately
                 resumePositionTicks = 0
                 if !isOffline {
-                    try? await client.reportPlaybackStart(itemId: freshItem.id, positionTicks: 0, playSessionId: playSessionId)
+                    try? await client.reportPlaybackStart(itemId: freshItem.id, positionTicks: 0, playSessionId: playSessionId, playMethod: currentPlayMethod)
                     startProgressReporting()
                 }
                 setupSegmentTracking()
@@ -339,6 +351,11 @@ final class PlayerViewModel: ObservableObject {
         subtitleLoadTask?.cancel()
         cleanupSegmentTracking()
         subtitleManager.clear()
+        // Reset the menu selection alongside the overlay — the re-apply
+        // below sets it back when it finds a match in the new source, and
+        // without this a failed match would leave the menu showing a track
+        // that isn't rendering.
+        selectedSubtitleTrackId = "off"
 
         if let endObserver {
             NotificationCenter.default.removeObserver(endObserver)
@@ -372,8 +389,12 @@ final class PlayerViewModel: ObservableObject {
             // Re-apply the session's subtitle selection on the rebuilt
             // player — the overlay was cleared along with the old player.
             // Match by content, not raw index: the new media source's stream
-            // indexes may differ from the old one's.
-            applySessionSubtitlePreference()
+            // indexes may differ from the old one's. When there was no manual
+            // pick this session, fall back to the Settings preference (which
+            // is what selected the subtitles that were just cleared).
+            if !applySessionSubtitlePreference() {
+                applyPreferredSubtitles()
+            }
 
             // Resume playback and tracking
             startProgressReporting()
@@ -710,15 +731,18 @@ final class PlayerViewModel: ObservableObject {
 
         selectedSubtitleTrackId = track.id
 
-        // Remember the session's subtitle intent by content so it survives
-        // quality changes and episode transitions (stream indexes don't).
-        sessionSubtitlePreference = SubtitlePreference(
-            language: track.languageCode,
-            displayTitle: track.displayName,
-            isExternal: track.isExternal
-        )
-
         if isUserSelection {
+            // Remember the session's subtitle intent by content so it
+            // survives quality changes and episode transitions (stream
+            // indexes don't). Only manual picks may write this — automatic
+            // re-applies can resolve via a weaker fallback tier (e.g.
+            // embedded "English" for an external "English (SDH)" pick), and
+            // storing that match would permanently degrade the intent.
+            sessionSubtitlePreference = SubtitlePreference(
+                language: track.languageCode,
+                displayTitle: track.displayName,
+                isExternal: track.isExternal
+            )
             // "On stays on until I turn it off" — persist the manual choice
             // across app launches too.
             playbackSettings.subtitlesEnabled = true

--- a/Shared/ViewModels/PlayerViewModel.swift
+++ b/Shared/ViewModels/PlayerViewModel.swift
@@ -90,6 +90,11 @@ final class PlayerViewModel: ObservableObject {
     private var currentMediaSource: MediaSourceInfo?
     private var currentSubtitleStreamIndex: Int?
 
+    // Server-side play session: sent with playback reports so the server can
+    // correlate them, and used to stop the session's transcode when playback
+    // is torn down or rebuilt.
+    private var playSessionId: String?
+
     // Skip intro/credits
     @Published var segments: [MediaSegmentDto] = []
     @Published var currentSegment: MediaSegmentDto?
@@ -178,7 +183,7 @@ final class PlayerViewModel: ObservableObject {
                 // User explicitly chose to start over - play from beginning
                 resumePositionTicks = 0
                 if !isOffline {
-                    try? await client.reportPlaybackStart(itemId: freshItem.id, positionTicks: 0)
+                    try? await client.reportPlaybackStart(itemId: freshItem.id, positionTicks: 0, playSessionId: playSessionId)
                     startProgressReporting()
                 }
                 setupSegmentTracking()
@@ -190,7 +195,7 @@ final class PlayerViewModel: ObservableObject {
                 let startTime = CMTime(value: startTicks / 10000, timescale: 1000)
                 await player?.seek(to: startTime)
                 if !isOffline {
-                    try? await client.reportPlaybackStart(itemId: freshItem.id, positionTicks: startTicks)
+                    try? await client.reportPlaybackStart(itemId: freshItem.id, positionTicks: startTicks, playSessionId: playSessionId)
                     startProgressReporting()
                 }
                 setupSegmentTracking()
@@ -200,7 +205,7 @@ final class PlayerViewModel: ObservableObject {
                 // No saved progress - start playing immediately
                 resumePositionTicks = 0
                 if !isOffline {
-                    try? await client.reportPlaybackStart(itemId: freshItem.id, positionTicks: 0)
+                    try? await client.reportPlaybackStart(itemId: freshItem.id, positionTicks: 0, playSessionId: playSessionId)
                     startProgressReporting()
                 }
                 setupSegmentTracking()
@@ -233,7 +238,7 @@ final class PlayerViewModel: ObservableObject {
         let positionTicks = Int64(currentTime.seconds * 10_000_000)
         let isPaused = player.timeControlStatus == .paused
 
-        try? await client.reportPlaybackProgress(itemId: item.id, positionTicks: positionTicks, isPaused: isPaused)
+        try? await client.reportPlaybackProgress(itemId: item.id, positionTicks: positionTicks, isPaused: isPaused, playSessionId: playSessionId)
     }
 
     private func handlePlaybackEnded() async {
@@ -243,7 +248,7 @@ final class PlayerViewModel: ObservableObject {
             // Mark as watched by reporting position at the end
             if let duration = player?.currentItem?.duration.seconds, duration.isFinite {
                 let endTicks = Int64(duration * 10_000_000)
-                try? await client.reportPlaybackStopped(itemId: item.id, positionTicks: endTicks)
+                try? await client.reportPlaybackStopped(itemId: item.id, positionTicks: endTicks, playSessionId: playSessionId)
             }
             // Mark item as played
             try? await client.markPlayed(itemId: item.id)
@@ -333,8 +338,17 @@ final class PlayerViewModel: ObservableObject {
         player = nil
         isLoading = true
 
+        // Kill the old transcode session before requesting a new one, so the
+        // server isn't left encoding a stream nobody is watching.
+        if let playSessionId, currentMediaSource?.transcodingUrl != nil {
+            try? await client.stopActiveEncoding(playSessionId: playSessionId)
+        }
+
         do {
-            try await setupPlayer(for: item, maxBitrate: quality.maxBitrate)
+            // An explicit non-Auto pick forces a transcode so the selection
+            // visibly takes effect: the tiers are caps, and a direct-played
+            // source under the cap would otherwise make the pick a no-op.
+            try await setupPlayer(for: item, maxBitrate: quality.maxBitrate, forceTranscode: quality != .auto)
             isLoading = false
             updateNowPlayingInfo(item: item)
 
@@ -367,7 +381,7 @@ final class PlayerViewModel: ObservableObject {
     }
 
     /// Shared player setup: resolves stream URL, creates AVPlayer with observers.
-    private func setupPlayer(for item: BaseItemDto, maxBitrate: Int? = nil) async throws {
+    private func setupPlayer(for item: BaseItemDto, maxBitrate: Int? = nil, forceTranscode: Bool = false) async throws {
         // Bitrate precedence: explicit override (quality menu change) →
         // session quality selection → global Settings cap. QualityOption.auto
         // has a nil bitrate, so "Auto" defers to Settings, where 0 = no cap.
@@ -378,13 +392,15 @@ final class PlayerViewModel: ObservableObject {
         let playbackInfo = try await client.getPlaybackInfo(
             itemId: item.id,
             maxBitrate: effectiveBitrate,
-            forceDirectPlay: playbackSettings.forceDirectPlay
+            forceDirectPlay: playbackSettings.forceDirectPlay,
+            forceTranscode: forceTranscode
         )
 
         guard let mediaSource = playbackInfo.mediaSources?.first else {
             throw PlayerError.noMediaSource
         }
 
+        playSessionId = playbackInfo.playSessionId
         currentMediaSource = mediaSource
         videoResolution = mediaSource.videoResolution
 
@@ -491,9 +507,15 @@ final class PlayerViewModel: ObservableObject {
             }
 
             if !isOfflinePlayback {
-                try? await client.reportPlaybackStopped(itemId: item.id, positionTicks: positionTicks)
+                try? await client.reportPlaybackStopped(itemId: item.id, positionTicks: positionTicks, playSessionId: playSessionId)
             }
         }
+
+        // Kill the session's server-side transcode, if one was active.
+        if !isOfflinePlayback, let playSessionId, currentMediaSource?.transcodingUrl != nil {
+            try? await client.stopActiveEncoding(playSessionId: playSessionId)
+        }
+        playSessionId = nil
 
         player?.pause()
         invalidatePlayerObservers()

--- a/Shared/ViewModels/PlayerViewModel.swift
+++ b/Shared/ViewModels/PlayerViewModel.swift
@@ -90,6 +90,17 @@ final class PlayerViewModel: ObservableObject {
     private var currentMediaSource: MediaSourceInfo?
     private var currentSubtitleStreamIndex: Int?
 
+    /// The subtitle track the session wants, described by content rather
+    /// than stream index (indexes are not stable across media sources).
+    /// Once set, subtitles stay on across quality changes and episode
+    /// transitions until explicitly turned off (disableSubtitles/stop).
+    private struct SubtitlePreference {
+        let language: String?
+        let displayTitle: String?
+        let isExternal: Bool
+    }
+    private var sessionSubtitlePreference: SubtitlePreference?
+
     // Server-side play session: sent with playback reports so the server can
     // correlate them, and used to stop the session's transcode when playback
     // is torn down or rebuilt.
@@ -360,14 +371,9 @@ final class PlayerViewModel: ObservableObject {
 
             // Re-apply the session's subtitle selection on the rebuilt
             // player — the overlay was cleared along with the old player.
-            // Rebuild the track from the media source rather than looking it
-            // up in subtitleTracks, which is only populated once the subtitle
-            // menu UI has appeared (never, on iOS).
-            if let selectedId = selectedSubtitleTrackId, selectedId != "off",
-               let stream = currentMediaSource?.subtitleStreams
-                   .first(where: { "\($0.index ?? 0)" == selectedId }) {
-                selectSubtitleTrack(Self.subtitleTrackOption(for: stream))
-            }
+            // Match by content, not raw index: the new media source's stream
+            // indexes may differ from the old one's.
+            applySessionSubtitlePreference()
 
             // Resume playback and tracking
             startProgressReporting()
@@ -485,6 +491,9 @@ final class PlayerViewModel: ObservableObject {
         subtitleLoadTask?.cancel()
         cleanupSegmentTracking()
         subtitleManager.clear()
+        // The session is over — the persisted playbackSettings carry the
+        // subtitle preference into the next one.
+        sessionSubtitlePreference = nil
 
         if let endObserver {
             NotificationCenter.default.removeObserver(endObserver)
@@ -575,7 +584,29 @@ final class PlayerViewModel: ObservableObject {
     /// these because they happen afterwards.
     private func applyPreferredTracks() async {
         await applyPreferredAudioLanguage()
-        applyPreferredSubtitles()
+        // The session's subtitle intent (a selection made in the player,
+        // e.g. during the previous episode) wins over the Settings-based
+        // preference — subtitles stay on until manually turned off.
+        if !applySessionSubtitlePreference() {
+            applyPreferredSubtitles()
+        }
+    }
+
+    /// Re-applies the session's subtitle intent against the current media
+    /// source. Returns false when there is no intent or no matching stream,
+    /// so callers can fall back to the Settings-based preference.
+    @discardableResult
+    private func applySessionSubtitlePreference() -> Bool {
+        guard let preference = sessionSubtitlePreference,
+              let stream = PlaybackSelection.matchingSubtitleStream(
+                in: currentMediaSource?.subtitleStreams ?? [],
+                language: preference.language,
+                displayTitle: preference.displayTitle,
+                isExternal: preference.isExternal
+              ) else { return false }
+
+        selectSubtitleTrack(Self.subtitleTrackOption(for: stream), isUserSelection: false)
+        return true
     }
 
     private func applyPreferredAudioLanguage() async {
@@ -601,7 +632,7 @@ final class PlayerViewModel: ObservableObject {
                 subtitlesEnabled: playbackSettings.subtitlesEnabled
               ) else { return }
 
-        selectSubtitleTrack(Self.subtitleTrackOption(for: stream))
+        selectSubtitleTrack(Self.subtitleTrackOption(for: stream), isUserSelection: false)
     }
 
     /// Builds a menu option for a Jellyfin subtitle stream using the same
@@ -656,30 +687,57 @@ final class PlayerViewModel: ObservableObject {
         }
     }
 
-    func selectSubtitleTrack(_ track: SubtitleTrackOption) {
-        // Update selection state
-        selectedSubtitleTrackId = track.isOffOption ? "off" : track.id
-
+    /// Selects a subtitle track. `isUserSelection` distinguishes a manual
+    /// pick in the player UI (persisted as the user's preference) from the
+    /// automatic re-application paths (Settings preference, quality change,
+    /// next episode), which must not overwrite the stored preference.
+    func selectSubtitleTrack(_ track: SubtitleTrackOption, isUserSelection: Bool = true) {
         // A newer selection supersedes any in-flight subtitle load — racing
         // loads used to call startTracking against a stale player.
         subtitleLoadTask?.cancel()
 
+        if track.isOffOption {
+            if isUserSelection {
+                // Manual "Off" — same persistence semantics as the views
+                // that call disableSubtitles() directly.
+                disableSubtitles()
+            } else {
+                selectedSubtitleTrackId = "off"
+                subtitleManager.clear()
+            }
+            return
+        }
+
+        selectedSubtitleTrackId = track.id
+
+        // Remember the session's subtitle intent by content so it survives
+        // quality changes and episode transitions (stream indexes don't).
+        sessionSubtitlePreference = SubtitlePreference(
+            language: track.languageCode,
+            displayTitle: track.displayName,
+            isExternal: track.isExternal
+        )
+
+        if isUserSelection {
+            // "On stays on until I turn it off" — persist the manual choice
+            // across app launches too.
+            playbackSettings.subtitlesEnabled = true
+            if let language = track.languageCode, !language.isEmpty {
+                playbackSettings.preferredSubtitleLanguage = language
+            }
+        }
+
         guard let item = currentItem, let player = player else { return }
 
-        if track.isOffOption {
-            // Turn off subtitles
-            subtitleManager.clear()
-        } else {
-            // Load and display subtitles via our custom overlay. Capture the
-            // player at creation: by the time the load finishes the player
-            // may have been rebuilt (quality change / next episode), and
-            // tracking a stale player would leave a live observer on it.
-            let capturedPlayer = player
-            subtitleLoadTask = Task {
-                await subtitleManager.loadSubtitles(itemId: item.id, subtitleIndex: track.index)
-                guard !Task.isCancelled, self.player === capturedPlayer else { return }
-                subtitleManager.startTracking(player: capturedPlayer)
-            }
+        // Load and display subtitles via our custom overlay. Capture the
+        // player at creation: by the time the load finishes the player
+        // may have been rebuilt (quality change / next episode), and
+        // tracking a stale player would leave a live observer on it.
+        let capturedPlayer = player
+        subtitleLoadTask = Task {
+            await subtitleManager.loadSubtitles(itemId: item.id, subtitleIndex: track.index)
+            guard !Task.isCancelled, self.player === capturedPlayer else { return }
+            subtitleManager.startTracking(player: capturedPlayer)
         }
     }
 
@@ -687,9 +745,16 @@ final class PlayerViewModel: ObservableObject {
     /// option: sets the "off" sentinel AND clears the subtitle overlay. Views
     /// must use this instead of mutating `selectedSubtitleTrackId` directly,
     /// which would leave the current subtitles on screen.
+    ///
+    /// This is the ONLY place (besides stop()) that drops the session
+    /// subtitle intent, and it persists the "off" choice — subtitles stay
+    /// off across episodes and app launches until re-enabled.
     func disableSubtitles() {
+        subtitleLoadTask?.cancel()
         selectedSubtitleTrackId = "off"
         subtitleManager.clear()
+        sessionSubtitlePreference = nil
+        playbackSettings.subtitlesEnabled = false
     }
 
     func loadAllTracks() {

--- a/Shared/ViewModels/PlayerViewModel.swift
+++ b/Shared/ViewModels/PlayerViewModel.swift
@@ -98,6 +98,7 @@ final class PlayerViewModel: ObservableObject {
     private var timeObserver: Any?
     private var segmentObserver: Any?
     private var progressReportTask: Task<Void, Never>?
+    private var subtitleLoadTask: Task<Void, Never>?
     private var statusObserver: NSKeyValueObservation?
     private var errorObserver: NSKeyValueObservation?
     private var rateObserver: NSKeyValueObservation?
@@ -106,6 +107,22 @@ final class PlayerViewModel: ObservableObject {
     private let playbackSettings = PlaybackSettings.shared
 
     func loadMedia(item: BaseItemDto, startFromBeginning: Bool = false, localFileURL: URL? = nil) async {
+        // Tear down everything tied to the previous player first — auto-play
+        // next episode reuses this ViewModel, and observers left on the old
+        // player crash when it deallocates (same teardown as changeQuality).
+        // The session subtitle intent is deliberately preserved so subtitles
+        // stay on across episodes; only the overlay/tracking is cleared.
+        progressReportTask?.cancel()
+        subtitleLoadTask?.cancel()
+        cleanupSegmentTracking()
+        subtitleManager.clear()
+        selectedSubtitleTrackId = "off"
+        invalidatePlayerObservers()
+        if let endObserver {
+            NotificationCenter.default.removeObserver(endObserver)
+            self.endObserver = nil
+        }
+
         isLoading = true
         error = nil
         errorMessage = nil
@@ -303,6 +320,7 @@ final class PlayerViewModel: ObservableObject {
         // Stop current playback
         player?.pause()
         progressReportTask?.cancel()
+        subtitleLoadTask?.cancel()
         cleanupSegmentTracking()
         subtitleManager.clear()
 
@@ -311,6 +329,7 @@ final class PlayerViewModel: ObservableObject {
             self.endObserver = nil
         }
 
+        invalidatePlayerObservers()
         player = nil
         isLoading = true
 
@@ -433,8 +452,21 @@ final class PlayerViewModel: ObservableObject {
         }
     }
 
+    /// Invalidates the KVO observations tied to the current player/item.
+    /// Must run before the player is dropped or replaced so no observation
+    /// outlives the object it watches.
+    private func invalidatePlayerObservers() {
+        statusObserver?.invalidate()
+        statusObserver = nil
+        errorObserver?.invalidate()
+        errorObserver = nil
+        rateObserver?.invalidate()
+        rateObserver = nil
+    }
+
     func stop() async {
         progressReportTask?.cancel()
+        subtitleLoadTask?.cancel()
         cleanupSegmentTracking()
         subtitleManager.clear()
 
@@ -464,6 +496,7 @@ final class PlayerViewModel: ObservableObject {
         }
 
         player?.pause()
+        invalidatePlayerObservers()
         player = nil
         currentItem = nil
         playbackStartDate = nil
@@ -605,16 +638,25 @@ final class PlayerViewModel: ObservableObject {
         // Update selection state
         selectedSubtitleTrackId = track.isOffOption ? "off" : track.id
 
+        // A newer selection supersedes any in-flight subtitle load — racing
+        // loads used to call startTracking against a stale player.
+        subtitleLoadTask?.cancel()
+
         guard let item = currentItem, let player = player else { return }
 
         if track.isOffOption {
             // Turn off subtitles
             subtitleManager.clear()
         } else {
-            // Load and display subtitles via our custom overlay
-            Task {
+            // Load and display subtitles via our custom overlay. Capture the
+            // player at creation: by the time the load finishes the player
+            // may have been rebuilt (quality change / next episode), and
+            // tracking a stale player would leave a live observer on it.
+            let capturedPlayer = player
+            subtitleLoadTask = Task {
                 await subtitleManager.loadSubtitles(itemId: item.id, subtitleIndex: track.index)
-                subtitleManager.startTracking(player: player)
+                guard !Task.isCancelled, self.player === capturedPlayer else { return }
+                subtitleManager.startTracking(player: capturedPlayer)
             }
         }
     }
@@ -847,6 +889,7 @@ final class PlayerViewModel: ObservableObject {
 
     deinit {
         progressReportTask?.cancel()
+        subtitleLoadTask?.cancel()
         cleanupRemoteCommands()
         if let endObserver {
             NotificationCenter.default.removeObserver(endObserver)

--- a/TopShelf/Info.plist
+++ b/TopShelf/Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundlePackageType</key>
 	<string>XPC!</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.0</string>
+	<string>$(MARKETING_VERSION)</string>
 	<key>CFBundleVersion</key>
 	<string>1</string>
 	<key>NSExtension</key>

--- a/project.yml
+++ b/project.yml
@@ -48,6 +48,10 @@ targets:
       path: Sashimi/Info.plist
       properties:
         CFBundleDisplayName: Sashimi
+        # Marketing version flows from the MARKETING_VERSION build setting so it's
+        # a single source of truth (xcodegen otherwise hardcodes a default "1.0"),
+        # and the Settings About row shows the real version.
+        CFBundleShortVersionString: "$(MARKETING_VERSION)"
         UILaunchScreen: {}
         NSAppTransportSecurity:
           NSAllowsLocalNetworking: true
@@ -63,7 +67,7 @@ targets:
     settings:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.mondominator.sashimi
-        MARKETING_VERSION: 1.0.0
+        MARKETING_VERSION: 1.0.1
         CURRENT_PROJECT_VERSION: 2
         SWIFT_VERSION: 5.9
         SDKROOT: appletvos
@@ -164,6 +168,9 @@ targets:
       path: TopShelf/Info.plist
       properties:
         CFBundleDisplayName: Sashimi TopShelf
+        # Keep the extension's version in lockstep with the app — App Store
+        # validation expects them to match.
+        CFBundleShortVersionString: "$(MARKETING_VERSION)"
         UIRequiredDeviceCapabilities:
           - arm64
         NSExtension:
@@ -172,7 +179,7 @@ targets:
     settings:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.mondominator.sashimi.topshelf
-        MARKETING_VERSION: 1.0.0
+        MARKETING_VERSION: 1.0.1
         CURRENT_PROJECT_VERSION: 2
         SWIFT_VERSION: 5.9
         SDKROOT: appletvos


### PR DESCRIPTION
Closes #181

## Bugs fixed (from Apple TV hardware report)

### 1. Quality/bitrate selection had no visible effect (and sometimes crashed)
- Explicit quality picks now force a transcode (`EnableDirectPlay`/`EnableDirectStream` = false via new `forceTranscode` param) so the server can't silently keep direct-playing the original file
- `MaxStreamingBitrate` sent top-level in the PlaybackInfo POST (nested-in-DeviceProfile is server-version-dependent)
- `PlaySessionId` tracked and sent in progress reports; stale transcodes killed via `DELETE /Videos/ActiveEncodings` on quality change and episode transition
- Accurate `PlayMethod` (Transcode vs DirectStream) reported so the dashboard reflects reality

### 2. Crashes when changing quality
- `SubtitleManager` stores the observer token together with the player it was created on — `removeTimeObserver` is now always called on the correct player, and teardown happens *before* the player is swapped (was: token from old player removed on new player → `NSInvalidArgumentException`)
- `loadMedia` does full teardown (KVO, time observers, in-flight tasks, segment tracking) before rebuilding on autoplay/Up Next
- In-flight subtitle loads cancelled on quality change; post-await identity guards (`self.player === capturedPlayer`) prevent stale tasks touching a replaced player

### 3. Two subtitle icons doing slightly different things
- Native tvOS transport-bar subtitle panel suppressed (`allowedSubtitleOptionLanguages = [""]`) — the custom `captions.bubble` menu is now the single subtitle control; native audio tab kept

### 4. Subtitles turning off by themselves
- Manual subtitle picks recorded as a session preference (language/title/external) and re-applied across quality changes and episode transitions via a tiered matcher — only cleared when you turn subtitles off yourself
- Manual enable also persists `subtitlesEnabled` + preferred language to Settings

## Version
- `MARKETING_VERSION` bumped to **1.0.1** and routed into the Info.plists (were hardcoded "1.0") so Settings shows the real version — you can now tell which build you're on

## Verification
- SwiftLint strict: clean
- tvOS: 134 tests passed (incl. 8 new `matchingSubtitleStream` tier tests)
- iOS: build succeeded
- ⚠️ Quality forcing / transcode kill / subtitle persistence need verification on Apple TV hardware

🤖 Generated with [Claude Code](https://claude.com/claude-code)