### PR TITLE
Exclude Dolby Vision Profile 5 from 'Original' download on non-DV devices

### DIFF
--- a/SashimiMobile/Downloads/Views/DownloadButton.swift
+++ b/SashimiMobile/Downloads/Views/DownloadButton.swift
@@ -198,7 +198,7 @@ struct DownloadButton: View {
         do {
             let info = try await JellyfinClient.shared.getPlaybackInfo(itemId: item.id)
             let compatible = info.mediaSources?.first
-                .map(DeviceMediaCompatibility.canDirectPlayOnDevice) ?? false
+                .map { DeviceMediaCompatibility.canDirectPlayOnDevice($0) } ?? false
             originalAllowed = compatible ? .yes : .no
         } catch {
             originalAllowed = .no

--- a/SashimiTests/DownloadCompatibilityTests.swift
+++ b/SashimiTests/DownloadCompatibilityTests.swift
@@ -29,47 +29,47 @@ final class DownloadCompatibilityTests: XCTestCase {
 
     func testMp4H264AacDirectPlays() throws {
         let source = try makeSource(container: "mp4", videoCodec: "h264", audioCodec: "aac")
-        XCTAssertTrue(DeviceMediaCompatibility.canDirectPlayOnDevice(source))
+        XCTAssertTrue(DeviceMediaCompatibility.canDirectPlayOnDevice(source, deviceSupportsDolbyVision: true))
     }
 
     func testMovHevcEac3DirectPlays() throws {
         let source = try makeSource(container: "mov", videoCodec: "hevc", audioCodec: "eac3")
-        XCTAssertTrue(DeviceMediaCompatibility.canDirectPlayOnDevice(source))
+        XCTAssertTrue(DeviceMediaCompatibility.canDirectPlayOnDevice(source, deviceSupportsDolbyVision: true))
     }
 
     func testMkvContainerFails() throws {
         let source = try makeSource(container: "mkv", videoCodec: "h264", audioCodec: "aac")
-        XCTAssertFalse(DeviceMediaCompatibility.canDirectPlayOnDevice(source))
+        XCTAssertFalse(DeviceMediaCompatibility.canDirectPlayOnDevice(source, deviceSupportsDolbyVision: true))
     }
 
     func testUnsupportedVideoCodecFails() throws {
         let source = try makeSource(container: "mp4", videoCodec: "vp9", audioCodec: "aac")
-        XCTAssertFalse(DeviceMediaCompatibility.canDirectPlayOnDevice(source))
+        XCTAssertFalse(DeviceMediaCompatibility.canDirectPlayOnDevice(source, deviceSupportsDolbyVision: true))
     }
 
     func testUnsupportedAudioCodecFails() throws {
         let source = try makeSource(container: "mp4", videoCodec: "h264", audioCodec: "dts")
-        XCTAssertFalse(DeviceMediaCompatibility.canDirectPlayOnDevice(source))
+        XCTAssertFalse(DeviceMediaCompatibility.canDirectPlayOnDevice(source, deviceSupportsDolbyVision: true))
     }
 
     func testCommaListContainerDirectPlays() throws {
         let source = try makeSource(container: "mp4,m4v", videoCodec: "h264", audioCodec: "aac")
-        XCTAssertTrue(DeviceMediaCompatibility.canDirectPlayOnDevice(source))
+        XCTAssertTrue(DeviceMediaCompatibility.canDirectPlayOnDevice(source, deviceSupportsDolbyVision: true))
     }
 
     func testNilContainerFailsClosed() throws {
         let source = try makeSource(container: nil, videoCodec: "h264", audioCodec: "aac")
-        XCTAssertFalse(DeviceMediaCompatibility.canDirectPlayOnDevice(source))
+        XCTAssertFalse(DeviceMediaCompatibility.canDirectPlayOnDevice(source, deviceSupportsDolbyVision: true))
     }
 
     func testNilCodecsFailClosed() throws {
         let source = try makeSource(container: "mp4", videoCodec: nil, audioCodec: nil)
-        XCTAssertFalse(DeviceMediaCompatibility.canDirectPlayOnDevice(source))
+        XCTAssertFalse(DeviceMediaCompatibility.canDirectPlayOnDevice(source, deviceSupportsDolbyVision: true))
     }
 
     func testH265AliasTreatedAsHevc() throws {
         let source = try makeSource(container: "mp4", videoCodec: "h265", audioCodec: "aac")
-        XCTAssertTrue(DeviceMediaCompatibility.canDirectPlayOnDevice(source))
+        XCTAssertTrue(DeviceMediaCompatibility.canDirectPlayOnDevice(source, deviceSupportsDolbyVision: true))
     }
 
     /// Builds a source with an explicit list of video/audio codecs, each
@@ -77,11 +77,13 @@ final class DownloadCompatibilityTests: XCTestCase {
     private func makeMultiStreamSource(
         container: String?,
         videoCodecs: [String],
-        audioCodecs: [String]
+        audioCodecs: [String],
+        videoRangeType: String? = nil
     ) throws -> MediaSourceInfo {
         var streams: [String] = []
+        let rangeField = videoRangeType.map { ", \"VideoRangeType\": \"\($0)\"" } ?? ""
         for codec in videoCodecs {
-            streams.append("{ \"Type\": \"Video\", \"Codec\": \"\(codec)\" }")
+            streams.append("{ \"Type\": \"Video\", \"Codec\": \"\(codec)\"\(rangeField) }")
         }
         for codec in audioCodecs {
             streams.append("{ \"Type\": \"Audio\", \"Codec\": \"\(codec)\" }")
@@ -101,26 +103,70 @@ final class DownloadCompatibilityTests: XCTestCase {
     func testMultiAudioWithCompatibleTrackDirectPlays() throws {
         let source = try makeMultiStreamSource(
             container: "mp4", videoCodecs: ["h264"], audioCodecs: ["truehd", "ac3"])
-        XCTAssertTrue(DeviceMediaCompatibility.canDirectPlayOnDevice(source))
+        XCTAssertTrue(DeviceMediaCompatibility.canDirectPlayOnDevice(source, deviceSupportsDolbyVision: true))
     }
 
     // Fix 1: no audio track is compatible → fail closed.
     func testMultiAudioAllIncompatibleFails() throws {
         let source = try makeMultiStreamSource(
             container: "mp4", videoCodecs: ["h264"], audioCodecs: ["truehd", "dts"])
-        XCTAssertFalse(DeviceMediaCompatibility.canDirectPlayOnDevice(source))
+        XCTAssertFalse(DeviceMediaCompatibility.canDirectPlayOnDevice(source, deviceSupportsDolbyVision: true))
     }
 
     // Fix 1 (defensive): at least one compatible video stream is enough.
     func testMultiVideoWithCompatibleTrackDirectPlays() throws {
         let source = try makeMultiStreamSource(
             container: "mp4", videoCodecs: ["mpeg2video", "h264"], audioCodecs: ["aac"])
-        XCTAssertTrue(DeviceMediaCompatibility.canDirectPlayOnDevice(source))
+        XCTAssertTrue(DeviceMediaCompatibility.canDirectPlayOnDevice(source, deviceSupportsDolbyVision: true))
     }
 
     // Fix 2: a mixed container list must be fully compatible.
     func testMixedContainerFailsClosed() throws {
         let source = try makeSource(container: "mkv,mp4", videoCodec: "h264", audioCodec: "aac")
-        XCTAssertFalse(DeviceMediaCompatibility.canDirectPlayOnDevice(source))
+        XCTAssertFalse(DeviceMediaCompatibility.canDirectPlayOnDevice(source, deviceSupportsDolbyVision: true))
+    }
+
+    // Fix 3: single-layer Dolby Vision P5 is hidden on a non-DV device.
+    func testDolbyVisionProfile5FailsOnNonDVDevice() throws {
+        let source = try makeMultiStreamSource(
+            container: "mp4", videoCodecs: ["hevc"], audioCodecs: ["aac"], videoRangeType: "DOVI")
+        XCTAssertFalse(DeviceMediaCompatibility.canDirectPlayOnDevice(source, deviceSupportsDolbyVision: false))
+    }
+
+    // Fix 3: single-layer Dolby Vision P5 direct-plays on a DV-capable device.
+    func testDolbyVisionProfile5DirectPlaysOnDVDevice() throws {
+        let source = try makeMultiStreamSource(
+            container: "mp4", videoCodecs: ["hevc"], audioCodecs: ["aac"], videoRangeType: "DOVI")
+        XCTAssertTrue(DeviceMediaCompatibility.canDirectPlayOnDevice(source, deviceSupportsDolbyVision: true))
+    }
+
+    // Fix 3: cross-compatible DV (DOVIWithHDR10) degrades to HDR10 → not gated.
+    func testDolbyVisionWithHDR10DirectPlaysOnNonDVDevice() throws {
+        let source = try makeMultiStreamSource(
+            container: "mp4", videoCodecs: ["hevc"], audioCodecs: ["aac"], videoRangeType: "DOVIWithHDR10")
+        XCTAssertTrue(DeviceMediaCompatibility.canDirectPlayOnDevice(source, deviceSupportsDolbyVision: false))
+    }
+
+    // Fix 3: plain HDR10 is never gated.
+    func testHDR10DirectPlaysOnNonDVDevice() throws {
+        let source = try makeMultiStreamSource(
+            container: "mp4", videoCodecs: ["hevc"], audioCodecs: ["aac"], videoRangeType: "HDR10")
+        XCTAssertTrue(DeviceMediaCompatibility.canDirectPlayOnDevice(source, deviceSupportsDolbyVision: false))
+    }
+
+    // Fix 3: a nil VideoRangeType is not gated (unchanged legacy behavior).
+    func testNilVideoRangeTypeNotGatedOnNonDVDevice() throws {
+        let source = try makeMultiStreamSource(
+            container: "mp4", videoCodecs: ["hevc"], audioCodecs: ["aac"], videoRangeType: nil)
+        XCTAssertTrue(DeviceMediaCompatibility.canDirectPlayOnDevice(source, deviceSupportsDolbyVision: false))
+    }
+
+    // Fix 3: per the rule, a bare "DOVI" range on the sole video stream gates it
+    // even for h264 (h264 can't carry DV P5 in practice, but we assert the rule
+    // as written — the gate keys off VideoRangeType, not the codec).
+    func testH264WithDolbyVisionRangeFailsOnNonDVDevice() throws {
+        let source = try makeMultiStreamSource(
+            container: "mp4", videoCodecs: ["h264"], audioCodecs: ["aac"], videoRangeType: "DOVI")
+        XCTAssertFalse(DeviceMediaCompatibility.canDirectPlayOnDevice(source, deviceSupportsDolbyVision: false))
     }
 }

--- a/SashimiTests/PlaybackSelectionTests.swift
+++ b/SashimiTests/PlaybackSelectionTests.swift
@@ -22,7 +22,8 @@ final class PlaybackSelectionTests: XCTestCase {
             channels: nil,
             index: index,
             isDefault: isDefault,
-            isExternal: isExternal
+            isExternal: isExternal,
+            videoRangeType: nil
         )
     }
 

--- a/Shared/Models/JellyfinModels.swift
+++ b/Shared/Models/JellyfinModels.swift
@@ -277,6 +277,7 @@ struct MediaStream: Codable {
     let index: Int?
     let isDefault: Bool?
     let isExternal: Bool?
+    let videoRangeType: String?
 
     enum CodingKeys: String, CodingKey {
         case type = "Type"
@@ -290,6 +291,7 @@ struct MediaStream: Codable {
         case index = "Index"
         case isDefault = "IsDefault"
         case isExternal = "IsExternal"
+        case videoRangeType = "VideoRangeType"
     }
 }
 

--- a/Shared/Services/DeviceMediaCompatibility.swift
+++ b/Shared/Services/DeviceMediaCompatibility.swift
@@ -1,3 +1,4 @@
+import AVFoundation
 import Foundation
 
 /// Determines whether a raw media source will direct-play on this device's
@@ -26,6 +27,23 @@ enum DeviceMediaCompatibility {
         }
     }
 
+    /// Whether this device (and its currently attached display) can render
+    /// Dolby Vision. Reflects live device/display capability at call time.
+    static var deviceSupportsDolbyVision: Bool {
+        AVPlayer.availableHDRModes.contains(.dolbyVision)
+    }
+
+    /// True when the stream is single-layer Dolby Vision with NO cross-compatible
+    /// fallback — Jellyfin reports `VideoRangeType == "DOVI"` (Profile 5). Only
+    /// this bare "DOVI" value is gated: the cross-compatible variants
+    /// (`DOVIWithHDR10` / `DOVIWithHLG` / `DOVIWithSDR`) degrade gracefully to
+    /// HDR10/HLG/SDR on non-DV devices and therefore MUST NOT be gated. All
+    /// non-DV values (sdr/hdr10/hlg) and nil also pass.
+    private static func isDolbyVisionWithoutFallback(_ rangeType: String?) -> Bool {
+        guard let rangeType else { return false }
+        return rangeType.lowercased().trimmingCharacters(in: .whitespaces) == "dovi"
+    }
+
     /// True only when the raw source file will direct-play on iOS/tvOS
     /// AVPlayer: its container must be compatible AND at least one video stream
     /// AND at least one audio stream must use an allowlisted codec. Fails closed
@@ -40,7 +58,16 @@ enum DeviceMediaCompatibility {
     /// streams — e.g. a TrueHD primary track plus an AC3 compatibility track on
     /// a Blu-ray rip — we require only that AT LEAST ONE stream of each type is
     /// playable; AVPlayer can select a compatible track at playback time.
-    static func canDirectPlayOnDevice(_ source: MediaSourceInfo) -> Bool {
+    ///
+    /// A single-layer Dolby Vision Profile 5 video stream (VideoRangeType
+    /// "DOVI", no HDR10/HLG/SDR fallback) is treated as NOT compatible on a
+    /// device that lacks Dolby Vision, because AVPlayer renders it with wrong
+    /// colors. `deviceSupportsDolbyVision` defaults to the live device state so
+    /// production callers are unchanged; tests inject a deterministic value.
+    static func canDirectPlayOnDevice(
+        _ source: MediaSourceInfo,
+        deviceSupportsDolbyVision: Bool = DeviceMediaCompatibility.deviceSupportsDolbyVision
+    ) -> Bool {
         guard let rawContainer = source.container, !rawContainer.isEmpty else { return false }
         let containers = rawContainer
             .lowercased()
@@ -56,7 +83,12 @@ enum DeviceMediaCompatibility {
             .filter { $0.type == "Video" }
             .contains { stream in
                 guard let codec = stream.codec, !codec.isEmpty else { return false }
-                return directPlayVideoCodecs.contains(canonicalCodec(codec))
+                guard directPlayVideoCodecs.contains(canonicalCodec(codec)) else { return false }
+                // Gate single-layer DV (Profile 5) on non-DV devices only.
+                if isDolbyVisionWithoutFallback(stream.videoRangeType), !deviceSupportsDolbyVision {
+                    return false
+                }
+                return true
             }
         guard hasCompatibleVideo else { return false }
 


### PR DESCRIPTION
Fixes #187 · follow-up to #185/#186

## Problem
`canDirectPlayOnDevice` accepted any `hevc` stream, so a **Dolby Vision Profile 5** file (single-layer DV, no fallback — Jellyfin `VideoRangeType == "DOVI"`) was offered as "Original". Downloaded and played on a device/display that can't render DV, it shows wrong colors (green/pink).

## Fix
- Decode `MediaStream.videoRangeType`.
- Detect device DV capability via `AVPlayer.availableHDRModes.contains(.dolbyVision)` (available on iOS/tvOS; reflects the current device/display).
- A video stream is treated as incompatible when its range type is the bare `"DOVI"` (Profile 5, no fallback) **and** the device lacks DV support. Cross-compatible DV (`DOVIWithHDR10/HLG/SDR/EL`), non-DV ranges (SDR/HDR10/HLG), and `nil` are **not** gated — so Profile 8.1/7 and normal SDR/HDR content are unaffected and nothing gets over-hidden.
- Compatibility function stays pure/testable: DV capability is an injected parameter defaulting to the live device read.

## Tests
6 new cases (DV-on vs DV-off, cross-compatible not gated, HDR10/nil not gated) — **19 total, 0 failures**. iOS + tvOS build clean; SwiftLint strict clean on authored files.