### PR TITLE
Fix hero timer stacking, silent playback-report failures, iPad episode label

### DIFF
--- a/Sashimi/Views/Home/HomeView.swift
+++ b/Sashimi/Views/Home/HomeView.swift
@@ -514,6 +514,11 @@ struct HeroSection: View {
 
     private func startAutoAdvance() {
         guard items.count > 1 else { return }
+        // A second onAppear without an intervening onDisappear (tab switch,
+        // navigation pop) would otherwise orphan the previous timer, which
+        // keeps mutating currentIndex — the hero then advances at a multiple
+        // of the intended rate and never settles.
+        autoAdvanceTimer?.invalidate()
         restartProgressAnimation()
         // One tick per slide; the progress bar fills via a single linear
         // animation instead of a 10Hz timer mutating state.

--- a/SashimiMobile/Views/Detail/MobileDetailView.swift
+++ b/SashimiMobile/Views/Detail/MobileDetailView.swift
@@ -725,17 +725,23 @@ struct MobileDetailView: View {
         HStack(spacing: MobileSpacing.md) {
             if let nextEp = nextEpisodeToPlay {
                 let epHasProgress = (nextEp.userData?.playbackPositionTicks ?? 0) > 0
-                let seasonNum = nextEp.parentIndexNumber ?? 1
-                let epNum = nextEp.indexNumber ?? 1
+                // Build the String first. Passing an interpolated literal to
+                // Label picks the LocalizedStringKey overload, which formats
+                // Int with grouping separators -- YouTube items use the year as
+                // the season number, so it rendered as "S2,024:E1,234".
+                // PhoneDetailView already does it this way.
+                let epLabel: String = {
+                    if let sNum = nextEp.parentIndexNumber, let eNum = nextEp.indexNumber {
+                        return "\(epHasProgress ? "Resume" : "Play") S\(sNum):E\(eNum)"
+                    }
+                    return epHasProgress ? "Resume" : "Play"
+                }()
 
                 Button {
                     playingItem = nextEp
                 } label: {
-                    Label(
-                        epHasProgress ? "Resume S\(seasonNum):E\(epNum)" : "Play S\(seasonNum):E\(epNum)",
-                        systemImage: "play.fill"
-                    )
-                    .font(.system(size: 14, weight: .semibold))
+                    Label(epLabel, systemImage: "play.fill")
+                        .font(.system(size: 14, weight: .semibold))
                 }
                 .buttonStyle(.borderedProminent)
 

--- a/Shared/ViewModels/PlayerViewModel.swift
+++ b/Shared/ViewModels/PlayerViewModel.swift
@@ -3,6 +3,7 @@ import AVKit
 import AVFoundation
 import Combine
 import MediaPlayer
+import os
 
 // swiftlint:disable file_length type_body_length function_body_length
 // PlayerViewModel manages complex video playback state - splitting would fragment playback logic
@@ -62,6 +63,12 @@ enum QualityOption: String, CaseIterable, Identifiable {
         }
     }
 }
+
+
+// Playback reporting is best-effort by design -- a failed report must never
+// interrupt playback -- but swallowing it silently meant watch state could
+// stop syncing with no trace at all.
+private let logger = Logger(subsystem: "com.mondominator.sashimi", category: "PlayerViewModel")
 
 @MainActor
 final class PlayerViewModel: ObservableObject {
@@ -268,7 +275,11 @@ final class PlayerViewModel: ObservableObject {
         // changeQuality — auto-play-next otherwise leaves the old encode
         // running until the server times it out.
         if let playSessionId, currentMediaSource?.transcodingUrl != nil {
-            try? await client.stopActiveEncoding(playSessionId: playSessionId)
+            do {
+                try await client.stopActiveEncoding(playSessionId: playSessionId)
+            } catch {
+                logger.error("stopActiveEncoding failed: \(error.localizedDescription, privacy: .public)")
+            }
         }
 
         isLoading = true
@@ -327,7 +338,11 @@ final class PlayerViewModel: ObservableObject {
                 resumePositionTicks = 0
                 pendingResumeTicks = 0
                 if !isOffline {
-                    try? await client.reportPlaybackStart(itemId: freshItem.id, positionTicks: 0, playSessionId: playSessionId, playMethod: currentPlayMethod)
+                    do {
+                        try await client.reportPlaybackStart(itemId: freshItem.id, positionTicks: 0, playSessionId: playSessionId, playMethod: currentPlayMethod)
+                    } catch {
+                        logger.error("reportPlaybackStart failed: \(error.localizedDescription, privacy: .public)")
+                    }
                     startProgressReporting()
                 }
                 setupSegmentTracking()
@@ -342,7 +357,11 @@ final class PlayerViewModel: ObservableObject {
                 // status observer re-applies it once HLS/transcode is ready.
                 await player?.seek(to: startTime)
                 if !isOffline {
-                    try? await client.reportPlaybackStart(itemId: freshItem.id, positionTicks: startTicks, playSessionId: playSessionId, playMethod: currentPlayMethod)
+                    do {
+                        try await client.reportPlaybackStart(itemId: freshItem.id, positionTicks: startTicks, playSessionId: playSessionId, playMethod: currentPlayMethod)
+                    } catch {
+                        logger.error("reportPlaybackStart failed: \(error.localizedDescription, privacy: .public)")
+                    }
                     startProgressReporting()
                 }
                 setupSegmentTracking()
@@ -353,7 +372,11 @@ final class PlayerViewModel: ObservableObject {
                 resumePositionTicks = 0
                 pendingResumeTicks = 0
                 if !isOffline {
-                    try? await client.reportPlaybackStart(itemId: freshItem.id, positionTicks: 0, playSessionId: playSessionId, playMethod: currentPlayMethod)
+                    do {
+                        try await client.reportPlaybackStart(itemId: freshItem.id, positionTicks: 0, playSessionId: playSessionId, playMethod: currentPlayMethod)
+                    } catch {
+                        logger.error("reportPlaybackStart failed: \(error.localizedDescription, privacy: .public)")
+                    }
                     startProgressReporting()
                 }
                 setupSegmentTracking()
@@ -386,7 +409,11 @@ final class PlayerViewModel: ObservableObject {
         let positionTicks = Int64(currentTime.seconds * 10_000_000)
         let isPaused = player.timeControlStatus == .paused
 
-        try? await client.reportPlaybackProgress(itemId: item.id, positionTicks: positionTicks, isPaused: isPaused, playSessionId: playSessionId)
+        do {
+            try await client.reportPlaybackProgress(itemId: item.id, positionTicks: positionTicks, isPaused: isPaused, playSessionId: playSessionId)
+        } catch {
+            logger.error("reportPlaybackProgress failed: \(error.localizedDescription, privacy: .public)")
+        }
     }
 
     private func handlePlaybackEnded() async {
@@ -401,10 +428,18 @@ final class PlayerViewModel: ObservableObject {
             // Mark as watched by reporting position at the end
             if let duration = player?.currentItem?.duration.seconds, duration.isFinite {
                 let endTicks = Int64(duration * 10_000_000)
-                try? await client.reportPlaybackStopped(itemId: item.id, positionTicks: endTicks, playSessionId: playSessionId)
+                do {
+                    try await client.reportPlaybackStopped(itemId: item.id, positionTicks: endTicks, playSessionId: playSessionId)
+                } catch {
+                    logger.error("reportPlaybackStopped failed: \(error.localizedDescription, privacy: .public)")
+                }
             }
             // Mark item as played
-            try? await client.markPlayed(itemId: item.id)
+            do {
+                try await client.markPlayed(itemId: item.id)
+            } catch {
+                logger.error("markPlayed failed: \(error.localizedDescription, privacy: .public)")
+            }
 
             // Check for next episode/video if this is an episode or video
             if playbackSettings.autoPlayNextEpisode, let next = await fetchNextItem(for: item) {
@@ -531,7 +566,11 @@ final class PlayerViewModel: ObservableObject {
         // Kill the old transcode session before requesting a new one, so the
         // server isn't left encoding a stream nobody is watching.
         if let playSessionId, currentMediaSource?.transcodingUrl != nil {
-            try? await client.stopActiveEncoding(playSessionId: playSessionId)
+            do {
+                try await client.stopActiveEncoding(playSessionId: playSessionId)
+            } catch {
+                logger.error("stopActiveEncoding failed: \(error.localizedDescription, privacy: .public)")
+            }
         }
 
         do {
@@ -715,13 +754,21 @@ final class PlayerViewModel: ObservableObject {
             }
 
             if !isOfflinePlayback {
-                try? await client.reportPlaybackStopped(itemId: item.id, positionTicks: positionTicks, playSessionId: playSessionId)
+                do {
+                    try await client.reportPlaybackStopped(itemId: item.id, positionTicks: positionTicks, playSessionId: playSessionId)
+                } catch {
+                    logger.error("reportPlaybackStopped failed: \(error.localizedDescription, privacy: .public)")
+                }
             }
         }
 
         // Kill the session's server-side transcode, if one was active.
         if !isOfflinePlayback, let playSessionId, currentMediaSource?.transcodingUrl != nil {
-            try? await client.stopActiveEncoding(playSessionId: playSessionId)
+            do {
+                try await client.stopActiveEncoding(playSessionId: playSessionId)
+            } catch {
+                logger.error("stopActiveEncoding failed: \(error.localizedDescription, privacy: .public)")
+            }
         }
         playSessionId = nil
 

--- a/Shared/ViewModels/PlayerViewModel.swift
+++ b/Shared/ViewModels/PlayerViewModel.swift
@@ -64,7 +64,6 @@ enum QualityOption: String, CaseIterable, Identifiable {
     }
 }
 
-
 // Playback reporting is best-effort by design -- a failed report must never
 // interrupt playback -- but swallowing it silently meant watch state could
 // stop syncing with no trace at all.


### PR DESCRIPTION
Closes #113. Partially addresses #143 and #149.

### #143 — HeroSection timer stacking
`startAutoAdvance()` assigned `autoAdvanceTimer` without invalidating the previous one, so a second `onAppear` with no intervening `onDisappear` (tab switch, navigation pop) orphaned a timer that kept mutating `currentIndex`. The hero then advanced at a multiple of the intended rate and never settled.

`HomeView.startAutoRefresh` **twelve lines above** already did the invalidate — this just matches it. The HomeView half of #143 was already fixed; this was the remaining half.

Worth noting: this is the same defect class as the Roku HeroBanner rotator fixed today in `sashimi-roku` #79. The pattern repeats across both codebases.

### #149 — silent playback reporting
Every playback report was a bare `try? await`, so a failure to report start / progress / stopped / markPlayed was **indistinguishable from success**. Watch state could silently stop syncing with no trace anywhere — exactly the class of bug that's invisible until someone notices their resume points are wrong.

These are best-effort by design and must never interrupt playback, so the calls still don't throw — they just log now. 10 call sites converted to `do`/`catch` with an `os` Logger, matching the existing `HomeViewModel` pattern. `stopActiveEncoding` is included, since a silent failure there leaks a server-side transcode.

`getOwnSession()` is deliberately left as `try?` — it's a guard for an optional capability, not a report.

### #113 — "Resume S2,024:E1,234" on iPad
Passing an interpolated string *literal* to `Label` picks the `LocalizedStringKey` overload, which formats `Int` with grouping separators. YouTube items use the year as the season number, so the separators showed up. Building the `String` first selects the `StringProtocol` overload instead.

`PhoneDetailView` already did exactly this, which is why iPhone never showed the bug — this brings iPad in line.

### Verification
- tvOS: **153 tests, 0 failures** (10 skipped — `XCTSkipUnless` keychain guards, correct in a simulator)
- `SashimiMobile`: builds clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XzUNvRCXML3DJe98KBCGkN
