### PR TITLE
feat(ux): plain-language playback wording (Original / Converted)

### DIFF
--- a/Sashimi/Views/Library/SettingsView.swift
+++ b/Sashimi/Views/Library/SettingsView.swift
@@ -655,10 +655,10 @@ struct PlaybackSettingsView: View {
                     SettingsNavigationRow(title: "Maximum Bitrate", subtitle: bitrateLabel) {
                         VideoQualitySettingsView()
                     }
-                    SettingsToggleRow(title: "Force Direct Play", isOn: $settings.forceDirectPlay)
+                    SettingsToggleRow(title: "Always Play Original", isOn: $settings.forceDirectPlay)
                 }
 
-                Text("Direct play streams the original file without transcoding.")
+                Text("Plays the original file untouched, never converted. If your connection cannot keep up, playback may stall rather than drop quality.")
                     .font(Typography.captionSmall)
                     .foregroundStyle(SashimiTheme.textTertiary)
                     .padding(.horizontal, 8)

--- a/SashimiMobile/Views/Settings/MobileSettingsView.swift
+++ b/SashimiMobile/Views/Settings/MobileSettingsView.swift
@@ -72,7 +72,7 @@ struct MobileSettingsView: View {
                 Toggle("Auto-Play Next Episode", isOn: $playbackSettings.autoPlayNextEpisode)
                 Toggle("Auto-Skip Intro", isOn: $playbackSettings.autoSkipIntro)
                 Toggle("Auto-Skip Credits", isOn: $playbackSettings.autoSkipCredits)
-                Toggle("Force Direct Play", isOn: $playbackSettings.forceDirectPlay)
+                Toggle("Always Play Original", isOn: $playbackSettings.forceDirectPlay)
                 // tvOS parity — same values as the tvOS Resume Threshold screen
                 Picker("Resume Threshold", selection: $playbackSettings.resumeThresholdSeconds) {
                     Text("Always resume").tag(0)

--- a/Shared/ViewModels/PlayerViewModel.swift
+++ b/Shared/ViewModels/PlayerViewModel.swift
@@ -105,10 +105,13 @@ final class PlayerViewModel: ObservableObject {
         let reason: String?
 
         var label: String {
+            // Viewer-facing wording: "Direct Play" vs "Direct Stream" is server
+            // plumbing — both deliver the identical video bits, so both read
+            // "Original". Only a transcode changes the picture: "Converted".
             switch method {
-            case .directPlay: return "Direct Play"
-            case .directStream: return "Direct Stream"
-            case .transcode: return "Transcode"
+            case .directPlay: return "Original"
+            case .directStream: return "Original"
+            case .transcode: return "Converted"
             }
         }
     }


### PR DESCRIPTION
## Why
"Direct Play / Direct Stream / Transcode" is server jargon. Direct Play and Direct Stream deliver the **identical video bits** — two labels for the same picture quality is what made it confusing (user feedback).

## New wording (all surfaces)
| Before | After |
|---|---|
| Direct Play | **Original** |
| Direct Stream | **Original** |
| Transcode | **Converted** (+ detail/reason as before) |
| Force Direct Play (setting) | **Always Play Original** |

Internal enums / API values / reported PlayMethod unchanged — display strings only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)