### PR TITLE
Quality change no longer wipes the resume point; offline playback gets observers

### DIFF
--- a/Shared/ViewModels/PlayerViewModel.swift
+++ b/Shared/ViewModels/PlayerViewModel.swift
@@ -299,7 +299,11 @@ final class PlayerViewModel: ObservableObject {
 
                 let asset = AVURLAsset(url: localFileURL)
                 let playerItem = AVPlayerItem(asset: asset, automaticallyLoadedAssetKeys: ["playable", "duration"])
-                player = AVPlayer(playerItem: playerItem)
+                // Same observer wiring as the online path. loadMedia has already
+                // torn down the previous endObserver, so building the player
+                // directly here left downloads with no end-of-item notification
+                // and no way to surface a decode failure.
+                makePlayerAndObservers(for: playerItem)
             } else {
                 // Online playback - fetch fresh data from server
                 freshItem = try await client.getItem(itemId: item.id)
@@ -580,8 +584,14 @@ final class PlayerViewModel: ObservableObject {
             isLoading = false
             updateNowPlayingInfo(item: item)
 
-            // Seek to saved position
+            // Seek to saved position. A bare pre-ready seek is silently dropped
+            // on HLS/transcode streams -- and forceTranscode above means any
+            // non-Auto pick is ALWAYS that case -- so arm pendingResumeTicks
+            // too and let the status observer re-apply it once the item is
+            // ready. Without this the stream restarts at 0:00 and the 5s
+            // progress report then overwrites the server's resume point with 0.
             if positionTicks > 0 {
+                pendingResumeTicks = positionTicks
                 let seekTime = CMTime(value: positionTicks / 10000, timescale: 1000)
                 await player?.seek(to: seekTime)
             }
@@ -596,7 +606,12 @@ final class PlayerViewModel: ObservableObject {
                 applyPreferredSubtitles()
             }
 
-            // Resume playback and tracking
+            // Resume playback and tracking. Segments belong to the ITEM, but
+            // cleanupSegmentTracking() cleared them with the player, and
+            // fetchSegments is otherwise only called from loadMedia -- so
+            // without this the observer runs against an empty array and skip
+            // intro/credits stays dead for the rest of the episode.
+            await fetchSegments(itemId: item.id)
             startProgressReporting()
             setupSegmentTracking()
             player?.play()
@@ -669,6 +684,17 @@ final class PlayerViewModel: ObservableObject {
             setupChapterMarkers(on: playerItem, chapters: chapters, duration: duration)
         }
 
+        makePlayerAndObservers(for: playerItem)
+    }
+
+    /// Builds the AVPlayer and wires every observer it needs.
+    ///
+    /// Factored out because offline playback builds its own AVPlayer and used
+    /// to skip all of this: downloaded episodes never fired
+    /// AVPlayerItemDidPlayToEndTime (so they never dismissed and auto-play-next
+    /// was dead for downloads), and a corrupt download sat on a black screen
+    /// with no error because nothing observed .failed.
+    private func makePlayerAndObservers(for playerItem: AVPlayerItem) {
         errorObserver = playerItem.observe(\.status) { [weak self] observed, _ in
             Task { @MainActor in
                 if observed.status == .failed {


### PR DESCRIPTION
Closes #294, #295, #296. Also fixes #292 (duplicate of #295).

### #294 — quality change wiped the server-side resume point
Changing quality mid-playback restarted from 0:00 **and** overwrote Jellyfin's saved position with 0.

`changeQuality` did a bare pre-ready seek on a brand-new `AVPlayer`. This file already documents that such a seek is silently dropped for HLS/transcode streams — which is precisely why `pendingResumeTicks` + `applyPendingResumeSeekIfNeeded()` exist for `loadMedia`. `changeQuality` never armed `pendingResumeTicks`, so the `readyToPlay` retry was a no-op for it. And because `changeQuality` passes `forceTranscode` for any non-Auto pick, that path is **always** the case where the seek gets dropped.

The damaging part was the follow-on: `startProgressReporting` resumed ~5s later and reported position 0, propagating the loss to every other client.

### #295 / #292 — skip intro/credits died after a quality change
`cleanupSegmentTracking` clears `segments`, but `fetchSegments` was only ever called from `loadMedia`, so `setupSegmentTracking` re-armed the observer against an empty array for the rest of the episode. Segments belong to the *item*, not the player.

### #296 — offline playback had no observers
The offline branch built its own `AVPlayer` and skipped all observer wiring, while `loadMedia` had already torn down the previous `endObserver`. So:
- Downloaded episodes never fired `AVPlayerItemDidPlayToEndTime` → never dismissed, and **auto-play-next was dead for all downloads**
- A corrupt download sat on a **permanent black screen**, because nothing observed `.failed`

Extracted `makePlayerAndObservers(for:)` and called it from both paths.

**Checked before trusting it:** `handlePlaybackEnded` already guards its server work behind `!isOfflinePlayback` and sets `playbackEnded` *outside* that guard — so downloads now dismiss correctly without trying to report to an unreachable server. Auto-play-next stays inside the online-only branch; playing the next *downloaded* episode would be new behaviour, so that's a separate gap rather than something this regressed.

### Verification
tvOS **150 tests / 0 failures**, `SashimiMobile` builds, `swiftlint --strict` clean.

**Not device-verified:** the offline paths need a real download to exercise end to end, and the quality-change resume needs a transcoding server. Both are worth a pass on hardware before you rely on them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XzUNvRCXML3DJe98KBCGkN
