### PR TITLE
fix(ios): downloads + subtitles broken on fresh multi-server installs

### DIFF
--- a/SashimiMobile/Downloads/Services/DownloadManager.swift
+++ b/SashimiMobile/Downloads/Services/DownloadManager.swift
@@ -596,6 +596,25 @@ extension DownloadManager: URLSessionDownloadDelegate {
         let itemId: String? = UserDefaults.standard.dictionary(forKey: Self.taskMapKey)?[String(taskId)] as? String
         guard let itemId else { return }
 
+        // A background download task reports HTTP 4xx/5xx here (not as a
+        // transport error), with the error page as the "downloaded" body.
+        // Without this guard we'd move that page to video.mp4 and mark the
+        // item COMPLETED — a broken file masquerading as a finished download.
+        if let http = downloadTask.response as? HTTPURLResponse, !(200...299).contains(http.statusCode) {
+            Task { @MainActor in
+                self.persistence.updateStatus(itemId: itemId, status: .failed, errorMessage: "Server returned HTTP \(http.statusCode)")
+                self.pendingProgress.removeValue(forKey: itemId)
+                self.activeDownloads.removeValue(forKey: itemId)
+                self.preparingItems.remove(itemId)
+                var map = self.taskIdMap
+                map.removeValue(forKey: self.taskKey(taskId))
+                self.taskIdMap = map
+                self.stateVersion += 1
+                self.dequeueNext()
+            }
+            return
+        }
+
         let destination = DownloadFileManager.videoPath(for: itemId, container: ext)
         let moveError: Error?
         do {

--- a/Shared/Services/SessionManager.swift
+++ b/Shared/Services/SessionManager.swift
@@ -155,6 +155,14 @@ final class SessionManager: ObservableObject {
         UserDefaults.standard.set(server.url.absoluteString, forKey: "serverURL")
         UserDefaults.standard.set(server.userId, forKey: "userId")
         UserDefaults.standard.set(server.username, forKey: "userName")
+        // The token, too: DownloadURLBuilder and SubtitleManager authorize their
+        // background requests off the global "accessToken" keychain key. Without
+        // this mirror a fresh multi-server install (no legacy token to inherit)
+        // has an empty global key, so every download and external-subtitle fetch
+        // fails instantly with "Could not build download URL". Per-server tokens
+        // live under "accessToken.<id>"; this keeps the active one in the global
+        // slot those two consumers read.
+        _ = KeychainHelper.save(token, forKey: keychainAccessTokenKey)
         await JellyfinClient.shared.configure(serverURL: server.url, accessToken: token, userId: server.userId)
         self.serverURL = server.url
         self.currentUser = UserDto(id: server.userId, name: server.username, serverID: nil, primaryImageTag: nil)
@@ -292,6 +300,9 @@ final class SessionManager: ObservableObject {
                 Task { await removeServer(id: active) }
             }
         }
+        // Clear the mirrored global token so a signed-out app can't authorize a
+        // download/subtitle fetch with the last session's token.
+        KeychainHelper.delete(forKey: keychainAccessTokenKey)
         Task { await JellyfinClient.shared.clearCredentials() }
         self.serverURL = nil
         self.currentUser = nil


### PR DESCRIPTION
**chad's immediate download failure.** Multi-server stores tokens per-server (`accessToken.<id>`) and migration deletes the legacy global `accessToken`. `activate()` mirrors serverURL/userId/userName to the legacy globals but forgot the token — and `DownloadURLBuilder`/`SubtitleManager` authorize off that global key. Fresh install → empty global key → `authorizedRequest` nil → instant "Could not build download URL". Subtitles broke identically.

Fix: mirror the active token into the global key in `activate()`; clear it on logout. Also hardened `didFinishDownloadingTo` to check HTTP status (a background task reports 4xx/5xx there with the error page as body — we were saving it as a fake-completed video.mp4). 🤖 Generated with [Claude Code](https://claude.com/claude-code)