### PR TITLE
iOS auth: center 'Use Different Server' button label

### DIFF
--- a/SashimiMobile/Views/Auth/MobileAuthView.swift
+++ b/SashimiMobile/Views/Auth/MobileAuthView.swift
@@ -87,10 +87,13 @@ struct MobileAuthView: View {
                 }
                 .disabled(username.isEmpty || isConnecting)
 
-                Button("Use Different Server") {
+                Button {
                     showLogin = false
                     serverURL = ""
                     normalizedServerURL = nil
+                } label: {
+                    Text("Use Different Server")
+                        .frame(maxWidth: .infinity)
                 }
             }
         }


### PR DESCRIPTION
Fixes #204 (reported by pratik). Centers the label to match Sign In in the same section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XzUNvRCXML3DJe98KBCGkN