### PR TITLE
fix(ios): tapping a session-expired server re-authenticates it

### DIFF
--- a/SashimiMobile/App/SashimiMobileApp.swift
+++ b/SashimiMobile/App/SashimiMobileApp.swift
@@ -67,6 +67,21 @@ struct ContentView: View {
                 .task {
                     await DownloadManager.shared.syncPendingProgress()
                 }
+                // Re-auth a saved server whose session expired: tapping it in
+                // the switcher raises reauthServer; present a prefilled login.
+                .sheet(item: $sessionManager.reauthServer) { server in
+                    NavigationStack {
+                        MobileAuthView(
+                            onCancel: { sessionManager.reauthServer = nil },
+                            onComplete: { sessionManager.reauthServer = nil },
+                            prefillServerURL: server.url
+                        )
+                        .navigationBarTitleDisplayMode(.inline)
+                    }
+                    .onDisappear {
+                        Task { await sessionManager.restoreActiveClient() }
+                    }
+                }
             } else {
                 NavigationStack {
                     MobileAuthView()

--- a/SashimiMobile/Views/Auth/MobileAuthView.swift
+++ b/SashimiMobile/Views/Auth/MobileAuthView.swift
@@ -5,6 +5,12 @@ struct MobileAuthView: View {
     /// there's always an obvious way back. nil for the root login (nothing to
     /// cancel to).
     var onCancel: (() -> Void)?
+    /// Called after a successful sign-in — lets a presenting sheet dismiss even
+    /// when no new server was added (e.g. re-authenticating an existing one).
+    var onComplete: (() -> Void)?
+    /// Pre-fills and jumps straight to the password step for this server (used
+    /// to re-authenticate a saved server whose session expired).
+    var prefillServerURL: URL?
 
     @EnvironmentObject var sessionManager: SessionManager
     @State private var serverURL = ""
@@ -38,6 +44,13 @@ struct MobileAuthView: View {
             Button("OK") { errorMessage = nil }
         } message: {
             Text(errorMessage ?? "")
+        }
+        .task {
+            guard let prefillServerURL, !showLogin else { return }
+            await JellyfinClient.shared.configure(serverURL: prefillServerURL)
+            serverURL = prefillServerURL.absoluteString
+            normalizedServerURL = prefillServerURL
+            showLogin = true
         }
     }
 
@@ -165,6 +178,7 @@ struct MobileAuthView: View {
                 try await sessionManager.login(serverURL: url, username: username, password: password)
                 await MainActor.run {
                     isConnecting = false
+                    onComplete?()
                 }
             } catch {
                 await MainActor.run {

--- a/Shared/Services/SessionManager.swift
+++ b/Shared/Services/SessionManager.swift
@@ -47,6 +47,10 @@ final class SessionManager: ObservableObject {
     @Published private(set) var servers: [ServerConfig] = []
     @Published private(set) var activeServerId: String?
     @Published var logoutReason: LogoutReason?
+    /// Set when the user picks a saved server whose token was dropped by a past
+    /// session expiry — the UI presents a prefilled re-auth for it. Cleared on
+    /// success or cancel.
+    @Published var reauthServer: ServerConfig?
 
     private let serversKey = "servers"
     private let activeServerIdKey = "activeServerId"
@@ -236,9 +240,14 @@ final class SessionManager: ObservableObject {
     }
 
     func switchServer(to id: String) async {
-        guard id != activeServerId,
-              let server = servers.first(where: { $0.id == id }),
-              let token = KeychainHelper.get(forKey: tokenKey(server.id)) else { return }
+        guard id != activeServerId, let server = servers.first(where: { $0.id == id }) else { return }
+        guard let token = KeychainHelper.get(forKey: tokenKey(server.id)) else {
+            // Token was dropped by a past session expiry (the entry was kept so
+            // the user could re-authenticate). Prompt a prefilled re-auth
+            // instead of silently doing nothing when they tap this server.
+            reauthServer = server
+            return
+        }
         activeServerId = id
         saveServers()
         await activate(server, token: token)


### PR DESCRIPTION
Switching to a saved server whose token was dropped (past session expiry) silently no-oped — 'nothing happens'. Now it opens a prefilled re-auth (straight to password); signing in recovers and activates it. 🤖 Generated with [Claude Code](https://claude.com/claude-code)