### PR TITLE
Stream chip: never label a Transcode session Direct Play

### DIFF
--- a/Shared/ViewModels/PlayerViewModel.swift
+++ b/Shared/ViewModels/PlayerViewModel.swift
@@ -165,7 +165,15 @@ final class PlayerViewModel: ObservableObject {
         let method = session.playState?.playMethod
         let info = session.transcodingInfo
 
-        if method == "Transcode", let info {
+        if method == "Transcode", info == nil {
+            // Transcode session whose ffmpeg already finished (or hasn't
+            // registered yet): Jellyfin drops TranscodingInfo but PlayMethod
+            // stays "Transcode". Keep the last known chip if we have one —
+            // never fall through to "Direct Play" for a transcode session.
+            if streamInfo == nil {
+                streamInfo = StreamInfo(method: .transcode, detail: nil, reason: nil)
+            }
+        } else if method == "Transcode", let info {
             if info.isVideoDirect == true {
                 // Container remux / audio conversion — video untouched
                 streamInfo = StreamInfo(method: .directStream, detail: nil, reason: nil)


### PR DESCRIPTION
Fixes #200. Server session truth showed PlayMethod=Transcode (audio remux, videoDirect=true) while the overlay chip said "Direct Play" — the chip logic required TranscodingInfo, which Jellyfin drops once ffmpeg completes. Now a Transcode session keeps the last known chip (or shows Transcode), never Direct Play.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XzUNvRCXML3DJe98KBCGkN