### PR TITLE
Revert: Mark Series as Watched from Continue Watching

### DIFF
--- a/Sashimi/Views/Home/ContinueWatchingRow.swift
+++ b/Sashimi/Views/Home/ContinueWatchingRow.swift
@@ -6,7 +6,6 @@ struct ContinueWatchingRow: View {
     let onSelect: (BaseItemDto) -> Void
     var onPlay: ((BaseItemDto) -> Void)?  // Optional: immediate playback on Play button
     var onSeeAll: (() -> Void)?  // Optional: opens the full Continue Watching grid
-    var onChange: (() -> Void)?  // Fired after a card context-menu mutation
 
     private func isYouTube(_ item: BaseItemDto) -> Bool {
         guard let libraryName = libraryNames[item.id] else { return false }
@@ -27,8 +26,7 @@ struct ContinueWatchingRow: View {
                             item: item,
                             isYouTube: isYouTube(item),
                             onSelect: { onSelect(item) },
-                            onPlayPause: onPlay != nil ? { onPlay?(item) } : nil,
-                            onChange: onChange
+                            onPlayPause: onPlay != nil ? { onPlay?(item) } : nil
                         )
                     }
 
@@ -82,7 +80,6 @@ struct ContinueWatchingCard: View {
     var isYouTube: Bool = false  // Whether this is YouTube content
     let onSelect: () -> Void
     var onPlayPause: (() -> Void)?  // Optional: immediate playback on Play/Pause button
-    var onChange: (() -> Void)?  // Fired after a context-menu mutation (row refresh)
 
     @FocusState private var isFocused: Bool
 
@@ -223,30 +220,6 @@ struct ContinueWatchingCard: View {
         .accessibilityElement(children: .combine)
         .accessibilityLabel(accessibilityDescription)
         .accessibilityHint("Double-tap to resume playback, or press Play to start immediately")
-        .contextMenu {
-            // Marking a CW EPISODE watched only advances Next Up to the next
-            // episode — the show never leaves the row. Marking the SERIES
-            // watched is the only Jellyfin mechanism that removes it
-            // (verified vs 10.11; there is no hide-from-next-up endpoint).
-            if item.type == .episode, let seriesId = item.seriesId {
-                Button {
-                    Task {
-                        try? await JellyfinClient.shared.markPlayed(itemId: seriesId)
-                        onChange?()
-                    }
-                } label: {
-                    Label("Mark Series as Watched", systemImage: "eye.circle")
-                }
-            }
-            Button {
-                Task {
-                    try? await JellyfinClient.shared.markPlayed(itemId: item.id)
-                    onChange?()
-                }
-            } label: {
-                Label(item.type == .episode ? "Mark Episode as Watched" : "Mark as Watched", systemImage: "eye")
-            }
-        }
         .onPlayPauseCommand {
             if let playPause = onPlayPause {
                 playPause()

--- a/Sashimi/Views/Home/HomeView.swift
+++ b/Sashimi/Views/Home/HomeView.swift
@@ -168,9 +168,6 @@ struct HomeView: View {
                         },
                         onSeeAll: {
                             showContinueWatchingDetail = true
-                        },
-                        onChange: {
-                            Task { await viewModel.refresh() }
                         }
                     )
                     .focusSection()

--- a/SashimiMobile/Views/Components/ItemContextMenu.swift
+++ b/SashimiMobile/Views/Components/ItemContextMenu.swift
@@ -4,43 +4,19 @@ import SwiftUI
 
 struct ItemContextMenu: View {
     let item: BaseItemDto
-    /// Fired after a mutation so the hosting row can refresh (optional).
-    var onChange: (() -> Void)?
 
     var body: some View {
         if item.userData?.played == true {
             Button {
-                Task {
-                    try? await JellyfinClient.shared.markUnplayed(itemId: item.id)
-                    onChange?()
-                }
+                Task { try? await JellyfinClient.shared.markUnplayed(itemId: item.id) }
             } label: {
                 Label("Mark as Unwatched", systemImage: "eye.slash")
             }
         } else {
             Button {
-                Task {
-                    try? await JellyfinClient.shared.markPlayed(itemId: item.id)
-                    onChange?()
-                }
+                Task { try? await JellyfinClient.shared.markPlayed(itemId: item.id) }
             } label: {
                 Label("Mark as Watched", systemImage: "eye")
-            }
-        }
-
-        // Episodes in Continue Watching: marking the EPISODE watched just
-        // advances Next Up to the next episode — the show never leaves the
-        // row. Marking the whole SERIES watched is the only mechanism the
-        // Jellyfin API offers to dismiss a show from Continue Watching
-        // (verified against 10.11; no hide-from-next-up endpoint exists).
-        if item.type == .episode, let seriesId = item.seriesId {
-            Button {
-                Task {
-                    try? await JellyfinClient.shared.markPlayed(itemId: seriesId)
-                    onChange?()
-                }
-            } label: {
-                Label("Mark Series as Watched", systemImage: "eye.circle")
             }
         }
 


### PR DESCRIPTION
Per user: pulling the 'Mark Series as Watched' addition. Reverts #270 across iOS context menu + tvOS CW long-press menu. The real CW fix (refresh-on-return) lives on Roku's watchStateDirty and is unaffected. 🤖 Generated with [Claude Code](https://claude.com/claude-code)