### PR TITLE
fix(ios): home rows pushed the iPad detail layout on iPhone

### DIFF
--- a/SashimiMobile/Views/Detail/MobileDetailView.swift
+++ b/SashimiMobile/Views/Detail/MobileDetailView.swift
@@ -223,7 +223,7 @@ struct MobileDetailView: View {
         .fullScreenPlayer(item: $startOverItem, startFromBeginning: true)
         .sheet(item: $showingEpisodeDetail) { episode in
             NavigationStack {
-                MobileDetailView(item: episode, libraryName: libraryName)
+                AdaptiveDetailView(item: episode, libraryName: libraryName)
             }
         }
         .task {
@@ -878,7 +878,7 @@ struct MobileDetailView: View {
             if NetworkMonitor.shared.isConnected, isEpisode, item.seriesId != nil {
                 NavigationLink {
                     if let seriesItem = navigateToSeriesItem {
-                        MobileDetailView(item: seriesItem, libraryName: libraryName)
+                        AdaptiveDetailView(item: seriesItem, libraryName: libraryName)
                     } else {
                         ProgressView()
                     }

--- a/SashimiMobile/Views/Home/MobileHomeView.swift
+++ b/SashimiMobile/Views/Home/MobileHomeView.swift
@@ -66,7 +66,7 @@ struct MobileHomeView: View {
                     items: viewModel.continueWatchingItems,
                     libraryNames: libNames
                 ) { item in
-                    MobileDetailView(item: item, libraryName: libNames[item.id])
+                    AdaptiveDetailView(item: item, libraryName: libNames[item.id])
                 }
             }
 
@@ -77,7 +77,7 @@ struct MobileHomeView: View {
                 libraryName: libraryName,
                 collectionType: library?.collectionType
             ) { item in
-                MobileDetailView(item: item, libraryName: libraryName)
+                AdaptiveDetailView(item: item, libraryName: libraryName)
             }
         }
     }


### PR DESCRIPTION
User report: opening Silo from home → Recently Added does an 'odd expanding thing' and the edges get cut off.

**Root cause:** MobileHomeView's rows pushed `MobileDetailView` (the iPad layout) directly — Search/Library correctly route through `AdaptiveDetailView` (compact → `PhoneDetailView`). The iPad layout reflows in a compact width (the expanding) and its metrics overflow the phone screen (the cut edges). Continue Watching had the same bug unreported, and MobileDetailView's internal episode/series pushes cascaded it.

**Fix:** all four call sites route through `AdaptiveDetailView`. iPad behavior unchanged (Adaptive resolves back to MobileDetailView at regular size class).

Verified: phone layout renders the same episode correctly edge-to-edge (sim screenshot in session).

🤖 Generated with [Claude Code](https://claude.com/claude-code)