### PR TITLE
Shuffle: header button on libraries + TV show detail (tvOS + iOS)

### DIFF
--- a/Sashimi/Views/Detail/MediaDetailView.swift
+++ b/Sashimi/Views/Detail/MediaDetailView.swift
@@ -735,6 +735,16 @@ struct MediaDetailView: View {
         }
     }
 
+    /// Shuffle: play a random episode of this series.
+    private func shuffleEpisode() async {
+        let seriesId = isSeries ? item.id : (item.seriesId ?? item.id)
+        if let ep = try? await JellyfinClient.shared.getRandomItem(parentId: seriesId, itemTypes: [.episode]) {
+            selectedEpisode = ep
+            startFromBeginning = false
+            showingPlayer = true
+        }
+    }
+
     // MARK: - Action Buttons
     private var actionButtonsRow: some View {
         HStack(spacing: 30) {
@@ -751,6 +761,17 @@ struct MediaDetailView: View {
                     selectedEpisode = nextEp
                     startFromBeginning = false
                     showingPlayer = true
+                }
+            }
+
+            // Series: shuffle a random episode
+            if isSeries {
+                ActionButton(
+                    title: "Shuffle",
+                    icon: "shuffle",
+                    isPrimary: false
+                ) {
+                    Task { await shuffleEpisode() }
                 }
             }
 

--- a/Sashimi/Views/Library/LibraryView.swift
+++ b/Sashimi/Views/Library/LibraryView.swift
@@ -298,6 +298,12 @@ struct LibraryDetailView: View {
                                 }
                             )
 
+                            if !isYouTubeLibrary {
+                                ShuffleButton {
+                                    Task { await shufflePlay() }
+                                }
+                            }
+
                             Spacer()
 
                             if totalCount > 0 {
@@ -430,6 +436,20 @@ struct LibraryDetailView: View {
             }
         }
         return items.first { $0.name.uppercased().hasPrefix(letter) }
+    }
+
+    /// Shuffle: play one random item from this library — a random movie for a
+    /// movie library, a random episode for a TV library.
+    private func shufflePlay() async {
+        let types: [ItemType] = switch library.collectionType {
+        case "tvshows": [.episode]
+        case "movies": [.movie]
+        default: [.movie, .episode]
+        }
+        if let item = try? await JellyfinClient.shared.getRandomItem(parentId: library.id, itemTypes: types) {
+            selectedItemIsYouTube = false
+            selectedItem = item
+        }
     }
 
     private func loadAllRemainingItems() async {
@@ -649,6 +669,35 @@ struct SortMenuButton: View {
                 }
             }
         }
+    }
+}
+
+// MARK: - Shuffle Button
+struct ShuffleButton: View {
+    let onShuffle: () -> Void
+    @FocusState private var isFocused: Bool
+
+    var body: some View {
+        Button(action: onShuffle) {
+            HStack(spacing: 8) {
+                Image(systemName: "shuffle")
+                Text("Shuffle")
+            }
+            .font(.system(size: 20))
+            .foregroundStyle(SashimiTheme.textPrimary)
+            .padding(.horizontal, 16)
+            .padding(.vertical, 10)
+            .background(isFocused ? SashimiTheme.accent.opacity(0.15) : SashimiTheme.cardBackground)
+            .clipShape(Capsule())
+            .overlay(
+                Capsule()
+                    .stroke(isFocused ? SashimiTheme.accent : .clear, lineWidth: 3)
+            )
+            .scaleEffect(isFocused ? 1.05 : 1.0)
+            .animation(.spring(response: 0.3, dampingFraction: 0.7), value: isFocused)
+        }
+        .buttonStyle(PlainNoHighlightButtonStyle())
+        .focused($isFocused)
     }
 }
 

--- a/SashimiMobile/Views/Detail/MobileDetailView.swift
+++ b/SashimiMobile/Views/Detail/MobileDetailView.swift
@@ -558,6 +558,14 @@ struct MobileDetailView: View {
         }
     }
 
+    /// Shuffle: play a random episode of this series.
+    private func shuffleEpisode() async {
+        let seriesId = isSeries ? item.id : (item.seriesId ?? item.id)
+        if let ep = try? await JellyfinClient.shared.getRandomItem(parentId: seriesId, itemTypes: [.episode]) {
+            playingItem = ep
+        }
+    }
+
     // MARK: - Action Buttons
 
     private var seriesActionButtons: some View {
@@ -578,6 +586,14 @@ struct MobileDetailView: View {
                 }
                 .buttonStyle(.borderedProminent)
             }
