### PR TITLE
iOS iPhone: detail parity + working badges

### DIFF
--- a/SashimiMobile/Views/Components/MobileRecentlyAddedRow.swift
+++ b/SashimiMobile/Views/Components/MobileRecentlyAddedRow.swift
@@ -106,7 +106,7 @@ struct MobileRecentlyAddedRow<Destination: View>: View {
             libraryName: libraryName,
             isCircular: isYouTubeLibrary,
             isLandscape: false,
-            badgeCount: (unplayedCount ?? 0) > 1 ? unplayedCount : nil
+            badgeCount: (unplayedCount ?? 0) >= 1 ? unplayedCount : nil
         )
     }
 
@@ -147,7 +147,7 @@ struct MobileRecentlyAddedRow<Destination: View>: View {
         for seriesId in seriesIds {
             do {
                 let series = try await JellyfinClient.shared.getItem(itemId: seriesId)
-                if let unplayedCount = series.userData?.unplayedItemCount, unplayedCount > 0 {
+                if let unplayedCount = series.userData?.unplayedItemCount, unplayedCount >= 1 {
                     counts[seriesId] = unplayedCount
                 }
             } catch {
@@ -264,7 +264,7 @@ struct MobileRecentlyAddedCard: View {
                 }
 
                 // "X new" badge
-                if let count = badgeCount, count > 1 {
+                if let count = badgeCount, count >= 1 {
                     Text("\(count) new")
                         .font(.system(size: 11, weight: .bold))
                         .foregroundStyle(.white)
@@ -364,7 +364,7 @@ struct MobileRecentlyAddedGridView<Destination: View>: View {
             libraryName: libraryName,
             isCircular: isYouTubeLibrary,
             isLandscape: false,
-            badgeCount: (unplayedCount ?? 0) > 1 ? unplayedCount : nil
+            badgeCount: (unplayedCount ?? 0) >= 1 ? unplayedCount : nil
         )
     }
 }

--- a/SashimiMobile/Views/Phone/PhoneDetailView.swift
+++ b/SashimiMobile/Views/Phone/PhoneDetailView.swift
@@ -243,12 +243,51 @@ struct PhoneDetailView: View {
             }
         }
 
+        if isSeries, !isYouTubeSeriesStyle, let logoURL = logoImageURL(for: item.id) {
+            LazyImage(url: logoURL) { state in
+                if let image = state.image {
+                    image.resizable().aspectRatio(contentMode: .fit)
+                } else if state.error != nil {
+                    seriesTitleText
+                }
+            }
+            .frame(maxHeight: 70)
+            .frame(maxWidth: .infinity, alignment: .leading)
+        } else {
+            seriesTitleText
+        }
+    }
+
+    private var seriesTitleText: some View {
         Text(isYouTubeSeriesStyle ? item.name.cleanedYouTubeTitle : item.name)
             .font(.system(size: 22, weight: .bold))
             .foregroundStyle(MobileColors.textPrimary)
             .lineLimit(3)
             .frame(maxWidth: .infinity, alignment: isYouTubeSeriesStyle ? .center : .leading)
             .clipped()
+    }
+
+    private func logoImageURL(for itemId: String) -> URL? {
+        JellyfinClient.shared.imageURL(itemId: itemId, imageType: "Logo", maxWidth: 500)
+    }
+
+    /// Premiere date "November 8, 2024" (tvOS parity)
+    private var premiereDateLongText: String? {
+        guard let raw = item.premiereDate else { return nil }
+        let iso = ISO8601DateFormatter()
+        iso.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        guard let date = iso.date(from: raw) ?? ISO8601DateFormatter().date(from: raw) else { return nil }
+        let fmt = DateFormatter()
+        fmt.dateFormat = "MMMM d, yyyy"
+        return fmt.string(from: date)
+    }
+
+    /// "Ends at 9:41 PM"
+    private var endsAtText: String? {
+        guard let ticks = item.runTimeTicks, ticks > 0 else { return nil }
+        let end = Date().addingTimeInterval(Double(ticks) / 10_000_000)
+        let fmt = DateFormatter(); fmt.timeStyle = .short
+        return "Ends at \(fmt.string(from: end))"
     }
 
     // MARK: - Metadata Row
@@ -264,16 +303,16 @@ struct PhoneDetailView: View {
                 .lineLimit(1)
         }
 
-        // Ratings row
-        ratingsRow
-
-        // Media info badges (non-series)
-        if !isSeries {
-            mediaInfoBadges
+        // Ratings + media chips on a single line
+        HStack(spacing: MobileSpacing.sm) {
+            ratingsRow
+            if !isSeries {
+                mediaInfoBadges
+            }
         }
 
-        // Genres
-        if let genres = item.genres, !genres.isEmpty {
+        // Genres line — movies only (series show rating in the meta line)
+        if !isSeries, let genres = item.genres, !genres.isEmpty {
             Text(genres.prefix(3).joined(separator: " \u{2022} "))
                 .font(MobileTypography.caption)
                 .foregroundStyle(MobileColors.textSecondary)
@@ -283,7 +322,9 @@ struct PhoneDetailView: View {
 
     private var metadataParts: [String] {
         var parts: [String] = []
-        if let year = item.productionYear {
+        if let dateText = premiereDateLongText {
+            parts.append(dateText)
+        } else if let year = item.productionYear {
             parts.append(String(year))
         }
         if isSeries, !seasons.isEmpty {
@@ -294,6 +335,9 @@ struct PhoneDetailView: View {
         }
         if let rating = item.officialRating {
             parts.append(rating)
+        }
+        if let ends = endsAtText {
+            parts.append(ends)
         }
         return parts
     }


### PR DESCRIPTION
Fixes #219. The iPhone uses PhoneDetailView + MobileRecentlyAddedRow, which earlier PRs never touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XzUNvRCXML3DJe98KBCGkN