### PR TITLE
feat: series overall rating on cover badge + Use Episode Ratings toggle

### DIFF
--- a/Sashimi/Views/Components/MediaRow.swift
+++ b/Sashimi/Views/Components/MediaRow.swift
@@ -50,6 +50,7 @@ struct MediaPosterButton: View {
     @FocusState private var isFocused: Bool
     @AppStorage("showQualityBadges") private var showQualityBadges = true
     @AppStorage("showReviewRatings") private var showReviewRatings = true
+    @AppStorage("useEpisodeRatings") private var useEpisodeRatings = false
 
     // Card dimensions
     private var cardWidth: CGFloat { isCircular ? 200 : (isLandscape ? 320 : 220) }
@@ -184,7 +185,8 @@ struct MediaPosterButton: View {
                         }
 
                         // Review rating badge (bottom-left; TMDb community rating)
-                        if showReviewRatings, !isLandscape, let rating = item.communityRating, rating > 0 {
+                        if showReviewRatings, !isLandscape,
+                           let rating = item.coverReviewRating(useEpisodeRatings: useEpisodeRatings) {
                             VStack {
                                 Spacer()
                                 HStack {

--- a/Sashimi/Views/Library/SettingsView.swift
+++ b/Sashimi/Views/Library/SettingsView.swift
@@ -692,6 +692,7 @@ struct PlaybackSettingsView: View {
                     SettingsToggleRow(title: "24-Hour Time", isOn: $settings.use24HourTime)
                     SettingsToggleRow(title: "Show Quality Badges", isOn: $settings.showQualityBadges)
                     SettingsToggleRow(title: "Show Review Ratings", isOn: $settings.showReviewRatings)
+                    SettingsToggleRow(title: "Use Episode Ratings", isOn: $settings.useEpisodeRatings)
                 }
             }
             .padding(.horizontal, 60)

--- a/SashimiMobile/Views/Components/MobileRecentlyAddedRow.swift
+++ b/SashimiMobile/Views/Components/MobileRecentlyAddedRow.swift
@@ -191,6 +191,7 @@ struct MobileRecentlyAddedCard: View {
 
     @AppStorage("showQualityBadges") private var showQualityBadges = true
     @AppStorage("showReviewRatings") private var showReviewRatings = true
+    @AppStorage("useEpisodeRatings") private var useEpisodeRatings = false
 
     private var isYouTube: Bool {
         if let name = libraryName, name.lowercased().contains("youtube") {
@@ -291,7 +292,8 @@ struct MobileRecentlyAddedCard: View {
                 }
 
                 // Review rating badge (bottom-left; TMDb community rating)
-                if showReviewRatings, !isCircular, !isLandscape, let rating = item.communityRating, rating > 0 {
+                if showReviewRatings, !isCircular, !isLandscape,
+                   let rating = item.coverReviewRating(useEpisodeRatings: useEpisodeRatings) {
                     ReviewRatingBadge(rating: rating, fontSize: 11, logoHeight: 11,
                                       horizontalPadding: 6, verticalPadding: 3, cornerRadius: 5)
                         .padding(4)

--- a/SashimiMobile/Views/Settings/MobileSettingsView.swift
+++ b/SashimiMobile/Views/Settings/MobileSettingsView.swift
@@ -64,6 +64,7 @@ struct MobileSettingsView: View {
             Section("Display") {
                 Toggle("Show Quality Badges", isOn: $playbackSettings.showQualityBadges)
                 Toggle("Show Review Ratings", isOn: $playbackSettings.showReviewRatings)
+                Toggle("Use Episode Ratings", isOn: $playbackSettings.useEpisodeRatings)
             }
 
             // Playback Section

--- a/Shared/Services/PlaybackSettings.swift
+++ b/Shared/Services/PlaybackSettings.swift
@@ -19,4 +19,9 @@ class PlaybackSettings: ObservableObject {
     @AppStorage("use24HourTime") var use24HourTime = false
     @AppStorage("showQualityBadges") var showQualityBadges = true
     @AppStorage("showReviewRatings") var showReviewRatings = true
+    // When false (default) the cover review-rating badge shows a TV show's
+    // overall rating rather than an individual episode's. Since episode DTOs
+    // don't carry the series' overall rating, episode cards suppress the badge
+    // unless the user opts into per-episode ratings here.
+    @AppStorage("useEpisodeRatings") var useEpisodeRatings = false
 }

--- a/Shared/Views/ReviewRatingBadge.swift
+++ b/Shared/Views/ReviewRatingBadge.swift
@@ -33,3 +33,22 @@ struct ReviewRatingBadge: View {
         .shadow(color: .black.opacity(0.35), radius: 2, y: 1)
     }
 }
+
+extension BaseItemDto {
+    /// Community (TMDb) rating to display on a cover badge, honoring the
+    /// `useEpisodeRatings` setting.
+    ///
+    /// A TV episode carries its own per-episode `communityRating`, which reads
+    /// as the *episode's* score — misleading on a cover that stands in for the
+    /// whole series. The episode DTO does not carry the series' overall rating
+    /// (detail views fetch the series separately for that), so unless the user
+    /// opts into episode-level ratings we suppress the badge on episode cards.
+    /// Series and movie cards always use their own (correct) rating.
+    ///
+    /// Returns `nil` when no badge should render.
+    func coverReviewRating(useEpisodeRatings: Bool) -> Double? {
+        if type == .episode && !useEpisodeRatings { return nil }
+        guard let rating = communityRating, rating > 0 else { return nil }
+        return rating
+    }
+}


### PR DESCRIPTION
## Summary
The cover review-rating badge (`ReviewRatingBadge`) must show a TV show's **overall** community rating, not an individual episode's. This adds a `useEpisodeRatings` setting (default **false**) so users can opt into episode-level ratings.

## Investigation — series vs. episode per surface
The badge renders in exactly two live places: **tvOS `MediaPosterButton`** (MediaRow.swift) and **iOS `MobileRecentlyAddedCard`**.

| Surface | Item type | communityRating meaning |
|---|---|---|
| Recently Added rows/grids (tvOS `RecentlyAddedLibraryRow`, iOS `MobileRecentlyAddedRow`) | **Series** for TV (`getLatestMedia` requests `IncludeItemTypes=Series`), Movie for movies | Show overall / movie — already correct |
| Library grids (tvOS `LibraryView`, iOS `MobileLibraryBrowseView`) | Series / Movie | correct |
| Search results (tvOS `SearchView`, iOS `MobileSearchView`) | can include **Episodes** | episode's own rating — the leak |
| Continue Watching / Next Up (both platforms) | Episodes | render **no badge** at all |

So the only place an episode-level rating could surface on a badge is **search results**. The episode `BaseItemDto` does **not** carry a series-overall rating field (`BaseItemDto` only has `communityRating`; detail views fetch the series separately into `@State`). Rather than firing a per-card series fetch on grids, `coverReviewRating(useEpisodeRatings:)` **suppresses the badge on episode cards** unless the user opts in.

## Changes
- `PlaybackSettings.swift`: add `useEpisodeRatings` (default `false`).
- `ReviewRatingBadge.swift`: add `BaseItemDto.coverReviewRating(useEpisodeRatings:)`.
- tvOS `MediaRow.swift` (`MediaPosterButton`) + iOS `MobileRecentlyAddedRow.swift` (`MobileRecentlyAddedCard`): gate the badge on the helper.
- tvOS `SettingsView.swift` + iOS `MobileSettingsView.swift`: add "Use Episode Ratings" toggle under "Show Review Ratings".

## Verification
- SwiftLint clean; iOS (`SashimiMobile`) and tvOS (`Sashimi`) both build.
- iPhone 17 sim: badges still render — Movies show own ratings, Recently Added TV shows **series** ratings (7.8 / 7.2 / 8.0), Continue Watching episode cards show no badge.

## Note (dead code)
`MediaRow` struct in `Sashimi/Views/Components/MediaRow.swift` has no call sites (only the co-located `MediaPosterButton` is used). Left untouched here; flagging for cleanup.

Fixes #278

🤖 Generated with [Claude Code](https://claude.com/claude-code)