### PR TITLE
fix(subtitles): ASS override tags ({\an8}) rendered as literal text

### DIFF
--- a/Shared/Services/SubtitleManager.swift
+++ b/Shared/Services/SubtitleManager.swift
@@ -130,6 +130,13 @@ class SubtitleManager: ObservableObject {
                         let textLine = lines[i]
                             .trimmingCharacters(in: .whitespaces)
                             .replacingOccurrences(of: "<[^>]+>", with: "", options: .regularExpression)
+                            // ASS/SSA override blocks ride along when SRT subs
+                            // with embedded styling get converted to VTT (e.g.
+                            // "{\an8}" = position top-center) — Jellyfin passes
+                            // them through verbatim and they rendered as literal
+                            // text at the start of lines. Strip any "{\...}".
+                            .replacingOccurrences(of: "\\{\\\\[^}]*\\}", with: "", options: .regularExpression)
+                            .trimmingCharacters(in: .whitespaces)
                         if !textLine.isEmpty {
                             textLines.append(textLine)
                         }


### PR DESCRIPTION
## Problem
Some subtitles show `{\an8}` (and similar) at the front of lines.

## Root cause
SRT subs with embedded ASS styling (`{\an8}` = top-center position, `{\i1}`, `{\pos(...)}`) pass through Jellyfin's SRT→VTT conversion verbatim. `SubtitleManager.parseWebVTT` stripped HTML-style `<...>` tags but not curly-brace ASS override blocks, so they rendered as literal text.

## Fix
Strip any `{\...}` block during cue parsing (backslash required, so plain-brace text like `{note}` is preserved). Verified against: leading `{\an8}`, stacked `{\an8}{\i1}`, mid-line `{\b1}bold{\b0}`, `{\pos(400,570)}`, plain braces preserved.

Shared/ change — applies to tvOS and iOS custom subtitle overlays.

🤖 Generated with [Claude Code](https://claude.com/claude-code)