### PR TITLE
fix(ios): remove redundant form-top Cancel

### DIFF
--- a/SashimiMobile/Views/Auth/MobileAuthView.swift
+++ b/SashimiMobile/Views/Auth/MobileAuthView.swift
@@ -20,16 +20,6 @@ struct MobileAuthView: View {
         // one (the root login wraps it; the Add Server sheet wraps it with a
         // Cancel toolbar). A nested stack here would shadow that Cancel button.
         Form {
-            if let onCancel {
-                Section {
-                    Button(role: .cancel) {
-                        onCancel()
-                    } label: {
-                        Label("Cancel", systemImage: "xmark.circle.fill")
-                            .foregroundStyle(.red)
-                    }
-                }
-            }
             if !showLogin {
                 serverEntrySection
             } else {


### PR DESCRIPTION
Add Server showed two Cancels; keep only the nav-bar one. 🤖 Generated with [Claude Code](https://claude.com/claude-code)