### PR TITLE
Mirror active server into legacy keys (restores artwork)

### DIFF
--- a/Shared/Services/SessionManager.swift
+++ b/Shared/Services/SessionManager.swift
@@ -145,6 +145,12 @@ final class SessionManager: ObservableObject {
     }
 
     private func activate(_ server: ServerConfig, token: String) async {
+        // Mirror the active server into the legacy single-server keys:
+        // JellyfinClient's image-URL builders and several views still read
+        // them directly (scrubbing them in migration killed all artwork).
+        UserDefaults.standard.set(server.url.absoluteString, forKey: "serverURL")
+        UserDefaults.standard.set(server.userId, forKey: "userId")
+        UserDefaults.standard.set(server.username, forKey: "userName")
         await JellyfinClient.shared.configure(serverURL: server.url, accessToken: token, userId: server.userId)
         self.serverURL = server.url
         self.currentUser = UserDto(id: server.userId, name: server.username, serverID: nil, primaryImageTag: nil)


### PR DESCRIPTION
Fixes #211 — post-migration, every image URL was built from the scrubbed legacy serverURL key.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XzUNvRCXML3DJe98KBCGkN