### PR TITLE
Clear the App Store submission blockers

### DIFF
--- a/Sashimi/Info.plist
+++ b/Sashimi/Info.plist
@@ -38,6 +38,12 @@
 		<key>NSAllowsLocalNetworking</key>
 		<true/>
 	</dict>
+	<key>NSBonjourServices</key>
+	<array>
+		<string>_jellyfin._tcp</string>
+	</array>
+	<key>NSLocalNetworkUsageDescription</key>
+	<string>Sashimi looks for Jellyfin servers on your local network.</string>
 	<key>UILaunchScreen</key>
 	<dict/>
 </dict>

--- a/Sashimi/PrivacyInfo.xcprivacy
+++ b/Sashimi/PrivacyInfo.xcprivacy
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>NSPrivacyTracking</key>
+	<false/>
+	<key>NSPrivacyTrackingDomains</key>
+	<array/>
+	<key>NSPrivacyCollectedDataTypes</key>
+	<array/>
+	<key>NSPrivacyAccessedAPITypes</key>
+	<array>
+		<dict>
+			<key>NSPrivacyAccessedAPIType</key>
+			<string>NSPrivacyAccessedAPICategoryUserDefaults</string>
+			<key>NSPrivacyAccessedAPITypeReasons</key>
+			<array>
+				<!-- CA92.1: app-private defaults (settings, search history, home row
+				     layout) read and written only by this app. -->
+				<string>CA92.1</string>
+				<!-- 1C8F.1: the app-group suite shared with the Top Shelf extension.
+				     CA92.1 alone would be wrong here because that reason explicitly
+				     excludes data readable by another bundle. -->
+				<string>1C8F.1</string>
+			</array>
+		</dict>
+	</array>
+</dict>
+</plist>

