### PR TITLE
Three UI races: stale season episodes, interleaved library pages, lost offline position

### DIFF
--- a/Sashimi/Views/Detail/MediaDetailView.swift
+++ b/Sashimi/Views/Detail/MediaDetailView.swift
@@ -1120,10 +1120,18 @@ struct MediaDetailView: View {
     private func loadEpisodesForSeason(seriesId: String, season: BaseItemDto) async {
         isLoadingEpisodes = true
         do {
-            episodes = try await JellyfinClient.shared.getEpisodes(seriesId: seriesId, seasonId: season.id)
+            let loaded = try await JellyfinClient.shared.getEpisodes(seriesId: seriesId, seasonId: season.id)
+            // Two quick tab presses race: if S1 resolves after S2 was selected,
+            // assigning here would show S1's episodes under a highlighted S2
+            // tab, and playing "S2E1" would start S1E1. Drop the stale result,
+            // and leave the spinner up for the request still in flight.
+            guard selectedSeason?.id == season.id else { return }
+            episodes = loaded
         } catch {
+            guard selectedSeason?.id == season.id else { return }
             ToastManager.shared.show("Failed to load episodes")
         }
+        guard selectedSeason?.id == season.id else { return }
         isLoadingEpisodes = false
     }
 

--- a/Sashimi/Views/Library/LibraryView.swift
+++ b/Sashimi/Views/Library/LibraryView.swift
@@ -230,6 +230,9 @@ struct LibraryDetailView: View {
     @State private var items: [BaseItemDto] = []
     @State private var isLoading = true
     @State private var isLoadingMore = false
+    /// Bumped whenever the sort/filter changes, so a page that was already in
+    /// flight can tell it belongs to a superseded ordering.
+    @State private var loadGeneration = 0
     @State private var selectedItem: BaseItemDto?
     @State private var selectedItemIsYouTube = false
     @State private var totalCount = 0
@@ -455,6 +458,7 @@ struct LibraryDetailView: View {
     private func loadAllRemainingItems() async {
         guard !isLoadingMore && items.count < totalCount else { return }
         isLoadingMore = true
+        let generation = loadGeneration
         do {
             let includeTypes: [ItemType]? = switch library.collectionType {
             case "tvshows": [.series]
@@ -472,6 +476,8 @@ struct LibraryDetailView: View {
                 isPlayed: filter.isPlayed,
                 isFavorite: filter.isFavorite
             )
+            // Sort/filter changed mid-flight -- this page is from the old ordering.
+            guard generation == loadGeneration else { return }
             items.append(contentsOf: response.items)
         } catch {
             // Silent fail — alphabet jump is best-effort
@@ -527,6 +533,10 @@ struct LibraryDetailView: View {
     }
 
     private func reloadWithNewSort() async {
+        // Invalidate any page already in flight: its startIndex was computed
+        // from the pre-reset count and against the OLD ordering, so appending
+        // it would interleave two sorts and duplicate rows.
+        loadGeneration &+= 1
         items = []
         totalCount = 0
         await loadItems()
@@ -536,6 +546,7 @@ struct LibraryDetailView: View {
         guard !isLoadingMore && hasMore else { return }
 
         isLoadingMore = true
+        let generation = loadGeneration
         do {
             let includeTypes: [ItemType]? = switch library.collectionType {
             case "tvshows": [.series]
@@ -554,6 +565,8 @@ struct LibraryDetailView: View {
                 isPlayed: filter.isPlayed,
                 isFavorite: filter.isFavorite
             )
+            // Sort/filter changed while this page was in flight -- discard it.
+            guard generation == loadGeneration else { return }
             items.append(contentsOf: response.items)
         } catch is CancellationError {
             // Ignore

--- a/SashimiMobile/Views/Player/MobilePlayerView.swift
+++ b/SashimiMobile/Views/Player/MobilePlayerView.swift
@@ -93,10 +93,7 @@ struct MobilePlayerView: View {
         }
         .onDisappear {
             viewModel.player?.pause()
-            if localFileURL != nil, let currentTime = viewModel.player?.currentTime() {
-                let ticks = Int64(currentTime.seconds * 10_000_000)
-                DownloadManager.shared.savePlaybackPosition(itemId: item.id, positionTicks: ticks)
-            }
+            saveOfflinePositionIfNeeded()
             Task {
                 await viewModel.stop()
                 NotificationCenter.default.post(name: .playbackDidStop, object: nil)
@@ -157,6 +154,12 @@ struct MobilePlayerView: View {
             // Close button
             Button {
                 viewModel.player?.pause()
+                // Capture BEFORE stop(): stop() nils the player, and for
+                // offline playback it hits no await first, so it completes long
+                // before the dismiss animation lets onDisappear run -- which is
+                // where the offline save lives. The position was silently lost
+                // every time the X was used.
+                saveOfflinePositionIfNeeded()
                 Task { await viewModel.stop() }
                 dismiss()
             } label: {
@@ -305,6 +308,12 @@ struct MobilePlayerView: View {
             // Always show a close button
             Button {
                 viewModel.player?.pause()
+                // Capture BEFORE stop(): stop() nils the player, and for
+                // offline playback it hits no await first, so it completes long
+                // before the dismiss animation lets onDisappear run -- which is
+                // where the offline save lives. The position was silently lost
+                // every time the X was used.
+                saveOfflinePositionIfNeeded()
                 Task { await viewModel.stop() }
                 dismiss()
             } label: {
@@ -340,6 +349,15 @@ struct MobilePlayerView: View {
             .frame(maxWidth: .infinity, maxHeight: .infinity)
         }
         .ignoresSafeArea()
+    }
+
+    /// Persists the offline resume point. Safe to call more than once: the
+    /// last call before the player is torn down wins, and it no-ops once the
+    /// player is gone.
+    private func saveOfflinePositionIfNeeded() {
+        guard localFileURL != nil, let currentTime = viewModel.player?.currentTime() else { return }
+        let ticks = Int64(currentTime.seconds * 10_000_000)
+        DownloadManager.shared.savePlaybackPosition(itemId: item.id, positionTicks: ticks)
     }
 }
 


### PR DESCRIPTION
Closes #300, #301, #302.

### #301 — wrong season's episodes
Clicking S1 then immediately S2 could leave **S1's episodes on screen under a highlighted S2 tab**, so playing "S2E1" started S1E1. `loadEpisodesForSeason` had no cancellation and no staleness check.

It now drops a result whose season is no longer selected, and leaves the spinner up for the request still in flight — previously the first completion cleared it while the second was still running.

### #302 — interleaved library pages
Changing sort or filter while a page was in flight interleaved two orderings: `reloadWithNewSort` resets `items`, but the running load appends a page whose `startIndex` was computed from the pre-reset count against the **old** sort. Result: 50 date-sorted items followed by 50 name-sorted ones, with duplicates.

Added a `loadGeneration` counter, bumped on reload and checked before every append.

**Both paging paths needed it**, not just the obvious one — `loadAllRemainingItems` (the "load everything" path behind Shuffle) appends the same way. My first pass put the capture in one function and the guard in the other, which wouldn't have compiled; the build caught it, not the reading.

### #300 — offline position lost on the X button
The offline resume point was saved only in `.onDisappear`, read from `viewModel.player`. The X button calls `stop()` (which nils the player) then `dismiss()`; for offline, `stop()` hits no `await` first, so it finishes well before the dismiss animation lets `onDisappear` run. **The position was lost every time the X was used.**

Factored into `saveOfflinePositionIfNeeded()`, called before `stop()` from both close buttons and still from `onDisappear` — it's idempotent and no-ops once the player is gone.

### Verification
tvOS **151 tests / 0 failures**, `SashimiMobile` builds, `swiftlint --strict` clean.

The offline path still wants a device with a real download to confirm end to end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XzUNvRCXML3DJe98KBCGkN
