### PR TITLE
feat: show playback delivery method in player overlay

### DIFF
--- a/Sashimi/Views/Player/TVPlayerViewController.swift
+++ b/Sashimi/Views/Player/TVPlayerViewController.swift
@@ -439,6 +439,42 @@ struct PlayerContentOverlay: View {
         .onReceive(clockTimer) { _ in
             clockTime = Date()
         }
+        // Refresh the delivery chip from the server whenever the overlay opens
+        .task(id: controlsVisible) {
+            if controlsVisible {
+                await viewModel.refreshStreamInfo()
+            }
+        }
+    }
+
+    // MARK: - Stream info chip
+
+    private func streamInfoChip(_ info: PlayerViewModel.StreamInfo) -> some View {
+        HStack(spacing: 8) {
+            Circle()
+                .fill(chipColor(for: info.method))
+                .frame(width: 10, height: 10)
+            Text(chipText(for: info))
+        }
+    }
+
+    private func chipColor(for method: PlayerViewModel.StreamInfo.Method) -> Color {
+        switch method {
+        case .directPlay: return .green
+        case .directStream: return .yellow
+        case .transcode: return .orange
+        }
+    }
+
+    private func chipText(for info: PlayerViewModel.StreamInfo) -> String {
+        var text = info.label
+        if let detail = info.detail {
+            text += " → \(detail)"
+        }
+        if let reason = info.reason {
+            text += " (\(reason))"
+        }
+        return text
     }
 
     // MARK: - Top Info Bar
@@ -499,7 +535,7 @@ struct PlayerContentOverlay: View {
                         .lineLimit(1)
                 }
 
-                // Release date, quality, and finish time
+                // Release date, quality, finish time, and delivery method
                 HStack(spacing: 8) {
                     if let dateText = formattedReleaseDate {
                         Text(dateText)
@@ -517,6 +553,11 @@ struct PlayerContentOverlay: View {
                                 .foregroundStyle(.white.opacity(0.4))
                         }
                         Text(finishText)
+                    }
+                    if let info = viewModel.streamInfo {
+                        Text("·")
+                            .foregroundStyle(.white.opacity(0.4))
+                        streamInfoChip(info)
                     }
                 }
                 .font(.system(size: 24, weight: .medium))

--- a/Shared/Models/JellyfinModels.swift
+++ b/Shared/Models/JellyfinModels.swift
@@ -265,6 +265,66 @@ struct MediaSourceInfo: Codable {
     }
 }
 
