### PR TITLE
Show unplayed badge for a single new episode

### DIFF
--- a/Sashimi/Views/Home/HomeView.swift
+++ b/Sashimi/Views/Home/HomeView.swift
@@ -593,7 +593,7 @@ struct RecentlyAddedLibraryRow: View {
                                 libraryType: library.collectionType,
                                 libraryName: library.name,
                                 isCircular: isYouTubeLibrary,
-                                badgeCount: (unplayedCount ?? 0) > 1 ? unplayedCount : nil
+                                badgeCount: (unplayedCount ?? 0) >= 1 ? unplayedCount : nil
                             ) {
                                 onSelect(item)
                             }


### PR DESCRIPTION
Changes the Recently Added badge threshold from >1 to >=1 so a series with exactly one new unwatched episode shows "1 new" (fixes #195). Matches the just-shipped Roku behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XzUNvRCXML3DJe98KBCGkN