### PR TITLE
feat(tvOS): merge logo + avatar into the tab bar row

### DIFF
--- a/Sashimi/App/SashimiApp.swift
+++ b/Sashimi/App/SashimiApp.swift
@@ -133,6 +133,16 @@ struct MainTabView: View {
     @State private var selectedTab = 0
 
     var body: some View {
+        ZStack(alignment: .top) {
+            mainTabs
+            // Logo + avatar share the tab bar row (issue #235): one focus
+            // strip instead of the old header-above-the-bar hop.
+            TabBarAccessories()
+        }
+        .onExitCommand(perform: exitCommandAction)
+    }
+
+    private var mainTabs: some View {
         TabView(selection: $selectedTab) {
             HomeView()
                 .tabItem {
@@ -158,7 +168,6 @@ struct MainTabView: View {
                 }
                 .tag(3)
         }
-        .onExitCommand(perform: exitCommandAction)
     }
 
     /// Menu/back button handling. Returns nil on the Home tab so the press

--- a/Sashimi/Views/Components/AppHeader.swift
+++ b/Sashimi/Views/Components/AppHeader.swift
@@ -1,62 +1,63 @@
 import SwiftUI
 
-/// Shared header component with logo and avatar display
-/// Used across all main tabs (Home, Library, Search, Settings)
-struct AppHeader: View {
+/// Accessories rendered on the same row as the native tab bar: a compact
+/// decorative logo at the left edge and the avatar (server quick-switcher)
+/// at the right. Replaces the old full-height AppHeader that lived above
+/// the tab bar and forced an extra focus hop (issue #235).
+struct TabBarAccessories: View {
     @EnvironmentObject private var sessionManager: SessionManager
     @State private var showServerSwitcher = false
     @State private var showAddServer = false
 
     var body: some View {
-        HStack(alignment: .top, spacing: 0) {
-            // Logo at left (includes "Sashimi" text)
+        HStack(alignment: .center) {
+            // Logo at left (decorative, never focusable)
             Image("Logo")
                 .resizable()
                 .aspectRatio(contentMode: .fit)
-                .frame(height: 220)
-                .padding(.top, -35)
+                .frame(height: 100)
+                .focusable(false)
 
             Spacer()
 
-            // User avatar — click for the server quick-switcher
+            // Avatar — sits at the right end of the tab bar row so a single
+            // rightward swipe from the last tab reaches it
             Button {
                 showServerSwitcher = true
             } label: {
-            ZStack {
-                Circle()
-                    .fill(
-                        LinearGradient(
-                            colors: [SashimiTheme.accent, SashimiTheme.accent.opacity(0.6)],
-                            startPoint: .topLeading,
-                            endPoint: .bottomTrailing
+                ZStack {
+                    Circle()
+                        .fill(
+                            LinearGradient(
+                                colors: [SashimiTheme.accent, SashimiTheme.accent.opacity(0.6)],
+                                startPoint: .topLeading,
+                                endPoint: .bottomTrailing
+                            )
                         )
-                    )
-                    .frame(width: 70, height: 70)
+                        .frame(width: 58, height: 58)
 
-                if let userId = sessionManager.currentUser?.id,
-                   let imageURL = JellyfinClient.shared.userImageURL(userId: userId) {
-                    AsyncImage(url: imageURL) { image in
-                        image
-                            .resizable()
-                            .aspectRatio(contentMode: .fill)
-                    } placeholder: {
+                    if let userId = sessionManager.currentUser?.id,
+                       let imageURL = JellyfinClient.shared.userImageURL(userId: userId) {
+                        AsyncImage(url: imageURL) { image in
+                            image
+                                .resizable()
+                                .aspectRatio(contentMode: .fill)
+                        } placeholder: {
+                            Image(systemName: "person.fill")
+                                .font(.system(size: 24))
+                                .foregroundStyle(.white)
+                        }
+                        .frame(width: 58, height: 58)
+                        .clipShape(Circle())
+                    } else {
                         Image(systemName: "person.fill")
-                            .font(.system(size: 28))
+                            .font(.system(size: 24))
                             .foregroundStyle(.white)
                     }
-                    .frame(width: 70, height: 70)
-                    .clipShape(Circle())
-                } else {
-                    Image(systemName: "person.fill")
-                        .font(.system(size: 28))
-                        .foregroundStyle(.white)
                 }
-            }
-            .shadow(color: SashimiTheme.accent.opacity(0.3), radius: 8)
+                .shadow(color: SashimiTheme.accent.opacity(0.3), radius: 8)
             }
             .buttonStyle(.plain)
-            .padding(.trailing, 30)
-            .padding(.top, 22)
             .confirmationDialog("Switch Server", isPresented: $showServerSwitcher, titleVisibility: .visible) {
                 ForEach(sessionManager.servers) { server in
                     Button(server.id == sessionManager.activeServerId ? "✓ \(server.name)" : server.name) {
@@ -70,12 +71,9 @@ struct AppHeader: View {
                 AddServerSheet()
             }
         }
-        .frame(maxWidth: .infinity)
-        .ignoresSafeArea(edges: .horizontal)
-        // The hero overlaps the header (negative padding below it in
-        // HomeView), which blocked focus from ever reaching the avatar
-        // button. Keep the header its own focus section, above the hero.
+        .padding(.horizontal, 60)
+        .padding(.top, 30)
+        // Own focus section beside the tab bar; content below is unaffected.
         .focusSection()
-        .zIndex(1)
     }
 }

--- a/Sashimi/Views/Home/HomeView.swift
+++ b/Sashimi/Views/Home/HomeView.swift
@@ -39,9 +39,9 @@ struct HomeView: View {
 
                 ScrollView(.vertical, showsIndicators: false) {
                     LazyVStack(alignment: .leading, spacing: 40) {
-                        // Header with logo and profile avatar
-                        AppHeader()
-                            .padding(.bottom, -80)
+                        // Clear the tab bar row (logo/avatar live there now)
+                        Spacer()
+                            .frame(height: 90)
 
                         // Render rows based on settings order
                         ForEach(homeSettings.rowConfigs) { config in

--- a/Sashimi/Views/Library/SettingsView.swift
+++ b/Sashimi/Views/Library/SettingsView.swift
@@ -559,7 +559,7 @@ struct HomeRowToggleButton: View {
     }
 }
 
-// MARK: - Settings Container (styled background with AppHeader and width constraint)
+// MARK: - Settings Container (styled background and width constraint)
 
 struct SettingsContainer<Content: View>: View {
     let content: Content


### PR DESCRIPTION
Removes the awkward two-stop navigation (content → AppHeader avatar → tab bar). One strip now shares the tab bar row:

- Compact **logo** at the left edge (decorative, not focusable)
- Native tabs in the middle (unchanged)
- **Avatar** at the right (own focusSection — one right-swipe from Settings reaches it; click opens the server switcher)
- Old full-height `AppHeader` deleted from Home; `TabBarAccessories` replaces it, overlaid on the `TabView`

Deployed to Living Room Apple TV for hardware focus testing.

Fixes #235

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XzUNvRCXML3DJe98KBCGkN