### PR TITLE
feat: bitrate on the player stream-info chip (iOS + tvOS)

### DIFF
--- a/SashimiMobile/Views/Player/MobilePlayerView.swift
+++ b/SashimiMobile/Views/Player/MobilePlayerView.swift
@@ -86,6 +86,7 @@ struct MobilePlayerView: View {
             // Populate the audio/subtitle menus (tvOS does this on player appear;
             // without it both lists stay empty and subtitles can never be enabled)
             viewModel.loadAllTracks()
+            await viewModel.refreshStreamInfo()
             scheduleAutoHide()
         }
         .onDisappear {
@@ -182,12 +183,38 @@ struct MobilePlayerView: View {
 
             Spacer()
 
+            // Stream-info chip (Direct Play / Transcode + bitrate)
+            if let info = viewModel.streamInfo {
+                streamInfoChip(info)
+            }
+
             // Settings menu
             settingsMenu
         }
         .padding(.horizontal, 20)
         .padding(.top, 8)
         .transition(.move(edge: .top).combined(with: .opacity))
+    }
+
+    private func streamInfoChip(_ info: PlayerViewModel.StreamInfo) -> some View {
+        var text = info.label
+        if let detail = info.detail { text += " · \(detail)" }
+        let color: Color
+        switch info.method {
+        case .directPlay: color = .green
+        case .directStream: color = .yellow
+        case .transcode: color = .orange
+        }
+        return HStack(spacing: 6) {
+            Circle().fill(color).frame(width: 8, height: 8)
+            Text(text)
+                .font(.caption2.weight(.semibold))
+                .foregroundStyle(.white)
+        }
+        .padding(.horizontal, 10)
+        .padding(.vertical, 6)
+        .background(.white.opacity(0.15))
+        .clipShape(Capsule())
     }
 
     private var controlBarSubtitle: String? {
@@ -238,6 +265,11 @@ struct MobilePlayerView: View {
 
     private func toggleOverlay() {
         showCustomOverlay.toggle()
+        // Refresh the stream-info chip each time the overlay is brought up
+        // (the transcode session may register/change after playback starts).
+        if showCustomOverlay {
+            Task { await viewModel.refreshStreamInfo() }
+        }
         scheduleAutoHide()
     }
 

--- a/Shared/Models/JellyfinModels.swift
+++ b/Shared/Models/JellyfinModels.swift
@@ -206,6 +206,7 @@ struct MediaSourceInfo: Codable {
     let transcodingUrl: String?
     let directStreamUrl: String?
     let mediaStreams: [MediaStream]?
+    let bitrate: Int?
 
     var videoCodec: String? {
         mediaStreams?.first(where: { $0.type == "Video" })?.codec
@@ -267,6 +268,7 @@ struct MediaSourceInfo: Codable {
         case transcodingUrl = "TranscodingUrl"
         case directStreamUrl = "DirectStreamUrl"
         case mediaStreams = "MediaStreams"
+        case bitrate = "Bitrate"
     }
 }
 

--- a/Shared/ViewModels/PlayerViewModel.swift
+++ b/Shared/ViewModels/PlayerViewModel.swift
@@ -196,10 +196,17 @@ final class PlayerViewModel: ObservableObject {
                 )
             }
         } else if method == "DirectStream" {
-            streamInfo = StreamInfo(method: .directStream, detail: nil, reason: nil)
+            streamInfo = StreamInfo(method: .directStream, detail: sourceBitrateDetail, reason: nil)
         } else if method != nil {
-            streamInfo = StreamInfo(method: .directPlay, detail: nil, reason: nil)
+            streamInfo = StreamInfo(method: .directPlay, detail: sourceBitrateDetail, reason: nil)
         }
+    }
+
+    /// Source file's overall bitrate ("4 Mbps") for direct play/stream chips —
+    /// transcode sessions report the target bitrate via TranscodingInfo instead.
+    private var sourceBitrateDetail: String? {
+        guard let bps = currentMediaSource?.bitrate, bps > 0 else { return nil }
+        return "\(Int(round(Double(bps) / 1_000_000))) Mbps"
     }
 
     private static func resolutionLabel(width: Int, height: Int) -> String {


### PR DESCRIPTION
Adds the bitrate (e.g. "4 Mbps") to the player's stream-info chip.

- **Shared**: `MediaSourceInfo` gains `Bitrate`; `refreshStreamInfo` puts the source bitrate on the **Direct Play** / **Direct Stream** chips (transcode already showed its target bitrate).
- **tvOS**: chip now reads e.g. "Direct Play → 4 Mbps".
- **iOS**: the stream-info chip was missing entirely — added it to the player top bar (method + bitrate), refreshed on load and each time the overlay is shown.

(Roku got the matching change in a separate commit — bitrate chip + Direct Play vs Direct Stream distinction.)

Fixes #245

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XzUNvRCXML3DJe98KBCGkN