### PR TITLE
feat(ipad): search poster grid + avatar server switcher

### DIFF
--- a/SashimiMobile/Views/Navigation/SidebarView.swift
+++ b/SashimiMobile/Views/Navigation/SidebarView.swift
@@ -46,6 +46,7 @@ struct MainNavigationView: View {
     @State private var sidebarWidth: CGFloat = 200
     @State private var navigationResetId: Int = 0
     @ObservedObject private var sessionManager = SessionManager.shared
+    @State private var showAddServer = false
     @ObservedObject private var downloadManager = DownloadManager.shared
     @ObservedObject private var networkMonitor = NetworkMonitor.shared
 
@@ -247,11 +248,36 @@ struct MainNavigationView: View {
                 downloadIndicator
             }
 
-            userAvatarView
+            // Quick server switcher (iPad equivalent of the phone's logo-tap
+            // menu) — the avatar was previously display-only.
+            Menu {
+                ForEach(sessionManager.servers) { server in
+                    Button {
+                        Task { await sessionManager.switchServer(to: server.id) }
+                    } label: {
+                        if server.id == sessionManager.activeServerId {
+                            Label(server.name, systemImage: "checkmark")
+                        } else {
+                            Text(server.name)
+                        }
+                    }
+                }
+                Divider()
+                Button {
+                    showAddServer = true
+                } label: {
+                    Label("Add Server…", systemImage: "plus")
+                }
+            } label: {
+                userAvatarView
+            }
         }
         .padding(.horizontal, MobileSpacing.md)
         .padding(.vertical, MobileSpacing.sm)
         .background(MobileColors.background)
+        .sheet(isPresented: $showAddServer) {
+            MobileAddServerSheet()
+        }
     }
 
     @ViewBuilder

