### PR TITLE
feat: show TMDb review rating on poster covers

### DIFF
--- a/Sashimi/Views/Components/MediaRow.swift
+++ b/Sashimi/Views/Components/MediaRow.swift
@@ -49,6 +49,7 @@ struct MediaPosterButton: View {
 
     @FocusState private var isFocused: Bool
     @AppStorage("showQualityBadges") private var showQualityBadges = true
+    @AppStorage("showReviewRatings") private var showReviewRatings = true
 
     // Card dimensions
     private var cardWidth: CGFloat { isCircular ? 200 : (isLandscape ? 320 : 220) }
@@ -178,6 +179,19 @@ struct MediaPosterButton: View {
                                     QualityBadge(label: quality, fontSize: 19,
                                                  horizontalPadding: 10, verticalPadding: 5, cornerRadius: 8)
                                         .padding(9)
+                                }
+                            }
+                        }
+
+                        // Review rating badge (bottom-left; TMDb community rating)
+                        if showReviewRatings, !isLandscape, let rating = item.communityRating, rating > 0 {
+                            VStack {
+                                Spacer()
+                                HStack {
+                                    ReviewRatingBadge(rating: rating, fontSize: 19, logoHeight: 18,
+                                                      horizontalPadding: 10, verticalPadding: 5, cornerRadius: 8)
+                                        .padding(9)
+                                    Spacer()
                                 }
                             }
                         }

--- a/Sashimi/Views/Library/SettingsView.swift
+++ b/Sashimi/Views/Library/SettingsView.swift
@@ -691,6 +691,7 @@ struct PlaybackSettingsView: View {
                 SettingsSection(title: "Display") {
                     SettingsToggleRow(title: "24-Hour Time", isOn: $settings.use24HourTime)
                     SettingsToggleRow(title: "Show Quality Badges", isOn: $settings.showQualityBadges)
+                    SettingsToggleRow(title: "Show Review Ratings", isOn: $settings.showReviewRatings)
                 }
             }
             .padding(.horizontal, 60)

