### PR TITLE
iOS: remove genre line from TV series detail

### DIFF
--- a/SashimiMobile/Views/Detail/MobileDetailView.swift
+++ b/SashimiMobile/Views/Detail/MobileDetailView.swift
@@ -318,13 +318,6 @@ struct MobileDetailView: View {
             .font(MobileTypography.caption)
             .foregroundStyle(MobileColors.textSecondary)
 
-            // Genres
-            if let genres = item.genres, !genres.isEmpty {
-                Text(([item.officialRating].compactMap { $0 } + genres.prefix(3)).joined(separator: " • "))
-                    .font(MobileTypography.caption)
-                    .foregroundStyle(MobileColors.textSecondary)
-            }
-
             // Action buttons
             seriesActionButtons
         }


### PR DESCRIPTION
Series pages don't need the genre chip line (rating already in the metadata row). Movies keep genres.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XzUNvRCXML3DJe98KBCGkN