### PR TITLE
iOS: remove rating from series meta line

### DIFF
--- a/SashimiMobile/Views/Detail/MobileDetailView.swift
+++ b/SashimiMobile/Views/Detail/MobileDetailView.swift
@@ -55,9 +55,7 @@ struct MobileDetailView: View {
         if !seasons.isEmpty {
             parts.append(seasons.count == 1 ? "1 Season" : "\(seasons.count) Seasons")
         }
-        if let rating = item.officialRating {
-            parts.append(rating)
-        }
+        // Rating shown near the ratings row for series, not the meta text line
         return parts
     }
 

--- a/SashimiMobile/Views/Phone/PhoneDetailView.swift
+++ b/SashimiMobile/Views/Phone/PhoneDetailView.swift
@@ -333,7 +333,8 @@ struct PhoneDetailView: View {
         if let runtime = item.runTimeTicks {
             parts.append(formatRuntime(runtime))
         }
-        if let rating = item.officialRating {
+        // Series show rating as/near ratings row, not in the meta text line
+        if !isSeries, let rating = item.officialRating {
             parts.append(rating)
         }
         if let ends = endsAtText {


### PR DESCRIPTION
Fixes #221. Rating out of the date/meta line for TV series (both iPhone and iPad); movies keep it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XzUNvRCXML3DJe98KBCGkN