### PR TITLE
fix: server-wizard cancel, blue links, tvOS home focus + nav guard

### DIFF
--- a/Sashimi/App/SashimiApp.swift
+++ b/Sashimi/App/SashimiApp.swift
@@ -157,6 +157,10 @@ struct MainTabView: View {
     @State private var libraries: [JellyfinLibrary] = []
     @State private var showServerSwitcher = false
     @State private var showAddServer = false
+    // One-shot: the hero grabs focus once on cold launch (the rail otherwise
+    // steals it while content is still loading). Also gates the edge guard so
+    // it doesn't interfere with that initial focus resolution.
+    @State private var didInitialHomeFocus = false
 
     private let railWidth: CGFloat = 120
     private let panelWidth: CGFloat = 340
@@ -173,6 +177,19 @@ struct MainTabView: View {
                 // Content wins initial focus so the app opens with the rail
                 // resting (collapsed), not auto-expanded onto Home.
                 .prefersDefaultFocus(true, in: mainScope)
+
+            // Invisible focus buffer at the rail/content seam. From content,
+            // one left press lands here (nothing visible happens); a second
+            // left press crosses into the rail — so the nav takes a deliberate
+            // double-press, not a single accidental swipe. Inert until the
+            // initial Home focus resolves, and only live while focus is in
+            // content, so exiting the rail stays a single right press.
+            Color.clear
+                .frame(width: 6)
+                .frame(maxHeight: .infinity)
+                .focusable(didInitialHomeFocus && focusedNav == nil)
+                .focusEffectDisabled()
+                .padding(.leading, railWidth)
 
             sidebar
         }
@@ -199,7 +216,7 @@ struct MainTabView: View {
     private var content: some View {
         switch selection {
         case .home, .avatar:
-            HomeView()
+            HomeView(focusNamespace: mainScope, onHeroReady: handleHeroReady)
         case .search:
             SearchView(onBackAtRoot: { selection = .home })
         case .settings:
@@ -209,8 +226,20 @@ struct MainTabView: View {
                 LibraryDetailView(library: LibraryView_Model(from: lib))
                     .id(id)  // rebuild the grid when switching libraries
             } else {
-                HomeView()
+                HomeView(focusNamespace: mainScope, onHeroReady: handleHeroReady)
             }
+        }
+    }
+
+    /// Cold-launch focus fix: the rail grabs focus while the hero is still
+    /// loading, so once the hero has content, drop rail focus and let the
+    /// hero (the mainScope default-focus target) take it. Runs once; the edge
+    /// guard is armed a beat later so it can't interfere with this handoff.
+    private func handleHeroReady() {
+        guard !didInitialHomeFocus, selection == .home || selection == .avatar else { return }
+        focusedNav = nil
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.6) {
+            didInitialHomeFocus = true
         }
     }
 

--- a/Sashimi/Theme/Theme.swift
+++ b/Sashimi/Theme/Theme.swift
@@ -8,6 +8,10 @@ enum SashimiTheme {
     static let accent = Color(red: 140 / 255, green: 92 / 255, blue: 199 / 255)
     static let accentSecondary = Color(red: 0.95, green: 0.65, blue: 0.25)
     static let highlight = Color(red: 140 / 255, green: 92 / 255, blue: 199 / 255)
+    // Interactive links / action glyphs (See All, Show More, the Continue
+    // Watching play symbol) — the original sky-blue accent, kept distinct from
+    // the purple brand accent so tappable affordances read as links.
+    static let link = Color(red: 0.36, green: 0.68, blue: 0.90)
     // Neutral focus/selection color — kept separate from the purple accent so
     // the ever-present focus ring stays quiet (native-tvOS feel) while purple
     // is reserved for deliberate accents (scrubber, progress, selected state).

--- a/Sashimi/Views/Auth/ServerConnectionView.swift
+++ b/Sashimi/Views/Auth/ServerConnectionView.swift
@@ -28,6 +28,10 @@ enum ServerValidationState: Equatable {
 // MARK: - Server Connection View
 
 struct ServerConnectionView: View {
+    /// When presented as a sheet (Add Server), this provides an explicit,
+    /// always-focusable way out — the initial login screen leaves it nil.
+    var onCancel: (() -> Void)?
+
     @EnvironmentObject private var sessionManager: SessionManager
     @StateObject private var serverDiscovery = ServerDiscovery()
 
@@ -248,6 +252,20 @@ struct ServerConnectionView: View {
             .frame(maxWidth: 600)
         }
         .padding(80)
+        .overlay(alignment: .topLeading) {
+            if let onCancel {
+                Button {
+                    onCancel()
+                } label: {
+                    HStack(spacing: 8) {
+                        Image(systemName: "chevron.left")
+                        Text("Cancel")
+                    }
+                    .font(.callout)
+                }
+                .padding(40)
+            }
+        }
         .onAppear {
             focusedField = .serverAddress
         }

--- a/Sashimi/Views/Home/ContinueWatchingRow.swift
+++ b/Sashimi/Views/Home/ContinueWatchingRow.swift
@@ -127,7 +127,7 @@ struct ContinueWatchingCard: View {
                         HStack(spacing: 10) {
                             Image(systemName: "play.fill")
                                 .font(.caption)
-                                .foregroundStyle(SashimiTheme.accent)
+                                .foregroundStyle(SashimiTheme.link)
 
                             Text(remainingTimeString)
                                 .font(.caption)

--- a/Sashimi/Views/Home/HomeView.swift
+++ b/Sashimi/Views/Home/HomeView.swift
@@ -4,6 +4,12 @@ import SwiftUI
 // HomeView contains the main home screen with multiple tightly-coupled components
 
 struct HomeView: View {
+    /// The parent focus scope (from MainTabView) so the hero can claim default
+    /// focus on Home — otherwise focus lands on the nav rail instead.
+    var focusNamespace: Namespace.ID?
+    /// Fired when the hero first has content — lets the parent pull focus off
+    /// the rail (which grabbed it while the hero was still loading).
+    var onHeroReady: (() -> Void)?
     @StateObject private var viewModel = HomeViewModel()
     @StateObject private var homeSettings = HomeScreenSettings.shared
     @EnvironmentObject private var sessionManager: SessionManager
@@ -93,6 +99,10 @@ struct HomeView: View {
         .task {
             await viewModel.loadContent()
             homeSettings.updateWithLibraries(viewModel.libraries)
+            if !viewModel.heroItems.isEmpty { onHeroReady?() }
+        }
+        .onChange(of: viewModel.heroItems.count) { _, count in
+            if count > 0 { onHeroReady?() }
         }
         .onAppear {
             // Initial load happens in .task above (and .task re-runs when the
@@ -130,6 +140,7 @@ struct HomeView: View {
                         items: viewModel.heroItems,
                         libraryNames: viewModel.heroItemLibraryNames,
                         currentIndex: $heroIndex,
+                        focusNamespace: focusNamespace,
                         onSelect: { item in
                             // Check if item comes from a library named YouTube
                             let libraryName = viewModel.heroItemLibraryNames[item.id] ?? ""
@@ -189,6 +200,7 @@ struct HeroSection: View {
     let items: [BaseItemDto]
     let libraryNames: [String: String]
     @Binding var currentIndex: Int
+    var focusNamespace: Namespace.ID?
     let onSelect: (BaseItemDto) -> Void
 
     @FocusState private var isFocused: Bool
@@ -466,6 +478,7 @@ struct HeroSection: View {
         }
         .buttonStyle(PlainNoHighlightButtonStyle())
         .focused($isFocused)
+        .defaultFocus(in: focusNamespace)
         .accessibilityElement(children: .combine)
         .accessibilityLabel(accessibilityDescription)
         .accessibilityHint("Double-tap to view details")
@@ -719,6 +732,20 @@ struct LoadingOverlay: View {
                     .font(.headline)
                     .foregroundStyle(SashimiTheme.textSecondary)
             }
+        }
+    }
+}
+
+private extension View {
+    /// Applies `prefersDefaultFocus` only when a namespace is supplied, so the
+    /// hero claims default focus on Home while leaving previews/other callers
+    /// (no namespace) untouched.
+    @ViewBuilder
+    func defaultFocus(in namespace: Namespace.ID?) -> some View {
+        if let namespace {
+            prefersDefaultFocus(true, in: namespace)
+        } else {
+            self
         }
     }
 }

--- a/Sashimi/Views/Library/SettingsView.swift
+++ b/Sashimi/Views/Library/SettingsView.swift
@@ -1184,7 +1184,7 @@ struct AddServerSheet: View {
     @State private var initialCount = 0
 
     var body: some View {
-        ServerConnectionView()
+        ServerConnectionView(onCancel: { dismiss() })
             .onAppear { initialCount = sessionManager.servers.count }
             .onChange(of: sessionManager.servers.count) { _, newCount in
                 if newCount > initialCount { dismiss() }

--- a/SashimiMobile/Theme/MobileTheme.swift
+++ b/SashimiMobile/Theme/MobileTheme.swift
@@ -9,6 +9,10 @@ enum MobileColors {
     // scrubber. On-brand with the logo/badges but calmer than the full-
     // saturation #BD3EED, which stays reserved for the quality badges.
     static let accent = Color(red: 140 / 255, green: 92 / 255, blue: 199 / 255)
+    // Interactive links / action glyphs (See All, Show More, the Continue
+    // Watching play symbol) — the original sky-blue accent, distinct from the
+    // purple brand accent so tappable affordances read as links.
+    static let link = Color(red: 0.36, green: 0.68, blue: 0.90)
     static let accentSecondary = Color(red: 0.95, green: 0.65, blue: 0.25)
     static let textPrimary = Color.white
     static let textSecondary = Color(white: 0.75)

--- a/SashimiMobile/Views/Components/MobileContinueWatchingCard.swift
+++ b/SashimiMobile/Views/Components/MobileContinueWatchingCard.swift
@@ -127,7 +127,7 @@ struct MobileContinueWatchingCard: View {
                     HStack(spacing: 6) {
                         Image(systemName: "play.fill")
                             .font(.system(size: 10))
-                            .foregroundStyle(MobileColors.accent)
+                            .foregroundStyle(MobileColors.link)
 
                         Text(remainingTimeText)
                             .font(.system(size: 11, weight: .medium))

--- a/SashimiMobile/Views/Components/MobileRecentlyAddedRow.swift
+++ b/SashimiMobile/Views/Components/MobileRecentlyAddedRow.swift
@@ -56,7 +56,7 @@ struct MobileRecentlyAddedRow<Destination: View>: View {
                     } label: {
                         Text("See All")
                             .font(MobileTypography.body)
-                            .foregroundStyle(MobileColors.accent)
+                            .foregroundStyle(MobileColors.link)
                     }
                 }
             }

--- a/SashimiMobile/Views/Phone/PhoneDetailView.swift
+++ b/SashimiMobile/Views/Phone/PhoneDetailView.swift
@@ -771,7 +771,7 @@ struct PhoneDetailView: View {
                 } label: {
                     Text(overviewExpanded ? "Show Less" : "Show More")
                         .font(MobileTypography.caption)
-                        .foregroundStyle(MobileColors.accent)
+                        .foregroundStyle(MobileColors.link)
                 }
             }
         }


### PR DESCRIPTION
- **Add Server wizard trap** → explicit Cancel button when presented as a sheet.
- **Blue links** (revert from purple): Continue Watching play symbol (tvOS+iOS), See All + Show More (iOS). New `link` color token.
- **tvOS Home hero default focus** → hero takes focus instead of the nav rail (fixes the async-load focus grab).
- **tvOS nav double-press-left** → invisible focus buffer so the rail needs a deliberate second press, not one accidental swipe.

The two tvOS focus behaviors need on-device verification. 🤖 Generated with [Claude Code](https://claude.com/claude-code)