### PR TITLE
Enforce 'Original' compatibility on all download paths (fixes season/bulk menu)

### DIFF
--- a/SashimiMobile/Downloads/Models/DownloadModels.swift
+++ b/SashimiMobile/Downloads/Models/DownloadModels.swift
@@ -37,6 +37,16 @@ enum DownloadQuality: String, Codable, CaseIterable, Identifiable {
         case .low: return 4_000_000
         }
     }
+
+    /// Resolves the quality that should actually be downloaded given whether the
+    /// raw source can direct-play on this device. `.original` is only honored
+    /// when the source is device-compatible; otherwise it degrades to `.high` so
+    /// we never persist an unplayable Original file. All transcoded tiers pass
+    /// through unchanged (the `compatible` flag is irrelevant for them).
+    static func effectiveQuality(requested: DownloadQuality, sourceIsCompatible: Bool) -> DownloadQuality {
+        guard requested == .original else { return requested }
+        return sourceIsCompatible ? .original : .high
+    }
 }
 
 // MARK: - Download Status

--- a/SashimiMobile/Downloads/Services/DownloadManager.swift
+++ b/SashimiMobile/Downloads/Services/DownloadManager.swift
@@ -215,6 +215,18 @@ final class DownloadManager: NSObject, ObservableObject {
         let effective = DownloadQuality.effectiveQuality(requested: requested, sourceIsCompatible: compatible)
         if effective != requested {
             persistence.updateQuality(itemId: itemId, quality: effective)
+            // Also reflect the downgrade in the UI's source of truth (mainContext).
+            // The persistence write above goes to a private queue context, which the
+            // @Query-backed UI doesn't observe — without this, a completed download
+            // can keep showing "Original" even though the file is actually High.
+            if let context = mainContext {
+                let predicate = #Predicate<DownloadedItem> { $0.itemId == itemId }
+                let descriptor = FetchDescriptor<DownloadedItem>(predicate: predicate)
+                if let record = try? context.fetch(descriptor).first {
+                    record.downloadQuality = effective
+                    try? context.save()
+                }
+            }
         }
         return effective
     }

--- a/SashimiMobile/Downloads/Services/DownloadManager.swift
+++ b/SashimiMobile/Downloads/Services/DownloadManager.swift
@@ -181,6 +181,53 @@ final class DownloadManager: NSObject, ObservableObject {
             return
         }
 
