### PR TITLE
feat(iOS): tap home header logo to quick-switch servers

### DIFF
--- a/SashimiMobile/Views/Phone/PhoneHomeView.swift
+++ b/SashimiMobile/Views/Phone/PhoneHomeView.swift
@@ -3,6 +3,8 @@ import SwiftUI
 struct PhoneHomeView: View {
     @StateObject private var viewModel = HomeViewModel()
     @StateObject private var rowSettings = HomeRowSettings.shared
+    @ObservedObject private var sessionManager = SessionManager.shared
+    @State private var showAddServer = false
 
     var body: some View {
         ScrollView {
@@ -20,19 +22,46 @@ struct PhoneHomeView: View {
         .navigationBarHidden(true)
         .safeAreaInset(edge: .top) {
             HStack(spacing: 8) {
-                Image("SidebarLogo")
-                    .resizable()
-                    .aspectRatio(contentMode: .fit)
-                    .frame(width: 32, height: 32)
-                    .clipShape(RoundedRectangle(cornerRadius: 7))
-                Text("Sashimi")
-                    .font(.system(size: 18, weight: .bold))
-                    .foregroundStyle(MobileColors.textPrimary)
+                // Logo taps open the server quick-switcher (phone equivalent
+                // of the tvOS avatar menu).
+                Menu {
+                    ForEach(sessionManager.servers) { server in
+                        Button {
+                            Task { await sessionManager.switchServer(to: server.id) }
+                        } label: {
+                            if server.id == sessionManager.activeServerId {
+                                Label(server.name, systemImage: "checkmark")
+                            } else {
+                                Text(server.name)
+                            }
+                        }
+                    }
+                    Divider()
+                    Button {
+                        showAddServer = true
+                    } label: {
+                        Label("Add Server…", systemImage: "plus")
+                    }
+                } label: {
+                    HStack(spacing: 8) {
+                        Image("SidebarLogo")
+                            .resizable()
+                            .aspectRatio(contentMode: .fit)
+                            .frame(width: 32, height: 32)
+                            .clipShape(RoundedRectangle(cornerRadius: 7))
+                        Text("Sashimi")
+                            .font(.system(size: 18, weight: .bold))
+                            .foregroundStyle(MobileColors.textPrimary)
+                    }
+                }
                 Spacer()
             }
             .padding(.horizontal, MobileSpacing.md)
             .padding(.vertical, MobileSpacing.xs)
             .background(MobileColors.background)
+        }
+        .sheet(isPresented: $showAddServer) {
+            MobileAddServerSheet()
         }
         .refreshable {
             await viewModel.loadContent()


### PR DESCRIPTION
Tapping the Sashimi logo/wordmark in the iPhone Home header now opens a server quick-switch menu:

- Lists all connected servers, checkmark on the active one
- Tap a server to switch (`SessionManager.switchServer`)
- **Add Server…** entry presents the existing `MobileAddServerSheet`

Phone counterpart of the tvOS avatar quick-switch. Header visuals unchanged.

Verified: local simulator build (iPhone 17) compiles clean.

Fixes #225

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XzUNvRCXML3DJe98KBCGkN