--- a/SashimiMobile/Views/Search/MobileSearchView.swift
+++ b/SashimiMobile/Views/Search/MobileSearchView.swift
@@ -27,6 +27,7 @@ private enum RecentSearches {
 }
 
 struct MobileSearchView: View {
+    @Environment(\.horizontalSizeClass) private var sizeClass
     @State private var searchText = ""
     @State private var searchResults: [BaseItemDto] = []
     @State private var isSearching = false
@@ -35,58 +36,48 @@ struct MobileSearchView: View {
     // that returned results (avoids logging every keystroke prefix).
     @State private var historyTask: Task<Void, Never>?
 
+    // Same column math as MobileLibraryBrowseView so search results read as
+    // the same surface as library browsing.
+    private func gridMetrics(availableWidth: CGFloat) -> (columns: [GridItem], cardWidth: CGFloat) {
+        let spacing = MobileSpacing.md
+        let avail = availableWidth - spacing * 2
+        let target: CGFloat = sizeClass == .compact ? 118 : 165
+        let count = max(2, Int((avail + spacing) / (target + spacing)))
+        let cardWidth = floor((avail - spacing * CGFloat(count - 1)) / CGFloat(count))
+        let cols = Array(repeating: GridItem(.fixed(cardWidth), spacing: spacing), count: count)
+        return (cols, cardWidth)
+    }
+
     var body: some View {
-        List {
-            if searchText.isEmpty {
-                if recentSearches.isEmpty {
-                    ContentUnavailableView(
-                        "Search",
-                        systemImage: "magnifyingglass",
-                        description: Text("Search for movies, shows, and more.")
-                    )
-                } else {
-                    Section {
-                        ForEach(recentSearches, id: \.self) { query in
-                            Button {
-                                searchText = query
-                            } label: {
-                                Label(query, systemImage: "clock.arrow.circlepath")
-                                    .foregroundStyle(MobileColors.textPrimary)
-                            }
-                        }
-                        Button {
-                            recentSearches = RecentSearches.clear()
-                        } label: {
-                            Text("Clear Recent Searches")
-                                .foregroundStyle(MobileColors.link)
-                        }
-                    } header: {
-                        Text("Recent Searches")
+        GeometryReader { geo in
+            ScrollView {
+                if searchText.isEmpty {
+                    if recentSearches.isEmpty {
+                        ContentUnavailableView(
+                            "Search",
+                            systemImage: "magnifyingglass",
+                            description: Text("Search for movies, shows, and more.")
+                        )
+                        .frame(minHeight: 300)
+                    } else {
+                        recentSearchesSection
                     }
-                }
-            } else if isSearching {
-                HStack {
-                    Spacer()
+                } else if isSearching && searchResults.isEmpty {
                     ProgressView()
-                    Spacer()
-                }
-            } else if searchResults.isEmpty {
-                ContentUnavailableView(
-                    "No Results",
-                    systemImage: "magnifyingglass",
-                    description: Text("No results found for \"\(searchText)\"")
-                )
-            } else {
-                ForEach(searchResults, id: \.id) { item in
-                    NavigationLink {
-                        AdaptiveDetailView(item: item)
-                    } label: {
-                        SearchResultRow(item: item)
-                    }
+                        .frame(maxWidth: .infinity, minHeight: 300)
+                } else if searchResults.isEmpty {
+                    ContentUnavailableView(
+                        "No Results",
+                        systemImage: "magnifyingglass",
+                        description: Text("No results found for \"\(searchText)\"")
+                    )
+                    .frame(minHeight: 300)
+                } else {
+                    resultsGrid(metrics: gridMetrics(availableWidth: geo.size.width))
                 }
             }
         }
-        .listStyle(.plain)
+        .background(MobileColors.background)
         .navigationTitle("Search")
         .searchable(text: $searchText, prompt: "Movies, shows, and more")
         .onChange(of: searchText) { _, newValue in
@@ -105,6 +96,102 @@ struct MobileSearchView: View {
         }
     }
 
+    // MARK: - Recent searches (chips)
+
+    private var recentSearchesSection: some View {
+        VStack(alignment: .leading, spacing: MobileSpacing.sm) {
+            Text("Recent Searches")
+                .font(MobileTypography.headline)
+                .foregroundStyle(MobileColors.textPrimary)
+
+            ScrollView(.horizontal, showsIndicators: false) {
+                HStack(spacing: MobileSpacing.xs) {
+                    ForEach(recentSearches, id: \.self) { query in
+                        Button {
+                            searchText = query
+                        } label: {
+                            Label(query, systemImage: "clock.arrow.circlepath")
+                                .font(MobileTypography.bodySmall)
+                                .foregroundStyle(MobileColors.textPrimary)
+                                .padding(.horizontal, 14)
+                                .padding(.vertical, 8)
+                                .background(MobileColors.cardBackground)
+                                .clipShape(Capsule())
+                        }
+                    }
+
+                    Button {
+                        recentSearches = RecentSearches.clear()
+                    } label: {
+                        Text("Clear")
+                            .font(MobileTypography.bodySmall)
+                            .foregroundStyle(MobileColors.link)
+                            .padding(.horizontal, 14)
+                            .padding(.vertical, 8)
+                            .overlay(Capsule().stroke(MobileColors.cardBackground, lineWidth: 1))
+                    }
+                }
+            }
+        }
+        .padding(.horizontal, MobileSpacing.md)
+        .padding(.top, MobileSpacing.sm)
+        .frame(maxWidth: .infinity, alignment: .leading)
+    }
+
+    // MARK: - Results grid
+
+    private func resultsGrid(metrics: (columns: [GridItem], cardWidth: CGFloat)) -> some View {
+        VStack(alignment: .leading, spacing: MobileSpacing.sm) {
+            Text(searchResults.count == 1 ? "1 result" : "\(searchResults.count) results")
+                .font(MobileTypography.caption)
+                .foregroundStyle(MobileColors.textTertiary)
+                .padding(.horizontal, MobileSpacing.md)
+
+            LazyVGrid(columns: metrics.columns, alignment: .leading, spacing: MobileSpacing.md) {
+                ForEach(searchResults, id: \.id) { item in
+                    NavigationLink {
+                        AdaptiveDetailView(item: item)
+                    } label: {
+                        VStack(alignment: .leading, spacing: 2) {
+                            MobileRecentlyAddedCard(
+                                item: item,
+                                width: metrics.cardWidth,
+                                libraryName: nil,
+                                isCircular: false,
+                                isLandscape: false,
+                                badgeCount: nil
+                            )
+                            Text(subtitleText(item))
+                                .font(MobileTypography.captionSmall)
+                                .foregroundStyle(MobileColors.textTertiary)
+                                .lineLimit(1)
+                        }
+                        .frame(width: metrics.cardWidth)
+                    }
+                    .buttonStyle(.plain)
+                }
+            }
+            .padding(.horizontal, MobileSpacing.md)
+        }
+        .padding(.top, MobileSpacing.xs)
+    }
+
+    /// "2024 · Movie" secondary line under each result card.
+    private func subtitleText(_ item: BaseItemDto) -> String {
+        var parts: [String] = []
+        if let year = item.productionYear { parts.append(String(year)) }
+        if let type = item.type {
+            switch type {
+            case .movie: parts.append("Movie")
+            case .series: parts.append("Series")
+            case .episode: parts.append("Episode")
+            case .boxSet: parts.append("Collection")
+            default: break
+            }
+        }
+        return parts.joined(separator: " · ")
+    }
+
     private func performSearch(query: String) async {
         guard !query.isEmpty else {
             searchResults = []
@@ -119,75 +206,5 @@ struct MobileSearchView: View {
         } catch {
             searchResults = []
         }
-    }
-}
-
-private struct SearchResultRow: View {
-    let item: BaseItemDto
-
-    private var posterURL: URL? {
-        guard let serverURL = UserDefaults.standard.string(forKey: "serverURL") else { return nil }
-        return URL(string: "\(serverURL)/Items/\(item.id)/Images/Primary?maxWidth=200")
-    }
-
-    private func iconForType(_ type: ItemType) -> String {
-        switch type {
-        case .movie:
-            return "film"
-        case .series:
-            return "tv"
-        case .episode:
-            return "play.rectangle"
-        case .season:
-            return "tv"
-        case .boxSet:
-            return "square.stack"
-        default:
-            return "photo"
-        }
-    }
-
-    var body: some View {
-        HStack(spacing: MobileSpacing.sm) {
-            LazyImage(url: posterURL) { state in
-                if let image = state.image {
-                    image
-                        .resizable()
-                        .aspectRatio(contentMode: .fill)
-                } else {
-                    RoundedRectangle(cornerRadius: MobileCornerRadius.small)
-                        .fill(MobileColors.cardBackground)
-                        .overlay {
-                            Image(systemName: iconForType(item.type ?? .unknown))
-                                .font(.system(size: 20))
-                                .foregroundStyle(MobileColors.textTertiary)
-                        }
-                }
-            }
-            .frame(width: 60, height: 90)
-            .clipShape(RoundedRectangle(cornerRadius: MobileCornerRadius.small))
-
-            VStack(alignment: .leading, spacing: MobileSpacing.xxs) {
-                Text(item.name)
-                    .font(MobileTypography.title)
-                    .foregroundStyle(MobileColors.textPrimary)
-                    .lineLimit(2)
-
-                if let year = item.productionYear {
-                    Text(String(year))
-                        .font(MobileTypography.bodySmall)
-                        .foregroundStyle(MobileColors.textSecondary)
-                }
-
-                if let type = item.type {
-                    Label(type.rawValue.capitalized, systemImage: iconForType(type))
-                        .font(MobileTypography.caption)
-                        .foregroundStyle(MobileColors.textTertiary)
-                }
-            }
-
-            Spacer()
-        }
-        .padding(.vertical, MobileSpacing.xxs)
     }
 }


### PR DESCRIPTION
- Search results as the Library-style adaptive poster grid (count line, year/type captions); recent searches as chips. Fixes the stretched bare-list mess on iPad; iPhone gets the same upgrade.
- iPad header avatar becomes the quick server-switch menu (+ Add Server) — was display-only. 🤖 Generated with [Claude Code](https://claude.com/claude-code)