### PR TITLE
Muted purple brand accent (iOS + tvOS)

### DIFF
--- a/Sashimi/Theme/Theme.swift
+++ b/Sashimi/Theme/Theme.swift
@@ -5,13 +5,13 @@ import SwiftUI
 enum SashimiTheme {
     static let background = Color(red: 0.07, green: 0.07, blue: 0.09)
     static let cardBackground = Color(white: 0.12)
-    static let accent = Color(red: 0.36, green: 0.68, blue: 0.90)
+    static let accent = Color(red: 140 / 255, green: 92 / 255, blue: 199 / 255)
     static let accentSecondary = Color(red: 0.95, green: 0.65, blue: 0.25)
-    static let highlight = Color(red: 0.36, green: 0.68, blue: 0.90)
+    static let highlight = Color(red: 140 / 255, green: 92 / 255, blue: 199 / 255)
     static let textPrimary = Color.white
     static let textSecondary = Color(white: 0.75)
     static let textTertiary = Color(white: 0.55)
-    static let focusGlow = Color(red: 0.36, green: 0.68, blue: 0.90).opacity(0.5)
+    static let focusGlow = Color(red: 140 / 255, green: 92 / 255, blue: 199 / 255).opacity(0.5)
     static let progressBackground = Color(white: 0.25)
     static let success = Color.green
     static let warning = Color.orange

--- a/SashimiMobile/Theme/MobileTheme.swift
+++ b/SashimiMobile/Theme/MobileTheme.swift
@@ -5,7 +5,9 @@ import SwiftUI
 enum MobileColors {
     static let background = Color(red: 0.07, green: 0.07, blue: 0.09)
     static let cardBackground = Color(white: 0.12)
-    static let accent = Color(red: 0.36, green: 0.68, blue: 0.90)
+    // Jellyfin purple (#BD3EED) — the app's brand accent, matching the logo,
+    // sidebar highlight, and quality badges.
+    static let accent = Color(red: 189 / 255, green: 62 / 255, blue: 237 / 255)
     static let accentSecondary = Color(red: 0.95, green: 0.65, blue: 0.25)
     static let textPrimary = Color.white
     static let textSecondary = Color(white: 0.75)

--- a/SashimiMobile/Theme/MobileTheme.swift
+++ b/SashimiMobile/Theme/MobileTheme.swift
@@ -5,9 +5,10 @@ import SwiftUI
 enum MobileColors {
     static let background = Color(red: 0.07, green: 0.07, blue: 0.09)
     static let cardBackground = Color(white: 0.12)
-    // Jellyfin purple (#BD3EED) — the app's brand accent, matching the logo,
-    // sidebar highlight, and quality badges.
-    static let accent = Color(red: 189 / 255, green: 62 / 255, blue: 237 / 255)
+    // Muted brand purple (#8C5CC7) for ambient UI accent — focus, progress,
+    // scrubber. On-brand with the logo/badges but calmer than the full-
+    // saturation #BD3EED, which stays reserved for the quality badges.
+    static let accent = Color(red: 140 / 255, green: 92 / 255, blue: 199 / 255)
     static let accentSecondary = Color(red: 0.95, green: 0.65, blue: 0.25)
     static let textPrimary = Color.white
     static let textSecondary = Color(white: 0.75)

--- a/SashimiMobile/Views/Player/MobilePlayerView.swift
+++ b/SashimiMobile/Views/Player/MobilePlayerView.swift
@@ -16,6 +16,8 @@ private struct PlayerViewController: UIViewControllerRepresentable {
         controller.showsPlaybackControls = true
         controller.allowsPictureInPicturePlayback = true
         controller.entersFullScreenWhenPlaybackBegins = false
+        // Tint the native transport controls with the brand accent (purple)
+        controller.view.tintColor = UIColor(MobileColors.accent)
         return controller
     }
 


### PR DESCRIPTION
Swap the app accent from blue to a muted brand purple (#8C5CC7) so the player controls, focus, selection, and progress read on-brand with the logo/sidebar/badges. Native iOS player transport tinted too. Bright #BD3EED stays reserved for the quality badges. Semantic colors (amber transcode, green watched) unchanged.

Validated on iPhone via TestFlight (beta.7 bright → beta.8 muted).

🤖 Generated with [Claude Code](https://claude.com/claude-code)