### PR TITLE
fix(iOS): subtitles render + audio menu + speed control in mobile player

### DIFF
--- a/SashimiMobile/Views/Player/MobilePlayerView.swift
+++ b/SashimiMobile/Views/Player/MobilePlayerView.swift
@@ -35,6 +35,7 @@ struct MobilePlayerView: View {
     @Environment(\.dismiss) private var dismiss
     @State private var showCustomOverlay = true
     @State private var hideTask: Task<Void, Never>?
+    @State private var playbackSpeed: Float = 1.0
 
     private var localFileURL: URL? {
         DownloadManager.shared.localVideoURL(for: item.id)
@@ -47,6 +48,9 @@ struct MobilePlayerView: View {
             if let player = viewModel.player {
                 PlayerViewController(player: player)
                     .ignoresSafeArea()
+
+                // App-rendered VTT subtitles (same pipeline as tvOS, phone sizing)
+                SubtitleOverlay(manager: viewModel.subtitleManager, fontSize: 17, bottomPadding: 48)
 
                 customOverlay
             } else {
@@ -79,6 +83,9 @@ struct MobilePlayerView: View {
                     }
                 }
             }
+            // Populate the audio/subtitle menus (tvOS does this on player appear;
+            // without it both lists stay empty and subtitles can never be enabled)
+            viewModel.loadAllTracks()
             scheduleAutoHide()
         }
         .onDisappear {
@@ -227,6 +234,26 @@ struct MobilePlayerView: View {
                                 if viewModel.selectedAudioTrackId == track.id {
                                     Image(systemName: "checkmark")
                                 }
+                            }
+                        }
+                    }
+                }
+            }
+
+            Section("Speed") {
+                ForEach([Float(0.5), 0.75, 1.0, 1.25, 1.5, 2.0], id: \.self) { speed in
+                    Button {
+                        playbackSpeed = speed
+                        // defaultRate keeps the speed across pause/play
+                        viewModel.player?.defaultRate = speed
+                        if viewModel.player?.rate != 0 {
+                            viewModel.player?.rate = speed
+                        }
+                    } label: {
+                        HStack {
+                            Text(speed == 1.0 ? "Normal" : String(format: "%g×", speed))
+                            if playbackSpeed == speed {
+                                Image(systemName: "checkmark")
                             }
                         }
                     }

--- a/SashimiMobile/Views/Player/MobilePlayerView.swift
+++ b/SashimiMobile/Views/Player/MobilePlayerView.swift
@@ -207,95 +207,7 @@ struct MobilePlayerView: View {
     // MARK: - Settings Menu
 
     private var settingsMenu: some View {
-        Menu {
-            Section("Quality") {
-                ForEach(QualityOption.allCases) { quality in
-                    Button {
-                        Task { await viewModel.changeQuality(quality) }
-                    } label: {
-                        HStack {
-                            Text(quality.displayName)
-                            if viewModel.selectedQuality == quality {
-                                Image(systemName: "checkmark")
-                            }
-                        }
-                    }
-                }
-            }
-
-            if !viewModel.audioTracks.isEmpty {
-                Section("Audio") {
-                    ForEach(Array(viewModel.audioTracks.enumerated()), id: \.element.id) { _, track in
-                        Button {
-                            viewModel.selectAudioTrack(track)
-                        } label: {
-                            HStack {
-                                Text(track.displayName)
-                                if viewModel.selectedAudioTrackId == track.id {
-                                    Image(systemName: "checkmark")
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-
-            Section("Speed") {
-                ForEach([Float(0.5), 0.75, 1.0, 1.25, 1.5, 2.0], id: \.self) { speed in
-                    Button {
-                        playbackSpeed = speed
-                        // defaultRate keeps the speed across pause/play
-                        viewModel.player?.defaultRate = speed
-                        if viewModel.player?.rate != 0 {
-                            viewModel.player?.rate = speed
-                        }
-                    } label: {
-                        HStack {
-                            Text(speed == 1.0 ? "Normal" : String(format: "%g×", speed))
-                            if playbackSpeed == speed {
-                                Image(systemName: "checkmark")
-                            }
-                        }
-                    }
-                }
-            }
-
-            Section("Subtitles") {
-                Button {
-                    // Route through the ViewModel so the subtitle overlay is
-                    // actually cleared, not just the selection state.
-                    viewModel.disableSubtitles()
-                } label: {
-                    HStack {
-                        Text("Off")
-                        if viewModel.selectedSubtitleTrackId == nil || viewModel.selectedSubtitleTrackId == "off" {
-                            Image(systemName: "checkmark")
-                        }
-                    }
-                }
-
-                // Skip the ViewModel's built-in "Off" option — this menu renders its own above
-                ForEach(viewModel.subtitleTracks.filter { !$0.isOffOption }) { subtitle in
-                    Button {
-                        viewModel.selectSubtitleTrack(subtitle)
-                    } label: {
-                        HStack {
-                            Text(subtitle.displayName)
-                            if viewModel.selectedSubtitleTrackId == subtitle.id {
-                                Image(systemName: "checkmark")
-                            }
-                        }
-                    }
-                }
-            }
-        } label: {
-            Image(systemName: "gearshape.fill")
-                .font(.system(size: 18))
-                .foregroundStyle(.white)
-                .frame(width: 36, height: 36)
-                .background(.white.opacity(0.15))
-                .clipShape(Circle())
-        }
+        PlayerSettingsMenu(viewModel: viewModel, playbackSpeed: $playbackSpeed)
     }
 
     // MARK: - Skip Button
@@ -394,6 +306,105 @@ struct MobilePlayerView: View {
             .frame(maxWidth: .infinity, maxHeight: .infinity)
         }
         .ignoresSafeArea()
+    }
+}
+
+// MARK: - Settings Menu (quality / audio / speed / subtitles)
+
+private struct PlayerSettingsMenu: View {
+    @ObservedObject var viewModel: PlayerViewModel
+    @Binding var playbackSpeed: Float
+
+    var body: some View {
+        Menu {
+            Section("Quality") {
+                ForEach(QualityOption.allCases) { quality in
+                    Button {
+                        Task { await viewModel.changeQuality(quality) }
+                    } label: {
+                        HStack {
+                            Text(quality.displayName)
+                            if viewModel.selectedQuality == quality {
+                                Image(systemName: "checkmark")
+                            }
+                        }
+                    }
+                }
+            }
+
+            if !viewModel.audioTracks.isEmpty {
+                Section("Audio") {
+                    ForEach(Array(viewModel.audioTracks.enumerated()), id: \.element.id) { _, track in
+                        Button {
+                            viewModel.selectAudioTrack(track)
+                        } label: {
+                            HStack {
+                                Text(track.displayName)
+                                if viewModel.selectedAudioTrackId == track.id {
+                                    Image(systemName: "checkmark")
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+
+            Section("Speed") {
+                ForEach([Float(0.5), 0.75, 1.0, 1.25, 1.5, 2.0], id: \.self) { speed in
+                    Button {
+                        playbackSpeed = speed
+                        // defaultRate keeps the speed across pause/play
+                        viewModel.player?.defaultRate = speed
+                        if viewModel.player?.rate != 0 {
+                            viewModel.player?.rate = speed
+                        }
+                    } label: {
+                        HStack {
+                            Text(speed == 1.0 ? "Normal" : String(format: "%g×", speed))
+                            if playbackSpeed == speed {
+                                Image(systemName: "checkmark")
+                            }
+                        }
+                    }
+                }
+            }
+
+            Section("Subtitles") {
+                Button {
+                    // Route through the ViewModel so the subtitle overlay is
+                    // actually cleared, not just the selection state.
+                    viewModel.disableSubtitles()
+                } label: {
+                    HStack {
+                        Text("Off")
+                        if viewModel.selectedSubtitleTrackId == nil || viewModel.selectedSubtitleTrackId == "off" {
+                            Image(systemName: "checkmark")
+                        }
+                    }
+                }
+
+                // Skip the ViewModel's built-in "Off" option — this menu renders its own above
+                ForEach(viewModel.subtitleTracks.filter { !$0.isOffOption }) { subtitle in
+                    Button {
+                        viewModel.selectSubtitleTrack(subtitle)
+                    } label: {
+                        HStack {
+                            Text(subtitle.displayName)
+                            if viewModel.selectedSubtitleTrackId == subtitle.id {
+                                Image(systemName: "checkmark")
+                            }
+                        }
+                    }
+                }
+            }
+        } label: {
+            Image(systemName: "gearshape.fill")
+                .font(.system(size: 18))
+                .foregroundStyle(.white)
+                .frame(width: 36, height: 36)
+                .background(.white.opacity(0.15))
+                .clipShape(Circle())
+        }
     }
 }
 

--- a/Shared/Views/SubtitleOverlay.swift
+++ b/Shared/Views/SubtitleOverlay.swift
@@ -2,8 +2,14 @@ import SwiftUI
 
 // MARK: - Subtitle Overlay View
 
+/// Draws the current VTT cue from SubtitleManager. Shared by the tvOS and
+/// mobile players; size defaults match the tvOS 10-foot UI.
 struct SubtitleOverlay: View {
     @ObservedObject var manager: SubtitleManager
+    var fontSize: CGFloat = 42
+    var bottomPadding: CGFloat = 80
+
+    private var compact: Bool { fontSize <= 24 }
 
     var body: some View {
         VStack {
@@ -11,16 +17,16 @@ struct SubtitleOverlay: View {
 
             if let cue = manager.currentCue {
                 Text(cue.text)
-                    .font(.system(size: 42, weight: .semibold))
+                    .font(.system(size: fontSize, weight: .semibold))
                     .foregroundStyle(.white)
                     .multilineTextAlignment(.center)
-                    .padding(.horizontal, 24)
-                    .padding(.vertical, 12)
+                    .padding(.horizontal, compact ? 12 : 24)
+                    .padding(.vertical, compact ? 6 : 12)
                     .background(
                         Color.black.opacity(0.75)
                     )
-                    .clipShape(RoundedRectangle(cornerRadius: 12))
-                    .padding(.bottom, 80)
+                    .clipShape(RoundedRectangle(cornerRadius: compact ? 8 : 12))
+                    .padding(.bottom, bottomPadding)
                     .transition(.opacity)
                     .id(cue.id)
             }


### PR DESCRIPTION
## Root cause (subtitles "not working")
Sashimi renders subtitles itself: it downloads the VTT from Jellyfin (`SubtitleManager`) and draws cues via `SubtitleOverlay`. On iPhone **both ends were unhooked**:
1. `loadSubtitleTracks()` was never called → the picker only ever showed **Off**
2. `SubtitleOverlay` was never mounted → even a selected track had nothing to draw it

The identical missing-loader bug made the **audio track menu** permanently empty.

## Changes
- `viewModel.loadAllTracks()` after media load (populates subtitle + audio menus)
- `SubtitleOverlay` moved to `Shared/` and parameterized (`fontSize`/`bottomPadding`; tvOS defaults unchanged); mounted in the mobile player at phone sizing (17pt)
- New **Speed** section in the mobile player menu (0.5×–2×, uses `defaultRate` so speed survives pause/play) — tvOS parity
- `xcodegen` project regenerated for the file move

Verified: iPhone 17 simulator build succeeds; tvOS covered by CI (overlay defaults preserve existing look).

Fixes #233

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XzUNvRCXML3DJe98KBCGkN