### PR TITLE
fix: Add Server wipes the active session (stuck on Connect to Server)

### DIFF
--- a/Sashimi/Views/Library/SettingsView.swift
+++ b/Sashimi/Views/Library/SettingsView.swift
@@ -1189,6 +1189,11 @@ struct AddServerSheet: View {
             .onChange(of: sessionManager.servers.count) { _, newCount in
                 if newCount > initialCount { dismiss() }
             }
+            .onDisappear {
+                // Re-point the shared client at the active server after the
+                // probe, so the live session keeps working.
+                Task { await sessionManager.restoreActiveClient() }
+            }
             .onExitCommand { dismiss() }
     }
 }

--- a/SashimiMobile/Views/Settings/MobileSettingsView.swift
+++ b/SashimiMobile/Views/Settings/MobileSettingsView.swift
@@ -170,5 +170,10 @@ struct MobileAddServerSheet: View {
         .onChange(of: sessionManager.servers.count) { _, newCount in
             if newCount > initialCount { dismiss() }
         }
+        .onDisappear {
+            // The probe repointed the shared client at the candidate server;
+            // re-point it at whatever server is active now so the session works.
+            Task { await sessionManager.restoreActiveClient() }
+        }
     }
 }

--- a/Shared/Services/JellyfinClient.swift
+++ b/Shared/Services/JellyfinClient.swift
@@ -467,7 +467,15 @@ actor JellyfinClient {
                 if isAuthRequest {
                     throw JellyfinError.invalidCredentials
                 }
-                await SessionManager.shared.logout(reason: .sessionExpired)
+                // Only treat as session expiry when the request was against the
+                // ACTIVE server. During an Add Server probe the shared client is
+                // briefly pointed at a different server; a 401 there must not
+                // nuke the live session (that stranded users with a saved-but-
+                // tokenless server they couldn't re-add).
+                let activeURL = await SessionManager.shared.serverURL
+                if let activeURL, self.serverURL == activeURL {
+                    await SessionManager.shared.logout(reason: .sessionExpired)
+                }
                 throw JellyfinError.sessionExpired
             }
 

--- a/Shared/Services/SessionManager.swift
+++ b/Shared/Services/SessionManager.swift
@@ -168,12 +168,30 @@ final class SessionManager: ObservableObject {
 
         let result = try await JellyfinClient.shared.authenticate(username: username, password: password)
 
-        if servers.contains(where: { $0.url == serverURL && $0.userId == result.user.id }) {
-            // Restore the previously active server's client config.
-            if let current = activeServer, let token = KeychainHelper.get(forKey: tokenKey(current.id)) {
-                await activate(current, token: token)
+        if let existing = servers.first(where: { $0.url == serverURL && $0.userId == result.user.id }) {
+            // Server is already saved. If there's a live session for it, this is
+            // a genuine duplicate add — restore the active client and report it.
+            // Otherwise the entry survived a session-expiry/sign-out (token was
+            // dropped but the entry kept), so the user is re-authenticating:
+            // recover by re-saving the fresh token and reactivating, instead of
+            // stranding them on "already connected to that one".
+            let hasLiveSession = isAuthenticated
+                && activeServerId == existing.id
+                && KeychainHelper.get(forKey: tokenKey(existing.id)) != nil
+            if hasLiveSession {
+                if let current = activeServer, let token = KeychainHelper.get(forKey: tokenKey(current.id)) {
+                    await activate(current, token: token)
+                }
+                throw SessionError.duplicateServer
             }
-            throw SessionError.duplicateServer
+            guard KeychainHelper.save(result.accessToken, forKey: tokenKey(existing.id)) else {
+                await JellyfinClient.shared.clearCredentials()
+                throw SessionError.credentialStorageFailed
+            }
+            activeServerId = existing.id
+            saveServers()
+            await activate(existing, token: result.accessToken)
+            return
         }
 
         var serverName = serverURL.host ?? "Jellyfin"
@@ -208,6 +226,15 @@ final class SessionManager: ObservableObject {
     }
 
     /// Switch the active server (no-op if already active or unknown).
+    /// Re-point the shared client at the active server + token. Call after an
+    /// Add Server probe (which repoints the shared client at the candidate
+    /// server) so the live session keeps working when the sheet closes.
+    func restoreActiveClient() async {
+        guard let server = activeServer,
+              let token = KeychainHelper.get(forKey: tokenKey(server.id)) else { return }
+        await JellyfinClient.shared.configure(serverURL: server.url, accessToken: token, userId: server.userId)
+    }
+
     func switchServer(to id: String) async {
         guard id != activeServerId,
               let server = servers.first(where: { $0.id == id }),


### PR DESCRIPTION
**Root cause:** Add Server repoints the shared client at the candidate server; a background 401 there triggered a 'session expired' logout that dropped the token but kept the server entry — so restore failed and re-login hit 'already connected'. Trapped.

- 401→logout only when the request was against the **active** server
- `login()` **recovers** a saved-but-tokenless server instead of throwing duplicate
- `restoreActiveClient()` re-points the client at the active server when the sheet closes

tvOS + iOS. 🤖 Generated with [Claude Code](https://claude.com/claude-code)