### PR TITLE
ci: ship the iOS (SashimiMobile) build to TestFlight on deploy

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -96,6 +96,19 @@ jobs:
           APP_STORE_CONNECT_KEY_CONTENT: ${{ secrets.APP_STORE_CONNECT_KEY_CONTENT }}
         run: bundle exec fastlane beta
 
+      # The iOS (SashimiMobile) beta lane fetches its own match certs and
+      # stamps its own epoch build number, so it runs standalone after tvOS.
+      - name: Deploy iOS to TestFlight
+        if: github.event.inputs.environment == 'testflight' || contains(github.ref, 'beta') || contains(github.ref, 'rc')
+        env:
+          MATCH_PASSWORD: ${{ secrets.MATCH_PASSWORD }}
+          MATCH_GIT_URL: ${{ secrets.MATCH_GIT_URL }}
+          MATCH_GIT_BASIC_AUTHORIZATION: ${{ secrets.MATCH_GIT_BASIC_AUTHORIZATION }}
+          APP_STORE_CONNECT_KEY_ID: ${{ secrets.APP_STORE_CONNECT_KEY_ID }}
+          APP_STORE_CONNECT_ISSUER_ID: ${{ secrets.APP_STORE_CONNECT_ISSUER_ID }}
+          APP_STORE_CONNECT_KEY_CONTENT: ${{ secrets.APP_STORE_CONNECT_KEY_CONTENT }}
+        run: bundle exec fastlane ios beta
+
       - name: Deploy to App Store
         if: github.event.inputs.environment == 'appstore'
         env:


### PR DESCRIPTION
Closes #183

`deploy.yml` only ran `bundle exec fastlane beta`, which resolves to the default platform (tvOS) — the iOS lanes existed but were never invoked by CI, so the iPhone/iPad app on TestFlight is stuck at a manual Jun 25 upload and is missing the audit fixes (#179) and player crash/subtitle fixes (#182) that live in `Shared/`.

## Change
- Add a **Deploy iOS to TestFlight** step running `bundle exec fastlane ios beta` under the same conditions as the tvOS step (manual `testflight` dispatch or `beta`/`rc` tags)
- No Fastfile changes needed: the iOS beta lane already fetches its own match certs, stamps its own epoch build number, skips git steps on CI, and outputs to `fastlane/build/` (already covered by the artifact upload glob)
- iOS SDK ships with Xcode on the runner — no extra platform download needed (unlike tvOS)

## Follow-up (tracked in #183)
`platform :ios` has no `release` lane, so the App Store path remains tvOS-only.

## After merge
Tag `v1.0.0-beta.6` so both platforms ship the current main (tvOS gets a rebuild of beta.5 code; iOS gets its first CI build with all fixes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)