### PR TITLE
fix(tvos): can't enter Search/Settings from the rail

### DIFF
--- a/Sashimi/App/SashimiApp.swift
+++ b/Sashimi/App/SashimiApp.swift
@@ -243,9 +243,9 @@ struct MainTabView: View {
         case .home, .avatar:
             HomeView(focusNamespace: mainScope, onHeroReady: handleHeroReady)
         case .search:
-            SearchView(onBackAtRoot: { selection = .home })
+            SearchView(onBackAtRoot: { selection = .home }, focusNamespace: mainScope)
         case .settings:
-            SettingsView(onBackAtRoot: { selection = .home })
+            SettingsView(onBackAtRoot: { selection = .home }, focusNamespace: mainScope)
         case .library(let id):
             if let lib = libraries.first(where: { $0.id == id }) {
                 LibraryDetailView(library: LibraryView_Model(from: lib))

--- a/Sashimi/Views/Library/SearchView.swift
+++ b/Sashimi/Views/Library/SearchView.swift
@@ -56,6 +56,10 @@ final class SearchHistoryManager: ObservableObject {
 
 struct SearchView: View {
     var onBackAtRoot: (() -> Void)?
+    /// Supplied by the rail so the search field can claim default focus in the
+    /// shared main scope — without it, pressing Right from the Search rail row
+    /// has no designated target and focus never enters this screen.
+    var focusNamespace: Namespace.ID?
     @State private var searchText = ""
     @State private var results: [BaseItemDto] = []
     @State private var isSearching = false
@@ -69,8 +73,9 @@ struct SearchView: View {
     @FocusState private var isSearchFieldFocused: Bool
     @FocusState private var isClearButtonFocused: Bool
 
-    init(onBackAtRoot: (() -> Void)? = nil) {
+    init(onBackAtRoot: (() -> Void)? = nil, focusNamespace: Namespace.ID? = nil) {
         self.onBackAtRoot = onBackAtRoot
+        self.focusNamespace = focusNamespace
     }
 
     // Detect YouTube content by checking if we've identified it as YouTube
@@ -128,6 +133,7 @@ struct SearchView: View {
                     TextField("Search movies, shows...", text: $searchText)
                         .textFieldStyle(.plain)
                         .font(.title3)
+                        .defaultFocus(in: focusNamespace)
 
                     // Clear button - show when there's text OR results
                     if !searchText.isEmpty || !results.isEmpty {
@@ -336,4 +342,18 @@ struct RecentSearchButton: View {
 
 #Preview {
     SearchView()
+}
+
+private extension View {
+    /// Claims default focus only when the rail supplies its shared namespace,
+    /// so the rightward beam from the Search rail row lands here. Previews (no
+    /// namespace) are untouched.
+    @ViewBuilder
+    func defaultFocus(in namespace: Namespace.ID?) -> some View {
+        if let namespace {
+            prefersDefaultFocus(true, in: namespace)
+        } else {
+            self
+        }
+    }
 }

--- a/Sashimi/Views/Library/SettingsView.swift
+++ b/Sashimi/Views/Library/SettingsView.swift
@@ -17,6 +17,10 @@ struct SettingsView: View {
 
     var showSignOut: Bool = true
     var onBackAtRoot: (() -> Void)?
+    /// Supplied by the rail so the first settings row can claim default focus
+    /// in the shared main scope — without it, pressing Right from the Settings
+    /// rail row has no designated target and focus never enters this screen.
+    var focusNamespace: Namespace.ID?
     @EnvironmentObject private var sessionManager: SessionManager
     @State private var showingLogoutConfirmation = false
     @State private var navigationPath = NavigationPath()
@@ -37,6 +41,7 @@ struct SettingsView: View {
                             ) {
                                 navigationPath.append(SettingsDestination.servers)
                             }
+                            .defaultFocus(in: focusNamespace)
 
                             SettingsOptionRow(
                                 icon: "house",
@@ -1195,5 +1200,19 @@ struct AddServerSheet: View {
                 Task { await sessionManager.restoreActiveClient() }
             }
             .onExitCommand { dismiss() }
+    }
+}
+
+private extension View {
+    /// Claims default focus only when the rail supplies its shared namespace,
+    /// so the rightward beam from the Settings rail row lands here. Callers
+    /// without a namespace (previews) are untouched.
+    @ViewBuilder
+    func defaultFocus(in namespace: Namespace.ID?) -> some View {
+        if let namespace {
+            prefersDefaultFocus(true, in: namespace)
+        } else {
+            self
+        }
     }
 }


### PR DESCRIPTION
From the rail you could highlight Search/Settings but Right wouldn't enter them (Home/libraries worked). They designated no prefersDefaultFocus target in the main scope, so the rightward beam from the bottom rail rows had nothing to land on. Fix: pass the main-scope namespace to both views and mark their first focusable with prefersDefaultFocus(in:), mirroring HomeView. 🤖 Generated with [Claude Code](https://claude.com/claude-code)