### PR TITLE
fix(mobile): missing cast — detail renders from the refreshed full item

### DIFF
--- a/SashimiMobile/Views/Detail/MobileDetailView.swift
+++ b/SashimiMobile/Views/Detail/MobileDetailView.swift
@@ -6,7 +6,11 @@ import NukeUI
 // MobileDetailView handles movies, series, and episodes in one view - splitting would fragment related display logic
 
 struct MobileDetailView: View {
-    let item: BaseItemDto
+    // @State (tvOS parity): list/search endpoints omit heavy fields like
+    // People, so the .task refresh swaps in the full item — with a plain
+    // `let`, cast (and other detail-only fields) silently never showed for
+    // items opened from search.
+    @State var item: BaseItemDto
     var libraryName: String?
     @State private var playingItem: BaseItemDto?
     @State private var startOverItem: BaseItemDto?
@@ -219,6 +223,7 @@ struct MobileDetailView: View {
         .task {
             if NetworkMonitor.shared.isConnected,
                let freshItem = try? await JellyfinClient.shared.getItem(itemId: item.id) {
+                item = freshItem
                 isWatched = freshItem.userData?.played ?? false
                 hasProgress = freshItem.progressPercent > 0
             } else {

--- a/SashimiMobile/Views/Phone/PhoneDetailView.swift
+++ b/SashimiMobile/Views/Phone/PhoneDetailView.swift
@@ -6,7 +6,11 @@ import NukeUI
 // PhoneDetailView handles movies, series, and episodes in one stacked layout - splitting would fragment related display logic
 
 struct PhoneDetailView: View {
-    let item: BaseItemDto
+    // @State (tvOS parity): list/search endpoints omit heavy fields like
+    // People, so the .task refresh swaps in the full item — with a plain
+    // `let`, cast (and other detail-only fields) silently never showed for
+    // items opened from search.
+    @State var item: BaseItemDto
     var libraryName: String?
 
     // MARK: - State (mirrored from MobileDetailView)
@@ -127,6 +131,7 @@ struct PhoneDetailView: View {
         .task {
             if NetworkMonitor.shared.isConnected,
                let freshItem = try? await JellyfinClient.shared.getItem(itemId: item.id) {
+                item = freshItem
                 isWatched = freshItem.userData?.played ?? false
                 hasProgress = freshItem.progressPercent > 0
             } else {


### PR DESCRIPTION
Search/list endpoints omit People; mobile detail views rendered the passed-in item and discarded the fresh getItem (which has People). item is now @State swapped by the refresh — tvOS pattern. Fixes cast missing on iPad/iPhone for search-opened items. 🤖 Generated with [Claude Code](https://claude.com/claude-code)