+        // Mark this item as the current download synchronously so re-entrant
+        // enqueues don't kick off a second concurrent download while we await
+        // the (only-for-.original) compatibility check below.
+        currentDownloadItemId = itemId
+
+        // Resolve the effective quality — for `.original`, verify the raw source
+        // will direct-play on this device; if not (or on any error) downgrade to
+        // `.high` and persist the downgrade — then start the actual download.
+        Task { [weak self] in
+            guard let self else { return }
+            let effectiveQuality = await self.resolveEffectiveQuality(itemId: itemId, requested: quality)
+            self.beginDownload(item: item, quality: effectiveQuality)
+        }
+    }
+
+    /// For `.original`, fetches playback info and downgrades to `.high` unless
+    /// the source can direct-play (fails closed on missing source / error).
+    /// Non-`.original` qualities skip the network call entirely. Persists the
+    /// downgrade so the DB/UI reflect what was actually downloaded.
+    private func resolveEffectiveQuality(itemId: String, requested: DownloadQuality) async -> DownloadQuality {
+        guard requested == .original else { return requested }
+
+        let compatible: Bool
+        do {
+            let info = try await JellyfinClient.shared.getPlaybackInfo(itemId: itemId)
+            compatible = info.mediaSources?.first
+                .map { DeviceMediaCompatibility.canDirectPlayOnDevice($0) } ?? false
+        } catch {
+            compatible = false // fail closed
+        }
+
+        let effective = DownloadQuality.effectiveQuality(requested: requested, sourceIsCompatible: compatible)
+        if effective != requested {
+            persistence.updateQuality(itemId: itemId, quality: effective)
+        }
+        return effective
+    }
+
+    /// Builds the download URL with the (already-resolved) effective quality and
+    /// starts the background download task.
+    private func beginDownload(item: BaseItemDto, quality: DownloadQuality) {
+        let itemId = item.id
+
+        // The item may have been cancelled while the compatibility check was in
+        // flight; bail if it's no longer the current download.
+        guard currentDownloadItemId == itemId else { return }
+
         // URLRequest (not bare URL) so the token travels in a header and the
         // background task keeps it across app relaunches.
         guard let downloadURL = DownloadURLBuilder.downloadURL(itemId: itemId, quality: quality),
@@ -205,7 +252,8 @@ final class DownloadManager: NSObject, ObservableObject {
         map[taskKey(task.taskIdentifier)] = itemId
         taskIdMap = map
 
-        currentDownloadItemId = itemId
+        // currentDownloadItemId was already set synchronously in startNextDownload
+        // so re-entrant enqueues couldn't start a second concurrent download.
         task.resume()
         persistence.updateStatus(itemId: itemId, status: .downloading)
         preparingItems.insert(itemId)

--- a/SashimiMobile/Downloads/Services/DownloadPersistence.swift
+++ b/SashimiMobile/Downloads/Services/DownloadPersistence.swift
@@ -34,6 +34,17 @@ final class DownloadPersistence {
         }
     }
 
+    func updateQuality(itemId: String, quality: DownloadQuality) {
+        queue.async { [weak self] in
+            guard let context = self?.modelContext else { return }
+            let predicate = #Predicate<DownloadedItem> { $0.itemId == itemId }
+            let descriptor = FetchDescriptor<DownloadedItem>(predicate: predicate)
+            guard let record = try? context.fetch(descriptor).first else { return }
+            record.downloadQuality = quality
+            try? context.save()
+        }
+    }
+
     func updateProgress(itemId: String, progress: Double, downloadedBytes: Int64, totalBytes: Int64) {
         queue.async { [weak self] in
             guard let context = self?.modelContext else { return }

--- a/SashimiMobile/Views/Detail/MobileDetailView.swift
+++ b/SashimiMobile/Views/Detail/MobileDetailView.swift
@@ -216,6 +216,7 @@ struct MobileDetailView: View {
             }
         }
         .onChange(of: episodes.first?.id) { _, _ in
+            seasonOriginalAllowed = false
             Task { await refreshSeasonOriginalAllowed() }
         }
     }

--- a/SashimiMobile/Views/Detail/MobileDetailView.swift
+++ b/SashimiMobile/Views/Detail/MobileDetailView.swift
@@ -26,6 +26,9 @@ struct MobileDetailView: View {
     @State private var showingNextNAlert = false
     @State private var showingNoUnwatchedAlert = false
     @State private var nextNInput = ""
+    // Fail-closed: hide Original in the season/bulk menu unless the representative
+    // first episode is confirmed device-compatible.
+    @State private var seasonOriginalAllowed = false
     @ObservedObject private var downloadManager = DownloadManager.shared
 
     private var isSeries: Bool { item.type == .series }
@@ -78,6 +81,12 @@ struct MobileDetailView: View {
         case .nextN(let count):
             return Array(episodes.filter { !($0.userData?.played ?? false) }.prefix(count))
         }
+    }
+
+    // Drops .original from the season/bulk menu unless the representative episode
+    // is confirmed device-compatible (mirrors DownloadButton.availableQualities).
+    private var availableSeasonQualities: [DownloadQuality] {
+        DownloadQuality.allCases.filter { $0 != .original || seasonOriginalAllowed }
     }
 
     var body: some View {
@@ -205,6 +214,26 @@ struct MobileDetailView: View {
                     await refreshPlaybackState()
                 }
             }
+        }
+        .onChange(of: episodes.first?.id) { _, _ in
+            Task { await refreshSeasonOriginalAllowed() }
+        }
+    }
+
+    /// Determines whether the season/bulk menu should offer Original, using the
+    /// first (representative) episode as a proxy — series are uniformly encoded.
+    /// Fails closed: any missing episode / source / error leaves it false.
+    private func refreshSeasonOriginalAllowed() async {
+        guard NetworkMonitor.shared.isConnected, let first = episodes.first else {
+            seasonOriginalAllowed = false
+            return
+        }
+        do {
+            let info = try await JellyfinClient.shared.getPlaybackInfo(itemId: first.id)
+            seasonOriginalAllowed = info.mediaSources?.first
+                .map { DeviceMediaCompatibility.canDirectPlayOnDevice($0) } ?? false
+        } catch {
+            seasonOriginalAllowed = false
         }
     }
 
