### PR TITLE
Local-first trailer (tvOS + iOS)

### DIFF
--- a/Sashimi/Views/Detail/MediaDetailView.swift
+++ b/Sashimi/Views/Detail/MediaDetailView.swift
@@ -735,6 +735,17 @@ struct MediaDetailView: View {
         }
     }
 
+    /// Play the item's local trailer inline; fall back to remote if none.
+    private func playLocalTrailer() async {
+        if let trailer = try? await JellyfinClient.shared.getLocalTrailers(itemId: item.id).first {
+            selectedEpisode = trailer
+            startFromBeginning = true
+            showingPlayer = true
+        } else {
+            showingTrailers = true
+        }
+    }
+
     /// Shuffle: play a random episode of this series.
     private func shuffleEpisode() async {
         let seriesId = isSeries ? item.id : (item.seriesId ?? item.id)
@@ -798,14 +809,19 @@ struct MediaDetailView: View {
                 }
             }
 
-            // Trailer button for movies and series with trailers
-            if !isEpisode, let trailers = item.remoteTrailers, !trailers.isEmpty {
+            // Trailer button — plays a local trailer inline (Trailarr) when one
+            // exists, else falls back to the remote (YouTube) hand-off.
+            if !isEpisode, (item.localTrailerCount ?? 0) > 0 || (item.remoteTrailers?.isEmpty == false) {
                 ActionButton(
                     title: "Trailer",
                     icon: "film",
                     isPrimary: false
                 ) {
-                    showingTrailers = true
+                    if (item.localTrailerCount ?? 0) > 0 {
+                        Task { await playLocalTrailer() }
+                    } else {
+                        showingTrailers = true
+                    }
                 }
             }
 

--- a/SashimiMobile/Views/Detail/MobileDetailView.swift
+++ b/SashimiMobile/Views/Detail/MobileDetailView.swift
@@ -713,11 +713,42 @@ struct MobileDetailView: View {
 
             watchedButton
 
+            if (item.localTrailerCount ?? 0) > 0 || (trailerURL != nil && NetworkMonitor.shared.isConnected) {
+                Button {
+                    if (item.localTrailerCount ?? 0) > 0 {
+                        Task { await playLocalTrailer() }
+                    } else if let trailerURL {
+                        Task { await UIApplication.shared.open(trailerURL) }
+                    }
+                } label: {
+                    Image(systemName: "film")
+                        .font(.system(size: 20))
+                        .foregroundStyle(MobileColors.textSecondary)
+                }
+                .buttonStyle(.bordered)
+                .tint(.white)
+            }
+
             if NetworkMonitor.shared.isConnected {
                 DownloadButton(item: item, quality: nil)
             }
 
             Spacer()
+        }
+    }
+
+    private var trailerURL: URL? {
+        guard let raw = item.remoteTrailers?.first?.url else { return nil }
+        return URL(string: raw)
+    }
+
+    /// Play the item's local trailer inline (Trailarr); falls back to the
+    /// remote URL if none is present.
+    private func playLocalTrailer() async {
+        if let trailer = try? await JellyfinClient.shared.getLocalTrailers(itemId: item.id).first {
+            playingItem = trailer
+        } else if let trailerURL {
+            await UIApplication.shared.open(trailerURL)
         }
     }
 

--- a/SashimiMobile/Views/Detail/MobileDetailView.swift
+++ b/SashimiMobile/Views/Detail/MobileDetailView.swift
@@ -911,7 +911,7 @@ struct MobileDetailView: View {
                 primaryImageAspectRatio: nil, mediaType: nil, productionYear: nil,
                 communityRating: nil, officialRating: nil, genres: nil, taglines: nil,
                 people: nil, criticRating: nil, premiereDate: nil, chapters: nil,
-                path: nil, remoteTrailers: nil, mediaStreams: nil
+                path: nil, remoteTrailers: nil, localTrailerCount: nil, mediaStreams: nil
             )
         }
 

