### PR TITLE
fix(ios): Add Server Cancel hidden by nested NavigationStack

### DIFF
--- a/SashimiMobile/App/SashimiMobileApp.swift
+++ b/SashimiMobile/App/SashimiMobileApp.swift
@@ -68,7 +68,9 @@ struct ContentView: View {
                     await DownloadManager.shared.syncPendingProgress()
                 }
             } else {
-                MobileAuthView()
+                NavigationStack {
+                    MobileAuthView()
+                }
             }
         }
         .task {

--- a/SashimiMobile/Views/Auth/MobileAuthView.swift
+++ b/SashimiMobile/Views/Auth/MobileAuthView.swift
@@ -11,20 +11,21 @@ struct MobileAuthView: View {
     @State private var normalizedServerURL: URL?
 
     var body: some View {
-        NavigationStack {
-            Form {
-                if !showLogin {
-                    serverEntrySection
-                } else {
-                    loginSection
-                }
+        // No NavigationStack here on purpose: this view is always hosted inside
+        // one (the root login wraps it; the Add Server sheet wraps it with a
+        // Cancel toolbar). A nested stack here would shadow that Cancel button.
+        Form {
+            if !showLogin {
+                serverEntrySection
+            } else {
+                loginSection
             }
-            .navigationTitle(showLogin ? "Sign In" : "Connect to Server")
-            .alert("Error", isPresented: .constant(errorMessage != nil)) {
-                Button("OK") { errorMessage = nil }
-            } message: {
-                Text(errorMessage ?? "")
-            }
+        }
+        .navigationTitle(showLogin ? "Sign In" : "Connect to Server")
+        .alert("Error", isPresented: .constant(errorMessage != nil)) {
+            Button("OK") { errorMessage = nil }
+        } message: {
+            Text(errorMessage ?? "")
         }
     }
 


### PR DESCRIPTION
The Add Server sheet's Cancel toolbar was shadowed by MobileAuthView's own inner NavigationStack, trapping the user on the Connect to Server screen. Removed the inner stack; root login gets its own. iPhone + iPad. 🤖 Generated with [Claude Code](https://claude.com/claude-code)