### PR TITLE
fix(tvos): rail double-press from hero + entry lands on current section

### DIFF
--- a/Sashimi/App/SashimiApp.swift
+++ b/Sashimi/App/SashimiApp.swift
@@ -153,6 +153,7 @@ struct MainTabView: View {
     // (so the rail rests collapsed). Drives the pullout expansion.
     @FocusState private var focusedNav: NavID?
     @Namespace private var mainScope
+    @Namespace private var railScope
     @State private var selection: NavID = .home
     @State private var libraries: [JellyfinLibrary] = []
     @State private var showServerSwitcher = false
@@ -190,6 +191,9 @@ struct MainTabView: View {
                 .focusable(didInitialHomeFocus && focusedNav == nil)
                 .focusEffectDisabled()
                 .padding(.leading, railWidth)
+                // Its own focus section so it competes on equal footing with
+                // the rail's section for the leftward beam.
+                .focusSection()
 
             sidebar
         }
@@ -199,8 +203,16 @@ struct MainTabView: View {
         .task { await loadLibraries() }
         // Focus-driven: moving focus onto a nav item switches the content
         // behind the blur immediately — no click needed (Plex behavior).
-        .onChange(of: focusedNav) { _, newValue in
+        .onChange(of: focusedNav) { old, newValue in
             if let newValue, newValue != .avatar {
+                // Entering the rail from content: land on the CURRENT
+                // section's row, not whatever geometry picked — otherwise
+                // focus-follows-selection immediately switches the content
+                // underneath the user.
+                if old == nil, newValue != selection {
+                    focusedNav = selection
+                    return
+                }
                 selection = newValue
             }
         }
@@ -361,6 +373,9 @@ struct MainTabView: View {
                 .ignoresSafeArea()
         }
         .animation(.easeInOut(duration: 0.28), value: expanded)
+        // Scope so prefersDefaultFocus can steer entry to the current
+        // section's row (the onChange snap is the deterministic fallback).
+        .focusScope(railScope)
         .focusSection()
     }
 
@@ -387,6 +402,7 @@ struct MainTabView: View {
         }
         .buttonStyle(SidebarButtonStyle())
         .focused($focusedNav, equals: id)
+        .prefersDefaultFocus(id == selection, in: railScope)
     }
 
     /// Soft accent highlight in place of the tvOS default white focus platter.

--- a/Sashimi/Views/Home/HomeView.swift
+++ b/Sashimi/Views/Home/HomeView.swift
@@ -475,11 +475,15 @@ struct HeroSection: View {
                 RoundedRectangle(cornerRadius: 24)
                     .stroke(SashimiTheme.focus.opacity(isFocused ? 0.6 : 0), lineWidth: 4)
             )
-            .padding(.horizontal, 50)
             .scaleEffect(isFocused ? 1.01 : 1.0)
             .animation(.spring(response: 0.35, dampingFraction: 0.7), value: isFocused)
         }
         .buttonStyle(PlainNoHighlightButtonStyle())
+        // Padding OUTSIDE the button: with it inside, the hero's focus frame
+        // stretched to the rail seam and covered the invisible double-press
+        // buffer — the focus engine saw the buffer as inside the hero and
+        // skipped straight to the rail on a single left press.
+        .padding(.horizontal, 50)
         .focused($isFocused)
         .defaultFocus(in: focusNamespace)
         .accessibilityElement(children: .combine)


### PR DESCRIPTION
- Hero's internal padding covered the double-press buffer → single left press entered the rail. Padding moved outside the button; buffer gets its own focusSection.
- Entering the rail now focuses the section you're already on (prefersDefaultFocus + onChange snap) instead of switching your screen. 🤖 Generated with [Claude Code](https://claude.com/claude-code)