--- a/SashimiMobile/Views/Offline/OfflineHomeView.swift
+++ b/SashimiMobile/Views/Offline/OfflineHomeView.swift
@@ -340,7 +340,7 @@ extension DownloadedItem {
             primaryImageAspectRatio: nil, mediaType: nil, productionYear: nil,
             communityRating: nil, officialRating: nil, genres: nil, taglines: nil,
             people: nil, criticRating: nil, premiereDate: nil, chapters: nil,
-            path: nil, remoteTrailers: nil, mediaStreams: nil
+            path: nil, remoteTrailers: nil, localTrailerCount: nil, mediaStreams: nil
         )
     }
 
@@ -383,6 +383,7 @@ extension DownloadedItem {
             chapters: nil,
             path: nil,
             remoteTrailers: nil,
+            localTrailerCount: nil,
             mediaStreams: nil
         )
     }

--- a/SashimiMobile/Views/Phone/PhoneDetailView.swift
+++ b/SashimiMobile/Views/Phone/PhoneDetailView.swift
@@ -500,6 +500,16 @@ struct PhoneDetailView: View {
             )
     }
 
+    /// Play the item's local trailer inline (Trailarr); falls back to the
+    /// remote URL if none is present.
+    private func playLocalTrailer() async {
+        if let trailer = try? await JellyfinClient.shared.getLocalTrailers(itemId: item.id).first {
+            playingItem = trailer
+        } else if let trailerURL {
+            await UIApplication.shared.open(trailerURL)
+        }
+    }
+
     /// Shuffle: play a random episode of this series.
     private func shuffleEpisode() async {
         if let ep = try? await JellyfinClient.shared.getRandomItem(parentId: contentSeriesId, itemTypes: [.episode]) {
@@ -560,9 +570,13 @@ struct PhoneDetailView: View {
             .buttonStyle(.bordered)
             .tint(.white)
 
-            if let trailerURL, NetworkMonitor.shared.isConnected {
+            if (item.localTrailerCount ?? 0) > 0 || (trailerURL != nil && NetworkMonitor.shared.isConnected) {
                 Button {
-                    UIApplication.shared.open(trailerURL)
+                    if (item.localTrailerCount ?? 0) > 0 {
+                        Task { await playLocalTrailer() }
+                    } else if let trailerURL {
+                        UIApplication.shared.open(trailerURL)
+                    }
                 } label: {
                     Image(systemName: "film")
                         .font(.system(size: 16))
@@ -708,9 +722,13 @@ struct PhoneDetailView: View {
                 .tint(.white)
             }
 
-            if let trailerURL, NetworkMonitor.shared.isConnected {
+            if (item.localTrailerCount ?? 0) > 0 || (trailerURL != nil && NetworkMonitor.shared.isConnected) {
                 Button {
-                    UIApplication.shared.open(trailerURL)
+                    if (item.localTrailerCount ?? 0) > 0 {
+                        Task { await playLocalTrailer() }
+                    } else if let trailerURL {
+                        UIApplication.shared.open(trailerURL)
+                    }
                 } label: {
                     Image(systemName: "film")
                         .font(.system(size: 16))
@@ -989,7 +1007,7 @@ struct PhoneDetailView: View {
                 primaryImageAspectRatio: nil, mediaType: nil, productionYear: nil,
                 communityRating: nil, officialRating: nil, genres: nil, taglines: nil,
                 people: nil, criticRating: nil, premiereDate: nil, chapters: nil,
-                path: nil, remoteTrailers: nil, mediaStreams: nil
+                path: nil, remoteTrailers: nil, localTrailerCount: nil, mediaStreams: nil
             )
         }
 

--- a/SashimiTests/DeepLinkTests.swift
+++ b/SashimiTests/DeepLinkTests.swift
@@ -70,7 +70,7 @@ final class DeepLinkTests: XCTestCase {
             primaryImageAspectRatio: nil, mediaType: nil, productionYear: nil,
             communityRating: nil, officialRating: nil, genres: nil,
             taglines: nil, people: nil, criticRating: nil,
-            premiereDate: nil, chapters: nil, path: nil, remoteTrailers: nil, mediaStreams: nil
+            premiereDate: nil, chapters: nil, path: nil, remoteTrailers: nil, localTrailerCount: nil, mediaStreams: nil
         )
     }
 

--- a/SashimiTests/HomeViewModelTests.swift
+++ b/SashimiTests/HomeViewModelTests.swift
@@ -94,7 +94,7 @@ final class HomeViewModelTests: XCTestCase {
             primaryImageAspectRatio: nil, mediaType: nil, productionYear: nil,
             communityRating: nil, officialRating: nil, genres: nil,
             taglines: nil, people: nil, criticRating: nil,
-            premiereDate: nil, chapters: nil, path: nil, remoteTrailers: nil, mediaStreams: nil
+            premiereDate: nil, chapters: nil, path: nil, remoteTrailers: nil, localTrailerCount: nil, mediaStreams: nil
         )
 
         let episode2 = BaseItemDto(
@@ -113,7 +113,7 @@ final class HomeViewModelTests: XCTestCase {
             primaryImageAspectRatio: nil, mediaType: nil, productionYear: nil,
             communityRating: nil, officialRating: nil, genres: nil,
             taglines: nil, people: nil, criticRating: nil,
-            premiereDate: nil, chapters: nil, path: nil, remoteTrailers: nil, mediaStreams: nil
+            premiereDate: nil, chapters: nil, path: nil, remoteTrailers: nil, localTrailerCount: nil, mediaStreams: nil
         )
 
         // Test that series deduplication works
@@ -144,7 +144,7 @@ final class HomeViewModelTests: XCTestCase {
             primaryImageAspectRatio: nil, mediaType: nil, productionYear: nil,
             communityRating: nil, officialRating: nil, genres: nil,
             taglines: nil, people: nil, criticRating: nil,
-            premiereDate: nil, chapters: nil, path: nil, remoteTrailers: nil, mediaStreams: nil
+            premiereDate: nil, chapters: nil, path: nil, remoteTrailers: nil, localTrailerCount: nil, mediaStreams: nil
         )
 
         let movie2 = BaseItemDto(
@@ -156,7 +156,7 @@ final class HomeViewModelTests: XCTestCase {
             primaryImageAspectRatio: nil, mediaType: nil, productionYear: nil,
             communityRating: nil, officialRating: nil, genres: nil,
             taglines: nil, people: nil, criticRating: nil,
-            premiereDate: nil, chapters: nil, path: nil, remoteTrailers: nil, mediaStreams: nil
+            premiereDate: nil, chapters: nil, path: nil, remoteTrailers: nil, localTrailerCount: nil, mediaStreams: nil
         )
 
         var seenIds = Set<String>()

--- a/SashimiTests/ModelTests.swift
+++ b/SashimiTests/ModelTests.swift
@@ -70,7 +70,7 @@ final class ModelTests: XCTestCase {
             primaryImageAspectRatio: nil, mediaType: nil, productionYear: nil,
             communityRating: nil, officialRating: nil, genres: nil,
             taglines: nil, people: nil, criticRating: nil,
-            premiereDate: nil, chapters: nil, path: nil, remoteTrailers: nil, mediaStreams: nil
+            premiereDate: nil, chapters: nil, path: nil, remoteTrailers: nil, localTrailerCount: nil, mediaStreams: nil
         )
         XCTAssertEqual(movie.displayTitle, "Test Movie")
 
@@ -84,7 +84,7 @@ final class ModelTests: XCTestCase {
             primaryImageAspectRatio: nil, mediaType: nil, productionYear: nil,
             communityRating: nil, officialRating: nil, genres: nil,
             taglines: nil, people: nil, criticRating: nil,
-            premiereDate: nil, chapters: nil, path: nil, remoteTrailers: nil, mediaStreams: nil
+            premiereDate: nil, chapters: nil, path: nil, remoteTrailers: nil, localTrailerCount: nil, mediaStreams: nil
         )
         XCTAssertEqual(episode.displayTitle, "Series Name S1E1")
     }
@@ -109,7 +109,7 @@ final class ModelTests: XCTestCase {
             primaryImageAspectRatio: nil, mediaType: nil, productionYear: nil,
             communityRating: nil, officialRating: nil, genres: nil,
             taglines: nil, people: nil, criticRating: nil,
-            premiereDate: nil, chapters: nil, path: nil, remoteTrailers: nil, mediaStreams: nil
+            premiereDate: nil, chapters: nil, path: nil, remoteTrailers: nil, localTrailerCount: nil, mediaStreams: nil
         )
 
         XCTAssertEqual(item.progressPercent, 0.5, accuracy: 0.01)

--- a/Shared/Models/JellyfinModels.swift
+++ b/Shared/Models/JellyfinModels.swift
@@ -80,6 +80,10 @@ struct BaseItemDto: Codable, Identifiable, Hashable {
     let chapters: [ChapterInfo]?
     let path: String?
     let remoteTrailers: [MediaUrl]?
+    /// Count of local trailer files (from Trailarr etc.) — present when the
+    /// query requests Fields=LocalTrailerCount. Drives the local-first Trailer
+    /// button (plays inline vs the remote YouTube hand-off).
+    let localTrailerCount: Int?
     /// Present only when the item query requests Fields=MediaStreams. Used for
     /// the resolution badge on cover art; nil for series/seasons (no stream).
     let mediaStreams: [MediaStream]?
@@ -126,6 +130,7 @@ struct BaseItemDto: Codable, Identifiable, Hashable {
         case chapters = "Chapters"
         case path = "Path"
         case remoteTrailers = "RemoteTrailers"
+        case localTrailerCount = "LocalTrailerCount"
     }
 
     func hash(into hasher: inout Hasher) {

--- a/Shared/Services/JellyfinClient.swift
+++ b/Shared/Services/JellyfinClient.swift
@@ -1058,12 +1058,20 @@ actor JellyfinClient {
         let data = try await request(
             path: "/Users/\(userId)/Items/\(itemId)",
             queryItems: [
-                URLQueryItem(name: "Fields", value: "Overview,PrimaryImageAspectRatio,CommunityRating,OfficialRating,Genres,Taglines,People,UserData,Chapters,ParentBackdropImageTags"),
+                URLQueryItem(name: "Fields", value: "Overview,PrimaryImageAspectRatio,CommunityRating,OfficialRating,Genres,Taglines,People,UserData,Chapters,ParentBackdropImageTags,RemoteTrailers,LocalTrailerCount"),
                 URLQueryItem(name: "EnableImageTypes", value: "Primary,Backdrop,Thumb")
             ]
         )
 
         return try JSONDecoder().decode(BaseItemDto.self, from: data)
+    }
+
+    /// Local trailer items (from Trailarr etc.) that Jellyfin exposes as
+    /// playable Trailer items. The endpoint returns a JSON array directly.
+    func getLocalTrailers(itemId: String) async throws -> [BaseItemDto] {
+        guard let userId else { throw JellyfinError.notConfigured }
+        let data = try await request(path: "/Users/\(userId)/Items/\(itemId)/LocalTrailers", queryItems: [])
+        return (try? JSONDecoder().decode([BaseItemDto].self, from: data)) ?? []
     }
 
     func getItemAncestors(itemId: String) async throws -> [BaseItemDto] {


### PR DESCRIPTION
Play a local trailer inline (Trailarr) when one exists, else fall back to the remote YouTube hand-off. New getLocalTrailers client helper + BaseItemDto.localTrailerCount. 🤖 Generated with [Claude Code](https://claude.com/claude-code)