### PR TITLE
Hide 'Original' download option when the source won't play on the device

### DIFF
--- a/SashimiMobile/Downloads/Views/DownloadButton.swift
+++ b/SashimiMobile/Downloads/Views/DownloadButton.swift
@@ -10,6 +10,10 @@ struct DownloadButton: View {
     @State private var progress: Double = 0
     @State private var showingQualitySheet = false
     @State private var showingDeleteConfirmation = false
+    // Cached after the first playback-info fetch so re-taps don't refetch.
+    // Fails closed to `.no` (hide Original) on any error.
+    @State private var originalAllowed: OriginalAvailability = .undetermined
+    @State private var determiningOptions = false
     @ObservedObject private var downloadManager = DownloadManager.shared
     @Environment(\.horizontalSizeClass) private var sizeClass
 
@@ -21,6 +25,13 @@ struct DownloadButton: View {
         case paused
         case completed
         case failed
+    }
+
+    /// Tri-state for whether the raw source can direct-play (offer "Original").
+    private enum OriginalAvailability {
+        case undetermined
+        case yes
+        case no
     }
 
     var body: some View {
@@ -35,6 +46,10 @@ struct DownloadButton: View {
         .onChange(of: downloadManager.stateVersion) { _, _ in refreshState() }
         .confirmationDialog("Download Quality", isPresented: $showingQualitySheet) {
             qualityOptions
+        } message: {
+            if originalAllowed == .no {
+                Text("Original isn't available — this file's format can't play offline on this device.")
+            }
         }
         .confirmationDialog("Remove Download?", isPresented: $showingDeleteConfirmation) {
             Button("Remove Download", role: .destructive) {
@@ -49,7 +64,10 @@ struct DownloadButton: View {
     private var label: some View {
         switch downloadState {
         case .notDownloaded:
-            if sizeClass == .compact {
+            if determiningOptions {
+                ProgressView()
+                    .scaleEffect(0.7)
+            } else if sizeClass == .compact {
                 Image(systemName: "arrow.down.circle")
                     .font(.system(size: 20))
             } else {
@@ -93,9 +111,14 @@ struct DownloadButton: View {
         }
     }
 
+    // Drops .original unless the source is confirmed device-compatible.
+    private var availableQualities: [DownloadQuality] {
+        DownloadQuality.allCases.filter { $0 != .original || originalAllowed == .yes }
+    }
+
     @ViewBuilder
     private var qualityOptions: some View {
-        ForEach(DownloadQuality.allCases) { option in
+        ForEach(availableQualities) { option in
             Button("\(option.displayName) — \(option.subtitle)") {
                 downloadManager.enqueueDownload(item: item, quality: option)
             }
@@ -107,11 +130,11 @@ struct DownloadButton: View {
         switch downloadState {
         case .notDownloaded:
             if showQualityPicker {
-                showingQualitySheet = true
+                presentQualitySheet()
             } else if let quality {
-                downloadManager.enqueueDownload(item: item, quality: quality.wrappedValue)
+                enqueueBoundQuality(quality.wrappedValue)
             } else {
-                showingQualitySheet = true
+                presentQualitySheet()
             }
 
         case .queued, .preparing, .downloading:
@@ -125,6 +148,52 @@ struct DownloadButton: View {
 
         case .failed:
             Task { await downloadManager.retryDownload(itemId: item.id) }
+        }
+    }
+
+    /// Determines Original compatibility (if not already cached), then shows
+    /// the quality sheet. While the playback-info fetch is in flight a loading
+    /// affordance is shown in the button label.
+    private func presentQualitySheet() {
+        if originalAllowed != .undetermined {
+            showingQualitySheet = true
+            return
+        }
+        Task {
+            await determineOriginalAllowed()
+            showingQualitySheet = true
+        }
+    }
+
+    /// Enqueues a pre-bound quality. If the bound quality is .original but the
+    /// source isn't device-compatible, downgrade to .high rather than silently
+    /// downloading an unplayable original.
+    private func enqueueBoundQuality(_ requested: DownloadQuality) {
+        guard requested == .original else {
+            downloadManager.enqueueDownload(item: item, quality: requested)
+            return
+        }
+        Task {
+            await determineOriginalAllowed()
+            let resolved: DownloadQuality = (originalAllowed == .yes) ? .original : .high
+            downloadManager.enqueueDownload(item: item, quality: resolved)
+        }
+    }
+
+    /// Fetches playback info once and caches whether the raw source will
+    /// direct-play. Fails closed: any thrown error yields false.
+    @MainActor
+    private func determineOriginalAllowed() async {
+        guard originalAllowed == .undetermined else { return }
+        determiningOptions = true
+        defer { determiningOptions = false }
+        do {
+            let info = try await JellyfinClient.shared.getPlaybackInfo(itemId: item.id)
+            let compatible = info.mediaSources?.first
+                .map(DeviceMediaCompatibility.canDirectPlayOnDevice) ?? false
+            originalAllowed = compatible ? .yes : .no
+        } catch {
+            originalAllowed = .no
         }
     }
 

--- a/SashimiMobile/Downloads/Views/DownloadButton.swift
+++ b/SashimiMobile/Downloads/Views/DownloadButton.swift
@@ -44,6 +44,13 @@ struct DownloadButton: View {
         .tint(.white)
         .onAppear { refreshState() }
         .onChange(of: downloadManager.stateVersion) { _, _ in refreshState() }
+        // DownloadButton is recycled in ForEach/LazyVStack; `item` is a `let`,
+        // so SwiftUI won't reset @State when a reused view gets a new item.
+        // Clear cached Original availability so we don't show a stale result.
+        .onChange(of: item.id) { _, _ in
+            originalAllowed = .undetermined
+            determiningOptions = false
+        }
         .confirmationDialog("Download Quality", isPresented: $showingQualitySheet) {
             qualityOptions
         } message: {
@@ -169,6 +176,7 @@ struct DownloadButton: View {
     /// source isn't device-compatible, downgrade to .high rather than silently
     /// downloading an unplayable original.
     private func enqueueBoundQuality(_ requested: DownloadQuality) {
+        guard !determiningOptions else { return }
         guard requested == .original else {
             downloadManager.enqueueDownload(item: item, quality: requested)
             return

--- a/SashimiTests/DownloadCompatibilityTests.swift
+++ b/SashimiTests/DownloadCompatibilityTests.swift
@@ -1,0 +1,74 @@
+import XCTest
+@testable import Sashimi
+
+final class DownloadCompatibilityTests: XCTestCase {
+    /// Decodes a MediaSourceInfo from JSON. `container` may be nil (omit the
+    /// key by passing nil); video/audio codecs are supplied via MediaStreams.
+    private func makeSource(
+        container: String?,
+        videoCodec: String?,
+        audioCodec: String?
+    ) throws -> MediaSourceInfo {
+        var streams: [String] = []
+        if let videoCodec {
+            streams.append("{ \"Type\": \"Video\", \"Codec\": \"\(videoCodec)\" }")
+        }
+        if let audioCodec {
+            streams.append("{ \"Type\": \"Audio\", \"Codec\": \"\(audioCodec)\" }")
+        }
+        let containerField = container.map { "\"Container\": \"\($0)\"," } ?? ""
+        let json = """
+        {
+            "Id": "source-1",
+            \(containerField)
+            "MediaStreams": [\(streams.joined(separator: ","))]
+        }
+        """
+        return try JSONDecoder().decode(MediaSourceInfo.self, from: Data(json.utf8))
+    }
+
+    func testMp4H264AacDirectPlays() throws {
+        let source = try makeSource(container: "mp4", videoCodec: "h264", audioCodec: "aac")
+        XCTAssertTrue(DeviceMediaCompatibility.canDirectPlayOnDevice(source))
+    }
+
+    func testMovHevcEac3DirectPlays() throws {
+        let source = try makeSource(container: "mov", videoCodec: "hevc", audioCodec: "eac3")
+        XCTAssertTrue(DeviceMediaCompatibility.canDirectPlayOnDevice(source))
+    }
+
+    func testMkvContainerFails() throws {
+        let source = try makeSource(container: "mkv", videoCodec: "h264", audioCodec: "aac")
+        XCTAssertFalse(DeviceMediaCompatibility.canDirectPlayOnDevice(source))
+    }
+
+    func testUnsupportedVideoCodecFails() throws {
+        let source = try makeSource(container: "mp4", videoCodec: "vp9", audioCodec: "aac")
+        XCTAssertFalse(DeviceMediaCompatibility.canDirectPlayOnDevice(source))
+    }
+
+    func testUnsupportedAudioCodecFails() throws {
+        let source = try makeSource(container: "mp4", videoCodec: "h264", audioCodec: "dts")
+        XCTAssertFalse(DeviceMediaCompatibility.canDirectPlayOnDevice(source))
+    }
+
+    func testCommaListContainerDirectPlays() throws {
+        let source = try makeSource(container: "mp4,m4v", videoCodec: "h264", audioCodec: "aac")
+        XCTAssertTrue(DeviceMediaCompatibility.canDirectPlayOnDevice(source))
+    }
+
+    func testNilContainerFailsClosed() throws {
+        let source = try makeSource(container: nil, videoCodec: "h264", audioCodec: "aac")
+        XCTAssertFalse(DeviceMediaCompatibility.canDirectPlayOnDevice(source))
+    }
+
+    func testNilCodecsFailClosed() throws {
+        let source = try makeSource(container: "mp4", videoCodec: nil, audioCodec: nil)
+        XCTAssertFalse(DeviceMediaCompatibility.canDirectPlayOnDevice(source))
+    }
+
+    func testH265AliasTreatedAsHevc() throws {
+        let source = try makeSource(container: "mp4", videoCodec: "h265", audioCodec: "aac")
+        XCTAssertTrue(DeviceMediaCompatibility.canDirectPlayOnDevice(source))
+    }
+}

--- a/SashimiTests/DownloadCompatibilityTests.swift
+++ b/SashimiTests/DownloadCompatibilityTests.swift
@@ -71,4 +71,56 @@ final class DownloadCompatibilityTests: XCTestCase {
         let source = try makeSource(container: "mp4", videoCodec: "h265", audioCodec: "aac")
         XCTAssertTrue(DeviceMediaCompatibility.canDirectPlayOnDevice(source))
     }
+
+    /// Builds a source with an explicit list of video/audio codecs, each
+    /// producing a separate MediaStream of the given type.
+    private func makeMultiStreamSource(
+        container: String?,
+        videoCodecs: [String],
+        audioCodecs: [String]
+    ) throws -> MediaSourceInfo {
+        var streams: [String] = []
+        for codec in videoCodecs {
+            streams.append("{ \"Type\": \"Video\", \"Codec\": \"\(codec)\" }")
+        }
+        for codec in audioCodecs {
+            streams.append("{ \"Type\": \"Audio\", \"Codec\": \"\(codec)\" }")
+        }
+        let containerField = container.map { "\"Container\": \"\($0)\"," } ?? ""
+        let json = """
+        {
+            "Id": "source-1",
+            \(containerField)
+            "MediaStreams": [\(streams.joined(separator: ","))]
+        }
+        """
+        return try JSONDecoder().decode(MediaSourceInfo.self, from: Data(json.utf8))
+    }
+
+    // Fix 1: a compatible track anywhere in the list makes the file playable.
+    func testMultiAudioWithCompatibleTrackDirectPlays() throws {
+        let source = try makeMultiStreamSource(
+            container: "mp4", videoCodecs: ["h264"], audioCodecs: ["truehd", "ac3"])
+        XCTAssertTrue(DeviceMediaCompatibility.canDirectPlayOnDevice(source))
+    }
+
+    // Fix 1: no audio track is compatible → fail closed.
+    func testMultiAudioAllIncompatibleFails() throws {
+        let source = try makeMultiStreamSource(
+            container: "mp4", videoCodecs: ["h264"], audioCodecs: ["truehd", "dts"])
+        XCTAssertFalse(DeviceMediaCompatibility.canDirectPlayOnDevice(source))
+    }
+
+    // Fix 1 (defensive): at least one compatible video stream is enough.
+    func testMultiVideoWithCompatibleTrackDirectPlays() throws {
+        let source = try makeMultiStreamSource(
+            container: "mp4", videoCodecs: ["mpeg2video", "h264"], audioCodecs: ["aac"])
+        XCTAssertTrue(DeviceMediaCompatibility.canDirectPlayOnDevice(source))
+    }
+
+    // Fix 2: a mixed container list must be fully compatible.
+    func testMixedContainerFailsClosed() throws {
+        let source = try makeSource(container: "mkv,mp4", videoCodec: "h264", audioCodec: "aac")
+        XCTAssertFalse(DeviceMediaCompatibility.canDirectPlayOnDevice(source))
+    }
 }

--- a/Shared/Services/DeviceMediaCompatibility.swift
+++ b/Shared/Services/DeviceMediaCompatibility.swift
@@ -1,0 +1,53 @@
+import Foundation
+
+/// Determines whether a raw media source will direct-play on this device's
+/// AVPlayer (iOS/tvOS) without any server-side remuxing or transcoding.
+///
+/// The allowlists below MUST mirror the iOS DirectPlayProfiles sent by
+/// `JellyfinClient.getPlaybackInfo` (Container "mp4,m4v"/"mov",
+/// VideoCodec "h264,hevc", AudioCodec "aac,ac3,eac3"). Those two definitions
+/// are the single source of truth for device compatibility — if one changes,
+/// update the other to keep them in sync.
+enum DeviceMediaCompatibility {
+    /// Containers AVPlayer can play natively.
+    static let directPlayContainers: Set<String> = ["mp4", "m4v", "mov"]
+    /// Video codecs AVPlayer can decode.
+    static let directPlayVideoCodecs: Set<String> = ["h264", "hevc"]
+    /// Audio codecs AVPlayer can decode.
+    static let directPlayAudioCodecs: Set<String> = ["aac", "ac3", "eac3"]
+
+    /// Normalizes common codec aliases onto the canonical name used above.
+    private static func canonicalCodec(_ raw: String) -> String {
+        let value = raw.lowercased().trimmingCharacters(in: .whitespaces)
+        switch value {
+        case "h265": return "hevc"
+        case "avc", "x264", "mpeg4/avc": return "h264"
+        default: return value
+        }
+    }
+
+    /// True only when the raw source file will direct-play on iOS/tvOS
+    /// AVPlayer: its container AND video codec AND audio codec must all be in
+    /// the allowlists. Fails closed — any nil/unknown field yields false.
+    ///
+    /// `container` may be a comma-separated list (e.g. "mp4,m4v" or
+    /// "mkv,webm"); it is considered compatible when at least one listed token
+    /// is in the container allowlist.
+    static func canDirectPlayOnDevice(_ source: MediaSourceInfo) -> Bool {
+        guard let rawContainer = source.container, !rawContainer.isEmpty else { return false }
+        let containers = rawContainer
+            .lowercased()
+            .split(separator: ",")
+            .map { $0.trimmingCharacters(in: .whitespaces) }
+            .filter { !$0.isEmpty }
+        guard containers.contains(where: { directPlayContainers.contains($0) }) else { return false }
+
+        guard let rawVideo = source.videoCodec, !rawVideo.isEmpty,
+              directPlayVideoCodecs.contains(canonicalCodec(rawVideo)) else { return false }
+
+        guard let rawAudio = source.audioCodec, !rawAudio.isEmpty,
+              directPlayAudioCodecs.contains(canonicalCodec(rawAudio)) else { return false }
+
+        return true
+    }
+}

--- a/Shared/Services/DeviceMediaCompatibility.swift
+++ b/Shared/Services/DeviceMediaCompatibility.swift
@@ -27,12 +27,19 @@ enum DeviceMediaCompatibility {
     }
 
     /// True only when the raw source file will direct-play on iOS/tvOS
-    /// AVPlayer: its container AND video codec AND audio codec must all be in
-    /// the allowlists. Fails closed — any nil/unknown field yields false.
+    /// AVPlayer: its container must be compatible AND at least one video stream
+    /// AND at least one audio stream must use an allowlisted codec. Fails closed
+    /// — any nil/unknown field, empty stream list, or unsupported token yields
+    /// false.
     ///
-    /// `container` may be a comma-separated list (e.g. "mp4,m4v" or
-    /// "mkv,webm"); it is considered compatible when at least one listed token
-    /// is in the container allowlist.
+    /// `container` may be a comma-separated list (e.g. "mp4,m4v"); EVERY listed
+    /// token must be in the container allowlist (so an anomalous "mkv,mp4" fails
+    /// closed rather than passing on the compatible token alone).
+    ///
+    /// Because a file can carry multiple audio (and, defensively, video)
+    /// streams — e.g. a TrueHD primary track plus an AC3 compatibility track on
+    /// a Blu-ray rip — we require only that AT LEAST ONE stream of each type is
+    /// playable; AVPlayer can select a compatible track at playback time.
     static func canDirectPlayOnDevice(_ source: MediaSourceInfo) -> Bool {
         guard let rawContainer = source.container, !rawContainer.isEmpty else { return false }
         let containers = rawContainer
@@ -40,13 +47,26 @@ enum DeviceMediaCompatibility {
             .split(separator: ",")
             .map { $0.trimmingCharacters(in: .whitespaces) }
             .filter { !$0.isEmpty }
-        guard containers.contains(where: { directPlayContainers.contains($0) }) else { return false }
+        guard !containers.isEmpty,
+              containers.allSatisfy({ directPlayContainers.contains($0) }) else { return false }
 
-        guard let rawVideo = source.videoCodec, !rawVideo.isEmpty,
-              directPlayVideoCodecs.contains(canonicalCodec(rawVideo)) else { return false }
+        guard let streams = source.mediaStreams, !streams.isEmpty else { return false }
 
-        guard let rawAudio = source.audioCodec, !rawAudio.isEmpty,
-              directPlayAudioCodecs.contains(canonicalCodec(rawAudio)) else { return false }
+        let hasCompatibleVideo = streams
+            .filter { $0.type == "Video" }
+            .contains { stream in
+                guard let codec = stream.codec, !codec.isEmpty else { return false }
+                return directPlayVideoCodecs.contains(canonicalCodec(codec))
+            }
+        guard hasCompatibleVideo else { return false }
+
+        let hasCompatibleAudio = streams
+            .filter { $0.type == "Audio" }
+            .contains { stream in
+                guard let codec = stream.codec, !codec.isEmpty else { return false }
+                return directPlayAudioCodecs.contains(canonicalCodec(codec))
+            }
+        guard hasCompatibleAudio else { return false }
 
         return true
     }


### PR DESCRIPTION
Fixes #185

## Problem
The download quality picker always offered **Original**, which downloads the raw source via `/Items/{id}/Download`. For a container/codec iOS can't play (e.g. MKV), the download completed but wouldn't play — a broken offline item.

## Fix
Only show **Original** when the source will actually direct-play on the device. On the download tap, fetch `getPlaybackInfo` (which already sends the iOS device profile) and check the source against the app's direct-play profile (container `mp4/m4v/mov`, video `h264/hevc`, audio `aac/ac3/eac3`) via a new `DeviceMediaCompatibility` helper. Incompatible sources show only High/Medium/Low (always transcoded to a playable H.264/AAC mp4). Fail closed: if compatibility can't be confirmed (e.g. offline), Original is hidden.

Details:
- **Any-stream** matching: a file with a TrueHD primary + AC3 compatibility audio track is correctly considered playable (AVPlayer uses the AC3 track).
- **Container** check is fail-closed (every token must be allowlisted), so an anomalous `"mkv,mp4"` won't slip through.
- Double-tap guarded; cached compatibility reset when a recycled list view (episode sheets) is handed a different item.
- `DownloadManager` / `DownloadURLBuilder` unchanged; the H.264/AAC tiers are unaffected.

Known limitation (follow-up): HEVC Dolby Vision profile 5 passes the codec check and could still be offered as Original; excluding it needs `videoRangeType` decoding + device-DV detection.

## Tests
`SashimiTests/DownloadCompatibilityTests` — 13 cases (compatible/incompatible containers & codecs, comma-lists, multi-audio-stream, alias normalization, nil fail-closed). iOS build succeeds, tests pass, SwiftLint strict clean.