### PR TITLE
iOS iPhone: episode detail parity (logo + episode list)

### DIFF
--- a/SashimiMobile/Views/Phone/PhoneDetailView.swift
+++ b/SashimiMobile/Views/Phone/PhoneDetailView.swift
@@ -308,16 +308,24 @@ struct PhoneDetailView: View {
 
     @ViewBuilder
     private var metadataRow: some View {
-        // Metadata line
-        let parts = metadataParts
-        if !parts.isEmpty {
-            Text(parts.joined(separator: " \u{2022} "))
-                .font(MobileTypography.caption)
-                .foregroundStyle(MobileColors.textSecondary)
-                .lineLimit(1)
+        // Metadata line: date • runtime, then a blue "Ends at" (tvOS accent)
+        HStack(spacing: 6) {
+            let parts = metadataParts
+            if !parts.isEmpty {
+                Text(parts.joined(separator: " \u{2022} "))
+                    .foregroundStyle(MobileColors.textSecondary)
+            }
+            if let ends = endsAtText {
+                if !parts.isEmpty {
+                    Text("\u{2022}").foregroundStyle(MobileColors.textSecondary)
+                }
+                Text(ends).foregroundStyle(MobileColors.accent)
+            }
         }
+        .font(MobileTypography.caption)
+        .lineLimit(1)
 
-        // Ratings + media chips on a single line
+        // Ratings + media (quality) chips on a single line
         HStack(spacing: MobileSpacing.sm) {
             ratingsRow
             if !isSeries {
@@ -341,18 +349,8 @@ struct PhoneDetailView: View {
         } else if let year = item.productionYear {
             parts.append(String(year))
         }
-        if isSeries, !seasons.isEmpty {
-            parts.append(seasons.count == 1 ? "1 Season" : "\(seasons.count) Seasons")
-        }
         if let runtime = item.runTimeTicks {
             parts.append(formatRuntime(runtime))
-        }
-        // Rating in the meta line for movies only (TV content omits it)
-        if isMovie, let rating = item.officialRating {
-            parts.append(rating)
-        }
-        if let ends = endsAtText {
-            parts.append(ends)
         }
         return parts
     }

--- a/SashimiMobile/Views/Phone/PhoneDetailView.swift
+++ b/SashimiMobile/Views/Phone/PhoneDetailView.swift
@@ -39,6 +39,10 @@ struct PhoneDetailView: View {
 
     private var isSeries: Bool { item.type == .series }
     private var isEpisode: Bool { item.type == .episode }
+    /// The series whose seasons/episodes this page lists (self for a series,
+    /// the parent for an episode) — drives the shared episode machinery.
+    private var contentSeriesId: String { isSeries ? item.id : (item.seriesId ?? item.id) }
+    private var isMovie: Bool { item.type == .movie }
     private var isMovie: Bool { item.type == .movie }
 
     private var isYouTubeStyle: Bool {
@@ -94,7 +98,7 @@ struct PhoneDetailView: View {
                     actionButtons
                     overviewSection
 
-                    if isSeries {
+                    if isSeries || isEpisode {
                         seasonsSection
                     }
 
@@ -230,7 +234,17 @@ struct PhoneDetailView: View {
     @ViewBuilder
     private var titleSection: some View {
         if isEpisode {
-            if let seriesName = item.seriesName {
+            if !isYouTubeChannelEpisode, let seriesId = item.seriesId, let logoURL = logoImageURL(for: seriesId) {
+                LazyImage(url: logoURL) { state in
+                    if let image = state.image {
+                        image.resizable().aspectRatio(contentMode: .fit).frame(maxHeight: 56)
+                    } else if state.error != nil, let seriesName = item.seriesName {
+                        Text(seriesName)
+                            .font(MobileTypography.caption)
+                            .foregroundStyle(MobileColors.textSecondary)
+                    }
+                }
+            } else if let seriesName = item.seriesName {
                 Text(isYouTubeStyle ? seriesName.cleanedYouTubeTitle : seriesName)
                     .font(MobileTypography.caption)
                     .foregroundStyle(MobileColors.textSecondary)
@@ -311,8 +325,8 @@ struct PhoneDetailView: View {
             }
         }
 
-        // Genres line — movies only (series show rating in the meta line)
-        if !isSeries, let genres = item.genres, !genres.isEmpty {
+        // Genres line — movies only
+        if isMovie, let genres = item.genres, !genres.isEmpty {
             Text(genres.prefix(3).joined(separator: " \u{2022} "))
                 .font(MobileTypography.caption)
                 .foregroundStyle(MobileColors.textSecondary)
@@ -333,8 +347,8 @@ struct PhoneDetailView: View {
         if let runtime = item.runTimeTicks {
             parts.append(formatRuntime(runtime))
         }
-        // Series show rating as/near ratings row, not in the meta text line
-        if !isSeries, let rating = item.officialRating {
+        // Rating in the meta line for movies only (TV content omits it)
+        if isMovie, let rating = item.officialRating {
             parts.append(rating)
         }
         if let ends = endsAtText {
@@ -619,7 +633,7 @@ struct PhoneDetailView: View {
                             Button {
                                 selectedSeason = season
                                 Task {
-                                    await loadEpisodesForSeason(seriesId: item.id, season: season)
+                                    await loadEpisodesForSeason(seriesId: contentSeriesId, season: season)
                                 }
                             } label: {
                                 Text(season.name)
@@ -816,7 +830,9 @@ struct PhoneDetailView: View {
             seriesCommunityRating = series?.communityRating
             seriesCriticRating = series?.criticRating
 
+            seasons = (try? await JellyfinClient.shared.getSeasons(seriesId: seriesId)) ?? []
             if let seasonId = item.seasonId {
+                selectedSeason = seasons.first { $0.id == seasonId }
                 episodes = try await JellyfinClient.shared.getEpisodes(seriesId: seriesId, seasonId: seasonId)
             }
         } catch {


### PR DESCRIPTION
Fixes #223. Continue Watching -> episode detail now shows the series logo and the episode list, and drops genres/rating (movie-only), matching tvOS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XzUNvRCXML3DJe98KBCGkN