### PR TITLE
fix(ios): series detail column overflow — logo ideal-size leak + rigid action row

### DIFF
--- a/SashimiMobile/Views/Phone/PhoneDetailView.swift
+++ b/SashimiMobile/Views/Phone/PhoneDetailView.swift
@@ -412,15 +412,26 @@ struct PhoneDetailView: View {
         if isEpisode {
             episodeTitleText
         } else if isSeries, !isYouTubeSeriesStyle, let logoURL = logoImageURL(for: item.id) {
-            LazyImage(url: logoURL) { state in
-                if let image = state.image {
-                    image.resizable().aspectRatio(contentMode: .fit)
-                } else if state.error != nil {
-                    seriesTitleText
+            // Bounded container + overlay: LazyImage under a height-only cap
+            // reports its IDEAL size (the raw logo pixels) when the ScrollView
+            // proposes unbounded height — a wide logo PNG then dictates the
+            // whole detail column's width, shoving every section past the
+            // screen edges (the "expanding, edges cut off" bug; same physics
+            // as the missing-backdrop movie fix). The overlay keeps the
+            // image's size out of layout entirely.
+            Color.clear
+                .frame(maxWidth: .infinity)
+                .frame(height: 70)
+                .overlay(alignment: .leading) {
+                    LazyImage(url: logoURL) { state in
+                        if let image = state.image {
+                            image.resizable().aspectRatio(contentMode: .fit)
+                        } else if state.error != nil {
+                            seriesTitleText
+                        }
+                    }
                 }
-            }
-            .frame(maxHeight: 70)
-            .frame(maxWidth: .infinity, alignment: .leading)
+                .clipped()
         } else {
             seriesTitleText
         }
@@ -668,13 +679,26 @@ struct PhoneDetailView: View {
 
     @ViewBuilder
     private var actionButtons: some View {
-        if isSeries {
-            seriesActionButtons
-        } else if isEpisode {
-            episodeActionButtons
-        } else {
-            movieActionButtons
+        // The button row's ideal width (e.g. "Resume S3:E3" + four circle
+        // buttons, all non-compressible) can exceed the content width on
+        // smaller phones. An HStack that can't compress CHOOSES its ideal
+        // width, which silently widens the whole detail column — every
+        // section then overhangs the screen and .clipped() trims both edges
+        // (the "expanding, edges cut off" bug). Hosting the row in a
+        // horizontal ScrollView caps it at the proposed width: it scrolls
+        // when tight and looks identical when it fits.
+        ScrollView(.horizontal, showsIndicators: false) {
+            Group {
+                if isSeries {
+                    seriesActionButtons
+                } else if isEpisode {
+                    episodeActionButtons
+                } else {
+                    movieActionButtons
+                }
+            }
         }
+        .scrollBounceBehavior(.basedOnSize, axes: .horizontal)
     }
 
     private var seriesActionButtons: some View {


### PR DESCRIPTION
Follow-up to #287: the routing fix sent iPhone to the right view, but PhoneDetailView itself had two independent column-wideners on **series** pages (user's Silo screenshot: clipped TMDB badge, zero margins, centered-looking logo — worse on smaller iPhones):

1. **Series logo**: `LazyImage` under a height-only cap reports its IDEAL size (raw logo pixels) when the ScrollView proposes unbounded height — a wide logo PNG dictated the whole column's width. Contained with the bounded `Color.clear` + overlay pattern.
2. **Action row**: `Resume S3:E3` + four circle buttons (non-compressible, `.fixedSize` label) has an ideal width beyond the content slot on smaller phones — an HStack that can't compress *chooses* its ideal, widening the column. Now hosted in a horizontal ScrollView with `.scrollBounceBehavior(.basedOnSize)` — identical when it fits, scrolls when tight.

Root-caused with GeometryReader width probes (column jumped 402→426.33pt exactly when the full item loaded). Verified on sim: 16pt margins restored, logo leading-aligned, all buttons on-screen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)