### PR TITLE
fix(tvos): hero off-center and harsh backdrop seam mid-hero

### DIFF
--- a/Sashimi/Views/Home/HomeView.swift
+++ b/Sashimi/Views/Home/HomeView.swift
@@ -61,7 +61,12 @@ struct HomeView: View {
                             .frame(height: 100)
                     }
                 }
-                .ignoresSafeArea(edges: .top)
+                // Horizontal too: the ScrollView applied the TRAILING safe-area
+                // inset to its content while the rail's leading padding absorbed
+                // the leading one — so the hero sat ~70pt off-center (50pt gap
+                // on the left, 120pt on the right). Ignoring both makes the
+                // hero's 50pt horizontal padding symmetric.
+                .ignoresSafeArea(edges: [.top, .horizontal])
                 .refreshable {
                     await viewModel.refresh()
                 }
@@ -304,7 +309,13 @@ struct HeroSection: View {
                     // Background color
                     SashimiTheme.background
 
-                    // Backdrop image positioned on the right with soft left edge
+                    // Backdrop image positioned on the right with soft left edge.
+                    // The fade mask is applied to the IMAGE, not the 0.7-width
+                    // container: a .fit image sizes to its fitted bounds (a 16:9
+                    // backdrop fills ~0.5 of the hero width), so a container-
+                    // relative ramp over the leftmost 25% never reached the
+                    // image's actual left edge — leaving a harsh vertical line
+                    // mid-hero. Image-relative, the ramp always covers the edge.
                     HStack(spacing: 0) {
                         Spacer()
                         SmartPosterImage(
@@ -313,18 +324,18 @@ struct HeroSection: View {
                             imageTypes: heroImageTypes,
                             contentMode: .fit
                         )
-                        .id(currentItem.id)
-                        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .trailing)
                         .mask(
                             LinearGradient(
                                 stops: [
                                     .init(color: .clear, location: 0.0),
-                                    .init(color: .white, location: 0.25)
+                                    .init(color: .white, location: 0.35)
                                 ],
                                 startPoint: .leading,
                                 endPoint: .trailing
                             )
                         )
+                        .id(currentItem.id)
+                        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .trailing)
                         .frame(width: geometry.size.width * 0.7, height: geometry.size.height)
                         .transition(.opacity)
                         .animation(.easeInOut(duration: 0.6), value: currentItem.id)


### PR DESCRIPTION
## Problems (user-reported)
1. The hero section isn't centered on Apple TV.
2. A harsh vertical line runs down the middle of the hero where the backdrop image's border sits.

## Root causes
1. The ScrollView applied the **trailing** safe-area inset to its content while the rail's leading padding absorbed the leading one — the hero sat ~70pt off-center (50pt gap left vs 120pt right).
2. The backdrop fade mask was applied to the 0.7-width **container**; a `.fit` 16:9 backdrop sizes to ~half the hero width (trailing-aligned), so the mask's leftmost-25% ramp never reached the image's actual left edge → hard vertical cut at mid-hero.

## Fixes
- Ignore horizontal safe area on the ScrollView so the hero's symmetric 50pt padding actually centers it.
- Mask the **image itself** so the fade always covers its left edge (ramp widened to 35%).

## Verification (tvOS 26.5 sim)
- Before: 'Alone' 16:9 backdrop with a hard edge at screen center, hero shifted left.
- After: same slide fades smoothly into the background; hero centered (~46/38pt gaps vs 46/122 before). Wide-art slides (Fear Factor) also verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)