### PR TITLE
feat(iOS): library browse — search, sort, and filter

### DIFF
--- a/SashimiMobile/Views/Library/MobileLibraryBrowseView.swift
+++ b/SashimiMobile/Views/Library/MobileLibraryBrowseView.swift
@@ -1,6 +1,60 @@
 import SwiftUI
 import NukeUI
 
+/// Sort fields for library browsing (mirrors tvOS LibrarySortOption).
+private enum LibrarySort: String, CaseIterable, Identifiable {
+    case name = "SortName"
+    case dateAdded = "DateCreated"
+    case releaseDate = "PremiereDate"
+    case rating = "CommunityRating"
+    case runtime = "Runtime"
+
+    var id: String { rawValue }
+
+    var label: String {
+        switch self {
+        case .name: return "Name"
+        case .dateAdded: return "Date Added"
+        case .releaseDate: return "Release Date"
+        case .rating: return "Rating"
+        case .runtime: return "Runtime"
+        }
+    }
+}
+
+/// Watched/favorites filter (mirrors tvOS LibraryFilterOption).
+private enum LibraryFilter: String, CaseIterable, Identifiable {
+    case all
+    case unwatched
+    case watched
+    case favorites
+
+    var id: String { rawValue }
+
+    var label: String {
+        switch self {
+        case .all: return "All"
+        case .unwatched: return "Unwatched"
+        case .watched: return "Watched"
+        case .favorites: return "Favorites"
+        }
+    }
+
+    // swiftlint:disable discouraged_optional_boolean
+    var isPlayed: Bool? {
+        switch self {
+        case .unwatched: return false
+        case .watched: return true
+        default: return nil
+        }
+    }
+
+    var isFavorite: Bool? {
+        self == .favorites ? true : nil
+    }
+    // swiftlint:enable discouraged_optional_boolean
+}
+
 struct MobileLibraryBrowseView: View {
     let libraryId: String
     let libraryName: String
@@ -10,13 +64,15 @@ struct MobileLibraryBrowseView: View {
     @State private var items: [BaseItemDto] = []
     @State private var isLoading = true
     @State private var totalCount = 0
+    @State private var sort: LibrarySort = .name
+    @State private var sortAscending = true
+    @State private var filter: LibraryFilter = .all
+    @State private var searchText = ""
+    /// Invalidates the in-flight load loop when sort/filter changes mid-fetch.
+    @State private var loadGeneration = 0
 
     private var isYouTubeLibrary: Bool {
         libraryName.lowercased().contains("youtube")
-    }
-
-    private var isTVLibrary: Bool {
-        collectionType?.lowercased() == "tvshows"
     }
 
     private var includeTypes: [ItemType]? {
@@ -25,6 +81,12 @@ struct MobileLibraryBrowseView: View {
         case "tvshows": return [.series]
         default: return nil
         }
+    }
+
+    /// Search filters client-side — the whole library is loaded eagerly.
+    private var displayedItems: [BaseItemDto] {
+        guard !searchText.isEmpty else { return items }
+        return items.filter { $0.name.localizedCaseInsensitiveContains(searchText) }
     }
 
     private var columns: [GridItem] {
@@ -37,54 +99,144 @@ struct MobileLibraryBrowseView: View {
             if isLoading && items.isEmpty {
                 ProgressView()
                     .frame(maxWidth: .infinity, minHeight: 300)
-            } else if items.isEmpty {
-                ContentUnavailableView(
-                    "No Items",
-                    systemImage: "rectangle.stack",
-                    description: Text("This library is empty.")
-                )
-                .frame(maxWidth: .infinity, minHeight: 300)
+            } else if displayedItems.isEmpty {
+                emptyState
             } else {
-                LazyVGrid(columns: columns, spacing: MobileSpacing.md) {
-                    ForEach(items, id: \.id) { item in
-                        NavigationLink {
-                            AdaptiveDetailView(item: item, libraryName: libraryName)
-                        } label: {
-                            MobileRecentlyAddedCard(
-                                item: item,
-                                width: sizeClass == .compact ? PhoneSizing.posterWidth : MobileSizing.posterWidth,
-                                libraryName: libraryName,
-                                isCircular: isYouTubeLibrary && item.type == .series,
-                                isLandscape: false,
-                                badgeCount: nil
-                            )
-                        }
-                        .buttonStyle(.plain)
-                        .contextMenu {
-                            ItemContextMenu(item: item)
+                VStack(alignment: .leading, spacing: MobileSpacing.sm) {
+                    Text(countText)
+                        .font(MobileTypography.captionSmall)
+                        .foregroundStyle(MobileColors.textTertiary)
+                        .padding(.horizontal, MobileSpacing.md)
+
+                    LazyVGrid(columns: columns, spacing: MobileSpacing.md) {
+                        ForEach(displayedItems, id: \.id) { item in
+                            NavigationLink {
+                                AdaptiveDetailView(item: item, libraryName: libraryName)
+                            } label: {
+                                MobileRecentlyAddedCard(
+                                    item: item,
+                                    width: sizeClass == .compact ? PhoneSizing.posterWidth : MobileSizing.posterWidth,
+                                    libraryName: libraryName,
+                                    isCircular: isYouTubeLibrary && item.type == .series,
+                                    isLandscape: false,
+                                    badgeCount: nil
+                                )
+                            }
+                            .buttonStyle(.plain)
+                            .contextMenu {
+                                ItemContextMenu(item: item)
+                            }
                         }
                     }
+                    .padding(.horizontal, MobileSpacing.md)
                 }
-                .padding(.horizontal, MobileSpacing.md)
                 .padding(.vertical, MobileSpacing.md)
             }
         }
         .background(MobileColors.background)
+        .searchable(text: $searchText, placement: .navigationBarDrawer(displayMode: .automatic))
+        .toolbar {
+            ToolbarItemGroup(placement: .topBarTrailing) {
+                sortMenu
+                filterMenu
+            }
+        }
         .task {
             await loadItems()
         }
+        .onChange(of: sort) { _, _ in reload() }
+        .onChange(of: sortAscending) { _, _ in reload() }
+        .onChange(of: filter) { _, _ in reload() }
+    }
+
+    private var countText: String {
+        if !searchText.isEmpty {
+            return "\(displayedItems.count) of \(totalCount) items"
+        }
+        return "\(totalCount) item\(totalCount == 1 ? "" : "s")"
+    }
+
+    @ViewBuilder
+    private var emptyState: some View {
+        if !searchText.isEmpty {
+            ContentUnavailableView.search(text: searchText)
+                .frame(maxWidth: .infinity, minHeight: 300)
+        } else if filter != .all {
+            ContentUnavailableView {
+                Label("No Items", systemImage: "line.3.horizontal.decrease.circle")
+            } description: {
+                Text("Nothing matches the \(filter.label) filter.")
+            } actions: {
+                Button("Clear Filter") { filter = .all }
+            }
+            .frame(maxWidth: .infinity, minHeight: 300)
+        } else {
+            ContentUnavailableView(
+                "No Items",
+                systemImage: "rectangle.stack",
+                description: Text("This library is empty.")
+            )
+            .frame(maxWidth: .infinity, minHeight: 300)
+        }
+    }
+
+    private var sortMenu: some View {
+        Menu {
+            Picker("Sort By", selection: $sort) {
+                ForEach(LibrarySort.allCases) { option in
+                    Text(option.label).tag(option)
+                }
+            }
+            Divider()
+            Button {
+                sortAscending.toggle()
+            } label: {
+                Label(
+                    sortAscending ? "Ascending" : "Descending",
+                    systemImage: sortAscending ? "arrow.up" : "arrow.down"
+                )
+            }
+        } label: {
+            Image(systemName: "arrow.up.arrow.down")
+        }
+    }
+
+    private var filterMenu: some View {
+        Menu {
+            Picker("Filter", selection: $filter) {
+                ForEach(LibraryFilter.allCases) { option in
+                    Text(option.label).tag(option)
+                }
+            }
+        } label: {
+            Image(systemName: filter == .all
+                ? "line.3.horizontal.decrease.circle"
+                : "line.3.horizontal.decrease.circle.fill")
+        }
+    }
+
+    private func reload() {
+        loadGeneration += 1
+        items = []
+        totalCount = 0
+        isLoading = true
+        Task { await loadItems() }
     }
 
     private func loadItems() async {
+        let generation = loadGeneration
         do {
             let response = try await JellyfinClient.shared.getItems(
                 parentId: libraryId,
                 includeTypes: includeTypes,
-                sortBy: "SortName",
-                sortOrder: "Ascending",
+                sortBy: sort.rawValue,
+                sortOrder: sortAscending ? "Ascending" : "Descending",
                 limit: 100,
-                startIndex: 0
+                startIndex: 0,
+                isPlayed: filter.isPlayed,
+                isFavorite: filter.isFavorite
             )
+            guard generation == loadGeneration else { return }
             items = response.items
             totalCount = response.totalRecordCount
 
@@ -93,17 +245,22 @@ struct MobileLibraryBrowseView: View {
                 let more = try await JellyfinClient.shared.getItems(
                     parentId: libraryId,
                     includeTypes: includeTypes,
-                    sortBy: "SortName",
-                    sortOrder: "Ascending",
+                    sortBy: sort.rawValue,
+                    sortOrder: sortAscending ? "Ascending" : "Descending",
                     limit: 100,
-                    startIndex: items.count
+                    startIndex: items.count,
+                    isPlayed: filter.isPlayed,
+                    isFavorite: filter.isFavorite
                 )
+                guard generation == loadGeneration else { return }
                 guard !more.items.isEmpty else { break }
                 items.append(contentsOf: more.items)
             }
         } catch {
             // Show what we have
         }
-        isLoading = false
+        if generation == loadGeneration {
+            isLoading = false
+        }
     }
 }


### PR DESCRIPTION
Brings the iPhone/iPad library grid (shared `MobileLibraryBrowseView`) up to the tvOS feature set, using native iOS idioms:

- **Search within library** — `.searchable` drawer on the grid; client-side over the fully loaded list; proper no-results state
- **Sort menu** (↑↓): Name, Date Added, Release Date, Rating, Runtime + asc/desc toggle — same five fields as tvOS
- **Filter menu** (funnel, fills when active): All / Unwatched / Watched / Favorites via `isPlayed`/`isFavorite`; empty state offers Clear Filter
- **Item count** above the grid ("247 items" / "12 of 247 items" while searching)
- Load-generation guard prevents a mid-fetch sort/filter change from interleaving stale pages
- Removes dead `isTVLibrary` property

De-scoped intentionally: tvOS letter-jump bar (search covers it on touch), refresh-on-return.

Verified: local simulator build (iPhone 17) succeeds.

Fixes #231

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XzUNvRCXML3DJe98KBCGkN