### PR TITLE
HLS profile: HEVC + EAC3 passthrough

### DIFF
--- a/Shared/Services/JellyfinClient.swift
+++ b/Shared/Services/JellyfinClient.swift
@@ -668,8 +668,11 @@ actor JellyfinClient {
                 [
                     "Container": "ts",
                     "Type": "Video",
-                    "VideoCodec": "h264",
-                    "AudioCodec": "aac,ac3",
+                    // tvOS plays HEVC and EAC3 in HLS natively — declaring
+                    // them lets mkv remuxes stream-copy both tracks instead
+                    // of re-encoding video / downmixing EAC3 5.1 to AAC.
+                    "VideoCodec": "h264,hevc",
+                    "AudioCodec": "aac,ac3,eac3",
                     "Protocol": "hls",
                     "Context": "Streaming",
                     "MaxAudioChannels": "6",


### PR DESCRIPTION
Fixes #202. Adds hevc to VideoCodec and eac3 to AudioCodec in the HLS transcoding profile so mkv remuxes copy both streams — no more silent EAC3→AAC downmix or HEVC re-encodes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XzUNvRCXML3DJe98KBCGkN