+// MARK: - Session info (live playback truth from the server)
+
+/// Subset of /Sessions used by the player's stream-info chip. The server is
+/// the only source that can distinguish a full transcode from a remux with
+/// the video stream copied (IsVideoDirect).
+struct SessionInfoDto: Codable {
+    let deviceId: String?
+    let playState: SessionPlayState?
+    let transcodingInfo: SessionTranscodingInfo?
+    let nowPlayingItemId: NowPlayingItemRef?
+
+    enum CodingKeys: String, CodingKey {
+        case deviceId = "DeviceId"
+        case playState = "PlayState"
+        case transcodingInfo = "TranscodingInfo"
+        case nowPlayingItemId = "NowPlayingItem"
+    }
+}
+
+/// Minimal reference to the session's playing item (id only — avoids
+/// re-decoding a full BaseItemDto we don't need).
+struct NowPlayingItemRef: Codable {
+    let id: String?
+
+    enum CodingKeys: String, CodingKey {
+        case id = "Id"
+    }
+}
+
+struct SessionPlayState: Codable {
+    /// "DirectPlay" | "DirectStream" | "Transcode"
+    let playMethod: String?
+
+    enum CodingKeys: String, CodingKey {
+        case playMethod = "PlayMethod"
+    }
+}
+
+struct SessionTranscodingInfo: Codable {
+    let videoCodec: String?
+    let audioCodec: String?
+    let bitrate: Int?
+    let width: Int?
+    let height: Int?
+    let isVideoDirect: Bool?
+    let isAudioDirect: Bool?
+    let transcodeReasons: [String]?
+
+    enum CodingKeys: String, CodingKey {
+        case videoCodec = "VideoCodec"
+        case audioCodec = "AudioCodec"
+        case bitrate = "Bitrate"
+        case width = "Width"
+        case height = "Height"
+        case isVideoDirect = "IsVideoDirect"
+        case isAudioDirect = "IsAudioDirect"
+        case transcodeReasons = "TranscodeReasons"
+    }
+}
+
 struct MediaStream: Codable {
     let type: String?
     let codec: String?

--- a/Shared/Services/JellyfinClient.swift
+++ b/Shared/Services/JellyfinClient.swift
@@ -808,6 +808,18 @@ actor JellyfinClient {
         return components.url
     }
 
+    /// Fetches this device's own session from the server — the authoritative
+    /// view of how playback is actually being delivered (DirectPlay vs a
+    /// remux with video copied vs a full transcode, and why).
+    func getOwnSession() async throws -> SessionInfoDto? {
+        let data = try await request(
+            path: "/Sessions",
+            queryItems: [URLQueryItem(name: "DeviceId", value: deviceId)]
+        )
+        let sessions = try JSONDecoder().decode([SessionInfoDto].self, from: data)
+        return sessions.first(where: { $0.nowPlayingItemId?.id != nil }) ?? sessions.first
+    }
+
     func reportPlaybackStart(itemId: String, positionTicks: Int64 = 0, playSessionId: String? = nil, playMethod: String = "DirectStream") async throws {
         var body: [String: Any] = [
             "ItemId": itemId,

--- a/Shared/ViewModels/PlayerViewModel.swift
+++ b/Shared/ViewModels/PlayerViewModel.swift
@@ -81,6 +81,31 @@ final class PlayerViewModel: ObservableObject {
     @Published var resumePositionTicks: Int64 = 0
     @Published var selectedQuality: QualityOption = .auto
     @Published var videoResolution: String?
+    @Published var streamInfo: StreamInfo?
+
+    /// How playback is actually being delivered, per the server's session —
+    /// shown as a chip in the player's top info bar when controls are visible.
+    struct StreamInfo: Equatable {
+        enum Method: Equatable {
+            case directPlay
+            case directStream   // container remux / audio conversion; video copied
+            case transcode
+        }
+
+        let method: Method
+        /// Transcode target, e.g. "1080p H264 8 Mbps" (nil unless transcoding)
+        let detail: String?
+        /// Human-readable primary transcode reason, e.g. "bitrate limit"
+        let reason: String?
+
+        var label: String {
+            switch method {
+            case .directPlay: return "Direct Play"
+            case .directStream: return "Direct Stream"
+            case .transcode: return "Transcode"
+            }
+        }
+    }
 
     // Track when playback actually started (for quick-exit protection)
     private var playbackStartDate: Date?
@@ -126,6 +151,67 @@ final class PlayerViewModel: ObservableObject {
     private var endObserver: NSObjectProtocol?
     private let client = JellyfinClient.shared
     private let playbackSettings = PlaybackSettings.shared
+
+    /// Refreshes the stream-info chip from the server's own session view.
+    /// Called when the player overlay becomes visible; cheap single GET.
+    func refreshStreamInfo() async {
+        guard !isOfflinePlayback else {
+            streamInfo = StreamInfo(method: .directPlay, detail: nil, reason: nil)
+            return
+        }
+        guard let session = try? await client.getOwnSession(),
+              session.nowPlayingItemId?.id != nil else { return }
+
+        let method = session.playState?.playMethod
+        let info = session.transcodingInfo
+
+        if method == "Transcode", let info {
+            if info.isVideoDirect == true {
+                // Container remux / audio conversion — video untouched
+                streamInfo = StreamInfo(method: .directStream, detail: nil, reason: nil)
+            } else {
+                var parts: [String] = []
+                if let width = info.width, let height = info.height {
+                    parts.append(Self.resolutionLabel(width: width, height: height))
+                }
+                if let codec = info.videoCodec { parts.append(codec.uppercased()) }
+                if let bitrate = info.bitrate, bitrate > 0 {
+                    parts.append("\(Int(round(Double(bitrate) / 1_000_000))) Mbps")
+                }
+                let reason = info.transcodeReasons?.first.map(Self.humanTranscodeReason)
+                streamInfo = StreamInfo(
+                    method: .transcode,
+                    detail: parts.isEmpty ? nil : parts.joined(separator: " "),
+                    reason: reason
+                )
+            }
+        } else if method == "DirectStream" {
+            streamInfo = StreamInfo(method: .directStream, detail: nil, reason: nil)
+        } else if method != nil {
+            streamInfo = StreamInfo(method: .directPlay, detail: nil, reason: nil)
+        }
+    }
+
+    private static func resolutionLabel(width: Int, height: Int) -> String {
+        if width >= 3200 || height >= 2160 { return "4K" }
+        if width >= 1800 || height >= 1080 { return "1080p" }
+        if width >= 1200 || height >= 720 { return "720p" }
+        return "\(height)p"
+    }
+
+    private static func humanTranscodeReason(_ reason: String) -> String {
+        switch reason {
+        case "ContainerNotSupported": return "container"
+        case "ContainerBitrateExceedsLimit": return "bitrate limit"
+        case "VideoCodecNotSupported": return "video codec"
+        case "AudioCodecNotSupported": return "audio codec"
+        case "SubtitleCodecNotSupported": return "subtitles"
+        case "VideoResolutionNotSupported": return "resolution"
+        case "AudioChannelsNotSupported": return "audio channels"
+        case "UnknownVideoStreamInfo", "UnknownAudioStreamInfo": return "stream info"
+        default: return reason
+        }
+    }
 
     func loadMedia(item: BaseItemDto, startFromBeginning: Bool = false, localFileURL: URL? = nil) async {
         // Tear down everything tied to the previous player first — auto-play
@@ -430,6 +516,7 @@ final class PlayerViewModel: ObservableObject {
         playSessionId = playbackInfo.playSessionId
         currentMediaSource = mediaSource
         videoResolution = mediaSource.videoResolution
+        streamInfo = nil   // stale for the new session; refreshed when the overlay opens
 
         let resolvedURL: URL?
         if let transcodingPath = mediaSource.transcodingUrl, !transcodingPath.isEmpty {


### PR DESCRIPTION
## What
Chip in the player's top info bar (appears with the transport overlay):

- 🟢 **Direct Play** — untouched file
- 🟡 **Direct Stream** — container/audio repackaged, video copied bit-for-bit
- 🟠 **Transcode → 1080p H264 8 Mbps (bitrate limit)** — target + why

## How
Server truth via `GET /Sessions?DeviceId=…` (`PlayState.PlayMethod` + `TranscodingInfo.IsVideoDirect`/reasons) — the only source that can distinguish a full transcode from a harmless remux. One request per overlay-open (`.task(id: controlsVisible)`), cleared on media change, offline playback short-circuits to Direct Play.

## Why
A server-side remote-bitrate cap silently transcoded LAN streams to 4 Mbps for weeks. This chip surfaces delivery truth at a glance.

Fixes #193

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XzUNvRCXML3DJe98KBCGkN