--- a/SashimiMobile/Views/Components/MobileRecentlyAddedRow.swift
+++ b/SashimiMobile/Views/Components/MobileRecentlyAddedRow.swift
@@ -190,6 +190,7 @@ struct MobileRecentlyAddedCard: View {
     let badgeCount: Int?
 
     @AppStorage("showQualityBadges") private var showQualityBadges = true
+    @AppStorage("showReviewRatings") private var showReviewRatings = true
 
     private var isYouTube: Bool {
         if let name = libraryName, name.lowercased().contains("youtube") {
@@ -287,6 +288,14 @@ struct MobileRecentlyAddedCard: View {
                                  horizontalPadding: 6, verticalPadding: 3, cornerRadius: 5)
                         .padding(4)
                         .frame(width: width, height: height, alignment: .bottomTrailing)
+                }
+
+                // Review rating badge (bottom-left; TMDb community rating)
+                if showReviewRatings, !isCircular, !isLandscape, let rating = item.communityRating, rating > 0 {
+                    ReviewRatingBadge(rating: rating, fontSize: 11, logoHeight: 11,
+                                      horizontalPadding: 6, verticalPadding: 3, cornerRadius: 5)
+                        .padding(4)
+                        .frame(width: width, height: height, alignment: .bottomLeading)
                 }
             }
 

--- a/SashimiMobile/Views/Settings/MobileSettingsView.swift
+++ b/SashimiMobile/Views/Settings/MobileSettingsView.swift
@@ -63,6 +63,7 @@ struct MobileSettingsView: View {
             // Display Section
             Section("Display") {
                 Toggle("Show Quality Badges", isOn: $playbackSettings.showQualityBadges)
+                Toggle("Show Review Ratings", isOn: $playbackSettings.showReviewRatings)
             }
 
             // Playback Section

--- a/Shared/Services/PlaybackSettings.swift
+++ b/Shared/Services/PlaybackSettings.swift
@@ -18,4 +18,5 @@ class PlaybackSettings: ObservableObject {
     @AppStorage("forceDirectPlay") var forceDirectPlay = false
     @AppStorage("use24HourTime") var use24HourTime = false
     @AppStorage("showQualityBadges") var showQualityBadges = true
+    @AppStorage("showReviewRatings") var showReviewRatings = true
 }

--- a/Shared/Views/ReviewRatingBadge.swift
+++ b/Shared/Views/ReviewRatingBadge.swift
@@ -1,0 +1,35 @@
+import SwiftUI
+
+/// Community (TMDb) review-rating chip shown on cover art (bottom-left corner).
+/// Mirrors `QualityBadge`'s dark translucent slate styling but pairs the TMDb
+/// logo with the `communityRating` formatted to one decimal (e.g. "8.0").
+///
+/// Sizing is parameterized so the 10-ft tvOS grid can render larger than the
+/// compact iOS grid while keeping identical styling. Driven by
+/// `BaseItemDto.communityRating` and gated on the `showReviewRatings` setting.
+struct ReviewRatingBadge: View {
+    let rating: Double
+    var fontSize: CGFloat = 12
+    var logoHeight: CGFloat = 12
+    var spacing: CGFloat = 4
+    var horizontalPadding: CGFloat = 6
+    var verticalPadding: CGFloat = 3
+    var cornerRadius: CGFloat = 6
+
+    var body: some View {
+        HStack(spacing: spacing) {
+            Image("TMDBLogo")
+                .resizable()
+                .aspectRatio(contentMode: .fit)
+                .frame(height: logoHeight)
+            Text(String(format: "%.1f", rating))
+                .font(.system(size: fontSize, weight: .bold))
+                .foregroundStyle(.white)
+        }
+        .padding(.horizontal, horizontalPadding)
+        .padding(.vertical, verticalPadding)
+        .background(Color.black.opacity(0.78))
+        .clipShape(RoundedRectangle(cornerRadius: cornerRadius))
+        .shadow(color: .black.opacity(0.35), radius: 2, y: 1)
+    }
+}


### PR DESCRIPTION
## Summary
Adds a community (TMDb) **review-rating badge** to the **lower-left corner** of poster covers across the app, on both the iOS mobile target (SashimiMobile) and the tvOS target (Sashimi). Mirrors the existing quality-badge pattern (which sits lower-right).

## What changed
- **New setting** `showReviewRatings` (Bool, default `true`) in `Shared/Services/PlaybackSettings.swift`, alongside `showQualityBadges`.
- **New shared view** `Shared/Views/ReviewRatingBadge.swift` — TMDb logo (`TMDBLogo` asset) + `communityRating` formatted to one decimal, on the same dark translucent slate capsule as `QualityBadge`. Sizing is parameterized for the 10-ft tvOS grid vs. compact iOS grid.
- **Render (iOS)**: `MobileRecentlyAddedCard` (the shared card used by home, library, and search) draws the badge bottom-left, gated on `showReviewRatings && communityRating > 0`, excluded on circular/landscape (YouTube) cards.
- **Render (tvOS)**: `MediaPosterButton` draws the badge bottom-left under the same gating, excluded on landscape (YouTube) cards.
- **Settings toggles**: "Show Review Ratings" added next to the quality-badges toggle in both the tvOS `SettingsView` Display section and the iOS `MobileSettingsView` Display section.

## Data
`communityRating` is already on `BaseItemDto` and `CommunityRating` is included in every relevant list/grid `Fields=` query in `JellyfinClient`, so no fetch changes were needed.

## Verification
- swiftlint `--strict`: 0 violations on all changed files.
- SashimiMobile builds (Debug, iPhone 17 sim); tvOS Sashimi builds (Debug, Apple TV sim).
- Seeded a logged-in session on the iPhone 17 simulator and confirmed the badge renders lower-left on the home rows (e.g. "5.8", "8.0", "8.5" with the TMDb logo) with the HD quality badge intact lower-right.

🤖 Generated with [Claude Code](https://claude.com/claude-code)