### PR TITLE
feat(iOS): show air date with episode number in episode list

### DIFF
--- a/SashimiMobile/Views/Phone/PhoneDetailView.swift
+++ b/SashimiMobile/Views/Phone/PhoneDetailView.swift
@@ -305,6 +305,17 @@ struct PhoneDetailView: View {
         return fmt.string(from: date)
     }
 
+    /// Episode air date "Nov 8, 2024" (short form for list rows)
+    private func shortAirDateText(_ episode: BaseItemDto) -> String? {
+        guard let raw = episode.premiereDate else { return nil }
+        let iso = ISO8601DateFormatter()
+        iso.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        guard let date = iso.date(from: raw) ?? ISO8601DateFormatter().date(from: raw) else { return nil }
+        let fmt = DateFormatter()
+        fmt.dateFormat = "MMM d, yyyy"
+        return fmt.string(from: date)
+    }
+
     /// "Ends at 9:41 PM"
     private var endsAtText: String? {
         guard let ticks = item.runTimeTicks, ticks > 0 else { return nil }
@@ -834,9 +845,15 @@ struct PhoneDetailView: View {
 
                         VStack(alignment: .leading, spacing: 4) {
                             if !isYouTubeStyle, let epNum = episode.indexNumber {
-                                Text("E\(epNum)")
-                                    .font(MobileTypography.captionSmall)
-                                    .foregroundStyle(MobileColors.accent)
+                                HStack(spacing: 4) {
+                                    Text("E\(epNum)")
+                                        .foregroundStyle(MobileColors.accent)
+                                    if let aired = shortAirDateText(episode) {
+                                        Text("• \(aired)")
+                                            .foregroundStyle(MobileColors.textTertiary)
+                                    }
+                                }
+                                .font(MobileTypography.captionSmall)
                             }
                             Text(episode.name)
                                 .font(MobileTypography.titleSmall)

--- a/Shared/Services/JellyfinClient.swift
+++ b/Shared/Services/JellyfinClient.swift
@@ -925,7 +925,7 @@ actor JellyfinClient {
 
         var queryItems = [
             URLQueryItem(name: "UserId", value: userId),
-            URLQueryItem(name: "Fields", value: "Overview,PrimaryImageAspectRatio,CommunityRating,ImageTags"),
+            URLQueryItem(name: "Fields", value: "Overview,PrimaryImageAspectRatio,CommunityRating,ImageTags,PremiereDate"),
             URLQueryItem(name: "EnableImageTypes", value: "Primary,Thumb")
         ]
 


### PR DESCRIPTION
Episode rows in the iPhone detail view now show the air date next to the episode number: **E1 • Nov 8, 2024** (date in muted tertiary, number keeps the accent color). Title and runtime lines unchanged.

Also adds `PremiereDate` to the `getEpisodes` Fields param (shared client — additive, benefits tvOS too if it wants dates later).

Verified: local parse-check clean; CI builds both targets.

Fixes #229

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XzUNvRCXML3DJe98KBCGkN