+
+            Button {
+                Task { await shuffleEpisode() }
+            } label: {
+                Label("Shuffle", systemImage: "shuffle")
+                    .font(.system(size: 14, weight: .semibold))
+            }
+            .buttonStyle(.bordered)
 
             watchedButton
 

--- a/SashimiMobile/Views/Library/MobileLibraryBrowseView.swift
+++ b/SashimiMobile/Views/Library/MobileLibraryBrowseView.swift
@@ -70,6 +70,8 @@ struct MobileLibraryBrowseView: View {
     @State private var searchText = ""
     /// Invalidates the in-flight load loop when sort/filter changes mid-fetch.
     @State private var loadGeneration = 0
+    /// Set by the Shuffle button to present the player on a random item.
+    @State private var shuffleItem: BaseItemDto?
 
     private var isYouTubeLibrary: Bool {
         libraryName.lowercased().contains("youtube")
@@ -80,6 +82,15 @@ struct MobileLibraryBrowseView: View {
         case "movies": return [.movie]
         case "tvshows": return [.series]
         default: return nil
+        }
+    }
+
+    /// Shuffle: play one random item — a random movie for a movie library, a
+    /// random episode for a TV library.
+    private func shufflePlay() async {
+        let types: [ItemType] = collectionType == "tvshows" ? [.episode] : [.movie]
+        if let item = try? await JellyfinClient.shared.getRandomItem(parentId: libraryId, itemTypes: types) {
+            shuffleItem = item
         }
     }
 
@@ -148,10 +159,18 @@ struct MobileLibraryBrowseView: View {
         .searchable(text: $searchText, placement: .navigationBarDrawer(displayMode: .automatic))
         .toolbar {
             ToolbarItemGroup(placement: .topBarTrailing) {
+                if !isYouTubeLibrary {
+                    Button {
+                        Task { await shufflePlay() }
+                    } label: {
+                        Image(systemName: "shuffle")
+                    }
+                }
                 sortMenu
                 filterMenu
             }
         }
+        .fullScreenPlayer(item: $shuffleItem)
         .task {
             await loadItems()
         }

--- a/SashimiMobile/Views/Phone/PhoneDetailView.swift
+++ b/SashimiMobile/Views/Phone/PhoneDetailView.swift
@@ -500,6 +500,13 @@ struct PhoneDetailView: View {
             )
     }
 
+    /// Shuffle: play a random episode of this series.
+    private func shuffleEpisode() async {
+        if let ep = try? await JellyfinClient.shared.getRandomItem(parentId: contentSeriesId, itemTypes: [.episode]) {
+            playingItem = ep
+        }
+    }
+
     // MARK: - Action Buttons
 
     @ViewBuilder
@@ -543,6 +550,15 @@ struct PhoneDetailView: View {
                     .tint(.white)
                 }
             }
+
+            Button {
+                Task { await shuffleEpisode() }
+            } label: {
+                Image(systemName: "shuffle")
+                    .font(.system(size: 16))
+            }
+            .buttonStyle(.bordered)
+            .tint(.white)
 
             if let trailerURL, NetworkMonitor.shared.isConnected {
                 Button {

--- a/Shared/Services/JellyfinClient.swift
+++ b/Shared/Services/JellyfinClient.swift
@@ -681,6 +681,18 @@ actor JellyfinClient {
         return try JSONDecoder().decode(ItemsResponse.self, from: data)
     }
 
+    /// Fetches one random item for the Shuffle button. `parentId` is the
+    /// library or series id; `itemTypes` scopes to movies or episodes.
+    func getRandomItem(parentId: String, itemTypes: [ItemType]) async throws -> BaseItemDto? {
+        let response = try await getItems(
+            parentId: parentId,
+            includeTypes: itemTypes,
+            sortBy: "Random",
+            limit: 1
+        )
+        return response.items.first
+    }
+
     func getPlaybackInfo(
         itemId: String,
         maxBitrate: Int? = nil,


### PR DESCRIPTION
Plays one random item now — a header **Shuffle** button on Movies/TV libraries (random movie / random episode), and a **Shuffle** action on a TV show's detail (random episode of that show). New `getRandomItem` client helper (SortBy=Random, Limit=1). Hidden for YouTube libraries.

Three places: Movies library, TV library, individual TV show — matching Robert's request.

🤖 Generated with [Claude Code](https://claude.com/claude-code)