### PR TITLE
feat(tvOS): sidebar navigation (.sidebarAdaptable, tvOS 18)

### DIFF
--- a/Sashimi/App/SashimiApp.swift
+++ b/Sashimi/App/SashimiApp.swift
@@ -133,31 +133,26 @@ struct MainTabView: View {
     @State private var selectedTab = 0
 
     var body: some View {
+        // Modern collapsible left-sidebar navigation (Apple TV app idiom).
+        // Icon rail at the left edge expands with labels on focus.
         TabView(selection: $selectedTab) {
-            HomeView()
-                .tabItem {
-                    Label("Home", systemImage: "house")
-                }
-                .tag(0)
+            Tab("Home", systemImage: "house", value: 0) {
+                HomeView()
+            }
 
-            LibraryView(onBackAtRoot: { selectedTab = 0 })
-                .tabItem {
-                    Label("Library", systemImage: "square.grid.2x2")
-                }
-                .tag(1)
+            Tab("Library", systemImage: "square.grid.2x2", value: 1) {
+                LibraryView(onBackAtRoot: { selectedTab = 0 })
+            }
 
-            SearchView(onBackAtRoot: { selectedTab = 0 })
-                .tabItem {
-                    Label("Search", systemImage: "magnifyingglass")
-                }
-                .tag(2)
+            Tab("Search", systemImage: "magnifyingglass", value: 2) {
+                SearchView(onBackAtRoot: { selectedTab = 0 })
+            }
 
-            SettingsView(onBackAtRoot: { selectedTab = 0 })
-                .tabItem {
-                    Label("Settings", systemImage: "gearshape")
-                }
-                .tag(3)
+            Tab("Settings", systemImage: "gearshape", value: 3) {
+                SettingsView(onBackAtRoot: { selectedTab = 0 })
+            }
         }
+        .tabViewStyle(.sidebarAdaptable)
         .onExitCommand(perform: exitCommandAction)
     }
 

--- a/project.yml
+++ b/project.yml
@@ -2,7 +2,7 @@ name: Sashimi
 options:
   bundleIdPrefix: com.sashimi
   deploymentTarget:
-    tvOS: "17.0"
+    tvOS: "18.0"
     iOS: "17.0"
   xcodeVersion: "15.0"
   defaultConfig: Release
@@ -187,7 +187,7 @@ targets:
         DEVELOPMENT_TEAM: S6WU9SVVDW
         CODE_SIGN_STYLE: Automatic
         SKIP_INSTALL: YES
-        TVOS_DEPLOYMENT_TARGET: "17.0"
+        TVOS_DEPLOYMENT_TARGET: "18.0"
     entitlements:
       path: TopShelf/TopShelf.entitlements
       properties:


### PR DESCRIPTION
Switches tvOS navigation from the classic top tab bar to the modern collapsible left sidebar (Apple TV app / Netflix idiom), using the native `.tabViewStyle(.sidebarAdaptable)` with the tvOS 18 `Tab` API — all focus/expand behavior is system-provided.

- Minimum tvOS raised **17 → 18** (root target + TopShelf extension)
- Home keeps the logo + decorative avatar header from #237
- iOS target untouched (this file is tvOS-only)

Deployed to Living Room Apple TV for side-by-side judgment vs the top bar.

Fixes #238

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XzUNvRCXML3DJe98KBCGkN