@@ -562,7 +591,7 @@ struct MobileDetailView: View {
                 .buttonStyle(.bordered)
                 .tint(.white)
                 .confirmationDialog("Select Quality", isPresented: $showingDownloadQuality) {
-                    ForEach(DownloadQuality.allCases) { quality in
+                    ForEach(availableSeasonQualities) { quality in
                         Button("\(quality.displayName) — \(quality.subtitle)") {
                             DownloadManager.shared.downloadSeason(
                                 episodes: episodesForDownload, quality: quality

--- a/SashimiMobile/Views/Phone/PhoneDetailView.swift
+++ b/SashimiMobile/Views/Phone/PhoneDetailView.swift
@@ -30,6 +30,9 @@ struct PhoneDetailView: View {
     @State private var showingNoUnwatchedAlert = false
     @State private var nextNInput = ""
     @State private var overviewExpanded = false
+    // Fail-closed: hide Original in the season/bulk menu unless the representative
+    // first episode is confirmed device-compatible.
+    @State private var seasonOriginalAllowed = false
     @ObservedObject private var downloadManager = DownloadManager.shared
 
     // MARK: - Computed Properties
@@ -69,6 +72,12 @@ struct PhoneDetailView: View {
         case .nextN(let count):
             return Array(episodes.filter { !($0.userData?.played ?? false) }.prefix(count))
         }
+    }
+
+    // Drops .original from the season/bulk menu unless the representative episode
+    // is confirmed device-compatible (mirrors DownloadButton.availableQualities).
+    private var availableSeasonQualities: [DownloadQuality] {
+        DownloadQuality.allCases.filter { $0 != .original || seasonOriginalAllowed }
     }
 
     // MARK: - Body
@@ -125,6 +134,26 @@ struct PhoneDetailView: View {
                     await refreshPlaybackState()
                 }
             }
+        }
+        .onChange(of: episodes.first?.id) { _, _ in
+            Task { await refreshSeasonOriginalAllowed() }
+        }
+    }
+
+    /// Determines whether the season/bulk menu should offer Original, using the
+    /// first (representative) episode as a proxy — series are uniformly encoded.
+    /// Fails closed: any missing episode / source / error leaves it false.
+    private func refreshSeasonOriginalAllowed() async {
+        guard NetworkMonitor.shared.isConnected, let first = episodes.first else {
+            seasonOriginalAllowed = false
+            return
+        }
+        do {
+            let info = try await JellyfinClient.shared.getPlaybackInfo(itemId: first.id)
+            seasonOriginalAllowed = info.mediaSources?.first
+                .map { DeviceMediaCompatibility.canDirectPlayOnDevice($0) } ?? false
+        } catch {
+            seasonOriginalAllowed = false
         }
     }
 
@@ -396,7 +425,7 @@ struct PhoneDetailView: View {
                 .buttonStyle(.bordered)
                 .tint(.white)
                 .confirmationDialog("Select Quality", isPresented: $showingDownloadQuality) {
-                    ForEach(DownloadQuality.allCases) { quality in
+                    ForEach(availableSeasonQualities) { quality in
                         Button("\(quality.displayName) \u{2014} \(quality.subtitle)") {
                             DownloadManager.shared.downloadSeason(
                                 episodes: episodesForDownload, quality: quality

--- a/SashimiMobile/Views/Phone/PhoneDetailView.swift
+++ b/SashimiMobile/Views/Phone/PhoneDetailView.swift
@@ -136,6 +136,7 @@ struct PhoneDetailView: View {
             }
         }
         .onChange(of: episodes.first?.id) { _, _ in
+            seasonOriginalAllowed = false
             Task { await refreshSeasonOriginalAllowed() }
         }
     }


### PR DESCRIPTION
Fixes #189 · follow-up to #186/#188

## Problem
The #186 gating only covered the per-item `DownloadButton`. The **season/bulk download** menu (`downloadSeason`) is a separate, ungated picker — so on iPad (TV series) "Original" was still offered, and any non-button path could enqueue an unplayable Original.

## Fix
**1. Enforce at the download layer (entry-point-agnostic guarantee).** `DownloadManager` now resolves an *effective quality* per queued item: for `.original`, it fetches `getPlaybackInfo` and, if the source won't direct-play (`DeviceMediaCompatibility.canDirectPlayOnDevice`) or the check fails, downgrades that item to `.high` before building the URL — and persists the downgrade to both the persistence context and the main context so the UI reflects the real quality. Transcoded tiers are untouched (no extra network call). Single-flight download guarantee preserved (verified: `currentDownloadItemId` set synchronously, cancel-during-fetch handled, queue advances on all terminal paths).

**2. Hide `.original` in the season menu.** Both detail views gate the season "Select Quality" list on the representative first episode's compatibility (`seasonOriginalAllowed`, fail-closed, reset synchronously on season change). Series are uniformly encoded; the per-item layer (1) covers any mixed-codec edge case.

## Result
Original is only offered/produced when the content will actually play — on every path (single item, whole season, N-unwatched, custom, retry).

## Verify
iOS + tvOS build clean; `DownloadCompatibilityTests` (19) pass; SwiftLint strict clean.