### PR TITLE
fix(playback): black screen with audio on HEVC/DV mkv (HLS TS→fMP4)

### DIFF
--- a/SashimiMobile/Downloads/Services/DownloadURLBuilder.swift
+++ b/SashimiMobile/Downloads/Services/DownloadURLBuilder.swift
@@ -31,14 +31,32 @@ enum DownloadURLBuilder {
 
     // MARK: - Video Download URLs
 
-    /// Build URL for downloading video at original quality (direct file download)
+    /// Build URL for downloading video at original quality.
+    ///
+    /// NOT the raw-file /Items/{id}/Download: an mkv original (e.g. a 4K DV8.1
+    /// HEVC WEBDL) downloads fine but AVPlayer can't render its video — black
+    /// screen with audio. Instead ask the transcode pipeline for a stream-copy
+    /// REMUX into mp4: identical video/audio bits (no re-encode, no quality
+    /// loss — VideoCodec lists the source codecs so copy applies), but in a
+    /// container AVPlayer demuxes, with HEVC tagged hvc1. Embedded subtitle
+    /// tracks are dropped by the remux; subtitles are downloaded separately as
+    /// VTT (subtitleURL), so nothing user-visible is lost.
     static func originalDownloadURL(itemId: String) -> URL? {
         guard let serverURL = UserDefaults.standard.string(forKey: "serverURL") else {
             return nil
         }
 
         var components = URLComponents(string: serverURL.trimmingCharacters(in: CharacterSet(charactersIn: "/")))
-        components?.path += "/Items/\(itemId)/Download"
+        components?.path += "/Videos/\(itemId)/stream.mp4"
+        components?.queryItems = [
+            URLQueryItem(name: "MediaSourceId", value: itemId),
+            URLQueryItem(name: "VideoCodec", value: "h264,hevc"),
+            URLQueryItem(name: "AudioCodec", value: "aac,ac3,eac3"),
+            URLQueryItem(name: "Container", value: "mp4"),
+            URLQueryItem(name: "AllowVideoStreamCopy", value: "true"),
+            URLQueryItem(name: "AllowAudioStreamCopy", value: "true"),
+            URLQueryItem(name: "DeviceId", value: deviceId)
+        ]
         return components?.url
     }
 

--- a/Shared/Services/JellyfinClient.swift
+++ b/Shared/Services/JellyfinClient.swift
@@ -729,7 +729,13 @@ actor JellyfinClient {
             ],
             "TranscodingProfiles": [
                 [
-                    "Container": "ts",
+                    // fMP4 segments, NOT "ts": AVPlayer does not decode HEVC
+                    // inside MPEG-TS segments (Apple's HLS spec requires fMP4
+                    // for HEVC), so an mkv HEVC remux in TS played audio over
+                    // a black screen (The Crown 4K DV8.1 WEBDL). With "mp4"
+                    // the server emits fMP4 segments tagged hvc1 (+PQ range,
+                    // DV supplemental codec) that AVPlayer actually renders.
+                    "Container": "mp4",
                     "Type": "Video",
                     // tvOS plays HEVC and EAC3 in HLS natively — declaring
                     // them lets mkv remuxes stream-copy both tracks instead


### PR DESCRIPTION
## Problem
Playing The Crown (4K HEVC **Dolby Vision 8.1** WEBDL **mkv**) on Apple TV gave a black screen with working audio. Same file broken as an 'original quality' download.

## Root cause
**AVPlayer does not decode HEVC inside MPEG-TS HLS segments** — Apple's HLS spec requires fMP4 segments for HEVC. Our device profile requested `Container: ts` with `VideoCodec: h264,hevc` + stream copy, so mkv HEVC remuxes served hevc-in-ts: EAC3 audio played, video silently failed.

## Proof (AVFoundation probe against the live server)
| Stream | Result |
|---|---|
| ts segments (old) | readyToPlay, 8s played, **0 video frames** — the exact symptom |
| fmp4 segments (new) | **video frames decode** at 3840x2160 |

The fmp4 master playlist advertises `CODECS="hvc1.2.4.L150.B0,ec-3"`, `VIDEO-RANGE=PQ`, `SUPPLEMENTAL-CODECS="dvh1.08.07/db1p"` — Apple-conformant, with an AVC fallback variant.

## Changes
- **Streaming (Shared/, affects tvOS + iOS):** transcoding profile `Container: ts` → `mp4` (HLS fMP4).
- **Downloads (iOS):** 'original quality' switched from the raw-file `/Download` (broken for mkv locally) to a **stream-copy remux** into mp4 — identical bits, hvc1-tagged, playable. Subtitles were already fetched separately as VTT.

## Testing
- AVFoundation probe above (same HLS engine as tvOS/iOS)
- tvOS + iOS targets build clean; SwiftLint clean

⚠️ Shared/ change → needs BOTH deploy tags when shipping (tvOS `v*-beta*` AND iOS `ios-v*-beta*`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)