--- a/TopShelf/PrivacyInfo.xcprivacy
+++ b/TopShelf/PrivacyInfo.xcprivacy
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>NSPrivacyTracking</key>
+	<false/>
+	<key>NSPrivacyTrackingDomains</key>
+	<array/>
+	<key>NSPrivacyCollectedDataTypes</key>
+	<array/>
+	<key>NSPrivacyAccessedAPITypes</key>
+	<array>
+		<dict>
+			<key>NSPrivacyAccessedAPIType</key>
+			<string>NSPrivacyAccessedAPICategoryUserDefaults</string>
+			<key>NSPrivacyAccessedAPITypeReasons</key>
+			<array>
+				<!-- 1C8F.1: this extension only ever reads the app-group suite the
+				     host app writes; it has no defaults of its own. -->
+				<string>1C8F.1</string>
+			</array>
+		</dict>
+	</array>
+</dict>
+</plist>

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -98,6 +98,7 @@ platform :tvos do
     upload_to_testflight(
       api_key: api_key,
       app_identifier: "com.mondominator.sashimi",
+      app_platform: "appletvos",
       skip_waiting_for_build_processing: true,
       # Only this build's changes (commits since the previous beta tag),
       # merge commits excluded — keeps TestFlight notes short.
@@ -115,7 +116,7 @@ platform :tvos do
 
     # Tag the release
     add_git_tag(
-      tag: "v#{get_version_number}-beta.#{lane_context[SharedValues::BUILD_NUMBER]}"
+      tag: "v#{get_version_number(target: 'Sashimi')}-beta.#{lane_context[SharedValues::BUILD_NUMBER]}"
     ) unless is_ci
   end
 
@@ -135,6 +136,13 @@ platform :tvos do
 
     # Upload to App Store
     upload_to_app_store(
+      # Explicit: the Appfile scopes an Array to :release for match, and
+      # deliver's app_identifier is typed String -- inheriting the Array raises
+      # "'app_identifier' value must be a String! Found Array instead."
+      app_identifier: "com.mondominator.sashimi",
+      # Without this, deliver defaults to "ios" and writes the tvOS metadata
+      # onto the iOS platform of the universal listing.
+      platform: "appletvos",
       skip_metadata: false,
       skip_screenshots: true,  # Set to false when screenshots are ready
       submit_for_review: false, # Set to true for auto-submit
@@ -143,7 +151,7 @@ platform :tvos do
     )
 
     # Tag the release
-    version = get_version_number
+    version = get_version_number(target: "Sashimi")
     add_git_tag(tag: "v#{version}") unless is_ci
     push_git_tags unless is_ci
   end

--- a/fastlane/metadata/en-US/apple_tv_privacy_policy.txt
+++ b/fastlane/metadata/en-US/apple_tv_privacy_policy.txt
@@ -1,70 +1,70 @@
-# Privacy Policy for Sashimi
+Privacy Policy for Sashimi
 
-**Last updated: July 2026**
+Last updated: July 2026
 
-## Overview
+Overview
 
 Sashimi is a client for Jellyfin media servers, available for Apple TV, iPhone and iPad. This privacy policy explains how Sashimi handles your data.
 
-## Data Collection
+Data Collection
 
-**Sashimi does not collect, store, or transmit any personal data to us or any third parties.**
+Sashimi does not collect, store, or transmit any personal data to us or any third parties.
 
-### What Sashimi Stores Locally
+What Sashimi Stores Locally
 
 Sashimi stores the following data locally on your device:
 
-1. **Server Connection Details**
+1. Server Connection Details
    - Your Jellyfin server URL
    - Authentication tokens (stored securely in iOS Keychain)
 
-2. **User Preferences**
+2. User Preferences
    - Home screen customization settings
    - Video quality preferences
 
-3. **Playback State**
+3. Playback State
    - Current playback position (synced with your Jellyfin server)
 
-4. **Downloaded Media (iPhone and iPad only)**
+4. Downloaded Media (iPhone and iPad only)
    - Movies and episodes you explicitly choose to download, stored in the app's
      private container so they can be played without a network connection
    - Subtitle files accompanying those downloads
    - A local database recording what is downloaded and how far you have watched
    - Downloads never leave your device, and deleting the app removes all of them
 
-### Data Transmission
+Data Transmission
 
 Sashimi only communicates with:
 
-1. **Your Jellyfin Server** - All media browsing, streaming, and playback progress is sent directly to your own Jellyfin server. This communication is between your device and your server only.
+1. Your Jellyfin Server - All media browsing, streaming, and playback progress is sent directly to your own Jellyfin server. This communication is between your device and your server only.
 
-2. **No Third-Party Services** - Sashimi does not use any analytics, tracking, crash reporting, or advertising services.
+2. No Third-Party Services - Sashimi does not use any analytics, tracking, crash reporting, or advertising services.
 
-## Data Storage Security
+Data Storage Security
 
 - Authentication tokens are stored in the iOS Keychain using industry-standard encryption
 - No sensitive data is stored in plain text
 - Data is stored only on your device and your Jellyfin server
 
-## Your Jellyfin Server
+Your Jellyfin Server
 
 Your Jellyfin server has its own privacy practices. Sashimi does not control what data your Jellyfin server collects or stores. Please refer to the Jellyfin documentation and your server administrator for information about server-side data handling.
 
-## Children's Privacy
+Children's Privacy
 
 Sashimi does not knowingly collect any information from children. The app requires access to a Jellyfin server, which is typically set up by adults.
 
-## Changes to This Policy
+Changes to This Policy
 
 We may update this privacy policy from time to time. Any changes will be posted to this page and the app's App Store listing.
 
-## Contact
+Contact
 
 If you have questions about this privacy policy, please open an issue on our GitHub repository:
 
 https://github.com/bitstorm-labs/sashimi-apple/issues
 
-## Open Source
+Open Source
 
 Sashimi is open source software. You can review the complete source code to verify our privacy practices:
 

--- a/fastlane/metadata/en-US/description.txt
+++ b/fastlane/metadata/en-US/description.txt
@@ -1,4 +1,4 @@
-Sashimi is a native tvOS client for Jellyfin media servers, bringing your personal media library to your Apple TV with a beautiful, intuitive interface.
+Sashimi is a native client for Jellyfin media servers, bringing your personal media library to Apple TV, iPhone and iPad with a fast, focused interface.
 
 FEATURES
 
@@ -17,13 +17,18 @@ Top Shelf Integration
 - Continue watching your favorite shows with one click
 
 Beautiful Design
-- Native SwiftUI interface designed specifically for Apple TV
+- Native SwiftUI interface built for each device
 - Smooth animations and transitions
-- Easy navigation with the Siri Remote
+- Siri Remote navigation on Apple TV
+
+On iPhone and iPad
+- Download movies and episodes to watch offline
+- Picture in Picture and background audio
+- Separate layouts tuned for iPhone and for iPad
 
 REQUIREMENTS
 
 - A Jellyfin media server (self-hosted or remote)
-- tvOS 17.0 or later
+- tvOS 17.0 or later, or iOS/iPadOS 17.0 or later
 
 Sashimi is open source and community-driven. We welcome feedback and contributions!

--- a/fastlane/metadata/en-US/keywords.txt
+++ b/fastlane/metadata/en-US/keywords.txt
@@ -1,1 +1,1 @@
-jellyfin,media,streaming,movies,tv shows,video,player,home theater,plex alternative,media server
+jellyfin,media,streaming,movies,tv shows,video,player,home theater,media server,offline

--- a/fastlane/metadata/en-US/privacy_url.txt
+++ b/fastlane/metadata/en-US/privacy_url.txt
@@ -1,1 +1,1 @@
-https://github.com/mondominator/sashimi/blob/main/PRIVACY.md
+https://github.com/bitstorm-labs/sashimi-apple/blob/main/PRIVACY.md

--- a/fastlane/metadata/en-US/release_notes.txt
+++ b/fastlane/metadata/en-US/release_notes.txt
@@ -1,4 +1,4 @@
-Initial release of Sashimi for Apple TV!
+Initial release of Sashimi for Apple TV, iPhone and iPad!
 
 - Browse your Jellyfin media library
 - Stream movies and TV shows

--- a/fastlane/metadata/en-US/subtitle.txt
+++ b/fastlane/metadata/en-US/subtitle.txt
@@ -1,1 +1,1 @@
-Jellyfin Client for Apple TV
+Jellyfin Client for Apple Devices

--- a/fastlane/metadata/en-US/support_url.txt
+++ b/fastlane/metadata/en-US/support_url.txt
@@ -1,1 +1,1 @@
-https://github.com/mondominator/sashimi/issues
+https://github.com/bitstorm-labs/sashimi-apple/issues

--- a/project.yml
+++ b/project.yml
@@ -35,12 +35,6 @@ targets:
       - path: Sashimi
         excludes:
           - "**/.DS_Store"
-          - "CatIcon.imagestack"
-          - "ChopsticksIcon.imagestack"
-          - "CatIcon.png"
-          - "CatIcon@2x.png"
-          - "ChopsticksIcon.png"
-          - "ChopsticksIcon@2x.png"
       - path: Shared
         excludes:
           - "**/.DS_Store"
@@ -55,6 +49,11 @@ targets:
         UILaunchScreen: {}
         NSAppTransportSecurity:
           NSAllowsLocalNetworking: true
+        # Without these two, tvOS 16+ denies NWBrowser outright and server
+        # discovery silently returns zero results forever.
+        NSBonjourServices:
+          - _jellyfin._tcp
+        NSLocalNetworkUsageDescription: Sashimi looks for Jellyfin servers on your local network.
         CFBundleURLTypes:
           - CFBundleURLSchemes:
               - sashimi


### PR DESCRIPTION
Closes #305, #306, #307, #308, #310. Partially addresses #309, #312.

### #305 — privacy manifest (submission blocker)
The tvOS target shipped **no** `PrivacyInfo.xcprivacy` while calling `NSUserDefaults` in five places → **ITMS-91053** on upload. TestFlight only warns, which is exactly why this survived; it would have stopped the first real App Store submission.

The reason code matters here: the manifest declares **both** `CA92.1` (app-private defaults) **and `1C8F.1`** (the app-group suite shared with Top Shelf). `CA92.1` alone would be wrong — it explicitly excludes data readable by another bundle, and `HomeViewModel` writes that suite for the extension to read. `TopShelf` gets its own manifest with `1C8F.1` only, since it just reads.

### #307 — discovery has never worked
tvOS 16+ denies `NWBrowser` without `NSBonjourServices`, so LAN server discovery returns zero results **permanently**, not intermittently. Added `NSBonjourServices` (`_jellyfin._tcp`) and `NSLocalNetworkUsageDescription`.

### #306 — release lane crashed before upload (submission blocker)
It inherited an Array `app_identifier` from the Appfile, but `deliver` types it `String`. Passed explicitly.

### #309 — release lane risks
Both tvOS upload lanes defaulted to platform `"ios"`, so `deliver` would write tvOS metadata onto the **iOS** platform of the universal listing. `get_version_number` was unqualified against three non-test targets, which raises *after* the upload succeeds. Store URLs still pointed at the pre-rename `mondominator/sashimi` and worked only via GitHub's 301.

### #308 — three metadata rejections
- No `apple_tv_privacy_policy.txt` — tvOS requires the policy as **text**, since it can't open a browser. Generated from `PRIVACY.md`.
- `"plex alternative"` in keywords — third-party trademark, Guideline 5.2.1.
- tvOS-only copy on a listing spanning Apple TV, iPhone and iPad, while iOS ships downloads, PiP and background audio documented nowhere.

### #310 — PRIVACY.md
Said "tvOS client", dated January 2025, and omitted **downloaded media** — the iOS app's largest data-at-rest category. App Privacy answers have to match the policy.

### Verification — and a trap worth knowing
Verified against a **clean** build, which mattered. An incremental build reported `BUILD SUCCEEDED` while still carrying a **two-day-old bundle** containing neither the manifest nor the Bonjour keys. I nearly recorded a false negative. After `clean build`:

```
manifest: PRESENT
NSBonjourServices: _jellyfin._tcp
usage desc: Sashimi looks for Jellyfin servers on your local network.
```

tvOS **150 tests / 0 failures**, `SashimiMobile` builds, `swiftlint --strict` clean, `Fastfile` passes `ruby -c`.

**Not verified:** that discovery now actually finds a server. That needs a device on the same LAN as a Jellyfin instance — and note the Jellyfin server here is in Docker bridge mode, which blocks broadcast discovery independently of this fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XzUNvRCXML3DJe98KBCGkN
