### PR TITLE
fix(tvos): first-launch focus lands on hero; Right enters Search/Settings

### DIFF
--- a/Sashimi/App/SashimiApp.swift
+++ b/Sashimi/App/SashimiApp.swift
@@ -154,6 +154,11 @@ struct MainTabView: View {
     @FocusState private var focusedNav: NavID?
     @Namespace private var mainScope
     @Namespace private var railScope
+    // Forces the focus engine to re-evaluate mainScope's default-focus target.
+    // prefersDefaultFocus(in:) is only honored when a scope first gains focus
+    // or when this action runs — clearing focusedNav or a directional beam that
+    // misses the content does NOT trigger it on its own.
+    @Environment(\.resetFocus) private var resetFocus
     @State private var selection: NavID = .home
     @State private var libraries: [JellyfinLibrary] = []
     @State private var showServerSwitcher = false
@@ -263,6 +268,13 @@ struct MainTabView: View {
     private func handleHeroReady() {
         guard !didInitialHomeFocus, selection == .home || selection == .avatar else { return }
         focusedNav = nil
+        // Clearing focusedNav drops the rail button but the engine keeps focus
+        // parked on the rail — it never re-evaluates the mainScope default. Kick
+        // it (next runloop, so the hero is in the tree) so the hero, the
+        // mainScope prefersDefaultFocus target, actually claims focus.
+        DispatchQueue.main.async {
+            resetFocus(in: mainScope)
+        }
         DispatchQueue.main.asyncAfter(deadline: .now() + 0.6) {
             didInitialHomeFocus = true
         }
@@ -377,6 +389,17 @@ struct MainTabView: View {
         // section's row (the onChange snap is the deterministic fallback).
         .focusScope(railScope)
         .focusSection()
+        // Right enters the content. Home/libraries fill the directional beam,
+        // so the engine moves there itself and this closure never fires. Search
+        // and Settings put their controls top/center — out of the beam from a
+        // rail row — so the Right press falls through here; resetFocus then
+        // lands on the content's prefersDefaultFocus target (search field /
+        // Servers row) instead of leaving focus stranded in the rail.
+        .onMoveCommand { direction in
+            if direction == .right {
+                resetFocus(in: mainScope)
+            }
+        }
     }
 
     private func navButton(_ id: NavID, _ title: String, _ icon: String) -> some View {

--- a/Sashimi/Views/Library/SearchView.swift
+++ b/Sashimi/Views/Library/SearchView.swift
@@ -130,10 +130,40 @@ struct SearchView: View {
             VStack(spacing: 0) {
                 // Search field at top with clear button
                 HStack(spacing: 16) {
-                    TextField("Search movies, shows...", text: $searchText)
+                    // The raw tvOS TextField draws a solid white focus platter
+                    // that no modifier can suppress. Keep it for focus +
+                    // keyboard, but hide its text/cursor and cover its platter
+                    // with a dark overlay (sized to the field's exact frame, so
+                    // height stays right and no white edges peek) — focus then
+                    // reads as our thin ring (the stroke below), not a white box.
+                    TextField("", text: $searchText)
                         .textFieldStyle(.plain)
                         .font(.title3)
+                        .foregroundStyle(.clear)
+                        .tint(.clear)
+                        .accessibilityLabel("Search movies and shows")
+                        .focused($isSearchFieldFocused)
                         .defaultFocus(in: focusNamespace)
+                        .overlay {
+                            ZStack(alignment: .leading) {
+                                // Over-sized dark fill: covers the platter's few-px
+                                // outset; the container's clipShape trims it back to
+                                // the rounded field, so no white rim peeks.
+                                SashimiTheme.cardBackground
+                                    .padding(-60)
+                                HStack(spacing: 16) {
+                                    Image(systemName: "magnifyingglass")
+                                        .font(.title3)
+                                        .foregroundStyle(isSearchFieldFocused ? SashimiTheme.textPrimary : SashimiTheme.textTertiary)
+                                    Text(searchText.isEmpty ? "Search movies, shows..." : searchText)
+                                        .font(.title3)
+                                        .foregroundStyle(searchText.isEmpty ? SashimiTheme.textTertiary : SashimiTheme.textPrimary)
+                                        .lineLimit(1)
+                                    Spacer(minLength: 0)
+                                }
+                            }
+                            .allowsHitTesting(false)
+                        }
 
                     // Clear button - show when there's text OR results
                     if !searchText.isEmpty || !results.isEmpty {

--- a/Sashimi/Views/Library/SettingsView.swift
+++ b/Sashimi/Views/Library/SettingsView.swift
@@ -189,9 +189,17 @@ struct SettingsOptionRow: View {
             }
             .padding(.horizontal, 28)
             .padding(.vertical, 24)
+            // Neutral focus: subtle white fill + white stroke (matches every
+            // other row — LibraryView, HomeRowToggleButton, etc.). A solid
+            // SashimiTheme.focus (Color.white) fill made the focused row a
+            // white box with the white-on-focus text vanishing into it.
             .background(
                 RoundedRectangle(cornerRadius: 16)
-                    .fill(isFocused ? SashimiTheme.focus : SashimiTheme.cardBackground)
+                    .fill(isFocused ? SashimiTheme.focus.opacity(0.15) : SashimiTheme.cardBackground)
+            )
+            .overlay(
+                RoundedRectangle(cornerRadius: 16)
+                    .stroke(SashimiTheme.focus.opacity(isFocused ? 1.0 : 0), lineWidth: 3)
             )
             .scaleEffect(isFocused ? 1.02 : 1.0)
             .animation(.spring(response: 0.3, dampingFraction: 0.7), value: isFocused)
@@ -510,7 +518,11 @@ struct HomeRowMoveButton: View {
                 .frame(width: 50, height: 50)
                 .background(
                     RoundedRectangle(cornerRadius: 10)
-                        .fill(isFocused ? SashimiTheme.focus : SashimiTheme.cardBackground)
+                        .fill(isFocused ? SashimiTheme.focus.opacity(0.15) : SashimiTheme.cardBackground)
+                )
+                .overlay(
+                    RoundedRectangle(cornerRadius: 10)
+                        .stroke(SashimiTheme.focus.opacity(isFocused ? 1.0 : 0), lineWidth: 2)
                 )
         }
         .buttonStyle(.card)


### PR DESCRIPTION
Fixes #280

## Problem
Two tvOS focus bugs, one root cause:
1. **Cold launch** focused the rail's **Home** link instead of the hero.
2. **Can't enter Search/Settings** from the rail — pressing Right did nothing.

`prefersDefaultFocus(_:in:)` is only honored when a focus scope first gains focus or when `resetFocus` runs. `resetFocus` was used nowhere, so clearing `focusedNav` (cold-launch handoff) and a rightward beam that misses top/center content (Search/Settings) both left focus stranded in the rail. Home/libraries worked only because their large hero / full grid fill the directional beam geometrically.

## Fix
- `@Environment(\.resetFocus)` added to `MainTabView`.
- `handleHeroReady()` calls `resetFocus(in: mainScope)` after clearing `focusedNav` → hero claims focus on launch.
- A rail-level `.onMoveCommand` routes a Right the engine can't otherwise satisfy through `resetFocus(in: mainScope)` → lands on the content's default target. Home/libraries fill the beam so this never fires for them.

## Verification (tvOS 26.5 simulator, driven end-to-end)
| Path | Before | After |
|------|--------|-------|
| Cold launch | rail Home focused | ✅ hero focused |
| Right → Settings | stuck in rail | ✅ Servers row |
| Right → Search | stuck in rail | ✅ search field |
| Right → Movies | worked | ✅ first poster (no regression) |
| Rail up/down, content→rail left | worked | ✅ still works |

🤖 Generated with [Claude Code](https://claude.com/claude-code)