### PR TITLE
Discover servers with Jellyfin's UDP broadcast instead of Bonjour

### DIFF
--- a/SashimiTests/ServerDiscoveryTests.swift
+++ b/SashimiTests/ServerDiscoveryTests.swift
@@ -1,0 +1,91 @@
+import XCTest
+@testable import Sashimi
+
+/// Discovery is a network protocol, so the useful tests come in two halves:
+/// pure parsing that always runs, and one live probe that skips when there is
+/// no Jellyfin on the LAN (same pattern as KeychainHelperTests, which skips
+/// when the simulator keychain is unavailable).
+final class ServerDiscoveryTests: XCTestCase {
+
+    // MARK: - Advertised address parsing
+
+    func testPortIsTakenFromAdvertisedAddress() {
+        XCTAssertEqual(ServerDiscovery.port(fromAdvertised: "http://192.168.1.10:8096"), 8096)
+        XCTAssertEqual(ServerDiscovery.port(fromAdvertised: "https://jelly.example.com:9096"), 9096)
+    }
+
+    func testPortIsParsedWhenSchemeIsMissing() {
+        // Jellyfin's reply is not guaranteed to include a scheme.
+        XCTAssertEqual(ServerDiscovery.port(fromAdvertised: "192.168.1.10:9096"), 9096)
+    }
+
+    func testPortIsNilWhenAbsentSoCallerCanDefault() {
+        // No port means the caller falls back to 8096 rather than guessing.
+        XCTAssertNil(ServerDiscovery.port(fromAdvertised: "http://192.168.1.10"))
+        XCTAssertNil(ServerDiscovery.port(fromAdvertised: "jellyfin.example.com"))
+        XCTAssertNil(ServerDiscovery.port(fromAdvertised: nil))
+    }
+
+    // MARK: - Live probe
+
+    /// Broadcasts on the real network and asserts we can parse a real reply.
+    ///
+    /// Skips when nothing answers, so CI (which has no Jellyfin) stays green
+    /// while a developer on the same LAN as a server gets real coverage. This
+    /// is the test that would have caught the original defect: the Bonjour
+    /// implementation could never have passed it, because Jellyfin advertises
+    /// no `_jellyfin._tcp` service.
+    @MainActor
+    func testDiscoveryFindsAServerOnTheLocalNetwork() async throws {
+        let discovery = ServerDiscovery()
+        discovery.startDiscovery()
+
+        // startDiscovery's probe window is 3s; give it headroom.
+        let deadline = Date().addingTimeInterval(8)
+        while discovery.isSearching, Date() < deadline {
+            try await Task.sleep(for: .milliseconds(200))
+        }
+
+        try XCTSkipUnless(
+            !discovery.discoveredServers.isEmpty,
+            "No Jellyfin server answered the UDP broadcast on this network - skipping the live half."
+        )
+
+        let server = try XCTUnwrap(discovery.discoveredServers.first)
+        XCTAssertFalse(server.id.isEmpty, "Server id is used to dedupe repeated probes")
+        XCTAssertFalse(server.name.isEmpty)
+        XCTAssertFalse(server.address.isEmpty)
+        XCTAssertGreaterThan(server.port, 0)
+
+        // The address must be the responder's source IP, not the advertised
+        // public hostname - that is what makes the URL usable on the LAN.
+        let url = try XCTUnwrap(server.url)
+        XCTAssertEqual(url.scheme, "http")
+        XCTAssertTrue(
+            server.address.allSatisfy { $0.isNumber || $0 == "." },
+            "Expected a dotted-quad source IP, got \(server.address)"
+        )
+    }
+
+    @MainActor
+    func testRepeatedProbesDoNotDuplicateTheSameServer() async throws {
+        let discovery = ServerDiscovery()
+
+        discovery.startDiscovery()
+        var deadline = Date().addingTimeInterval(8)
+        while discovery.isSearching, Date() < deadline {
+            try await Task.sleep(for: .milliseconds(200))
+        }
+        try XCTSkipUnless(!discovery.discoveredServers.isEmpty, "No server on this network - skipping.")
+        let firstCount = discovery.discoveredServers.count
+
+        discovery.startDiscovery()
+        deadline = Date().addingTimeInterval(8)
+        while discovery.isSearching, Date() < deadline {
+            try await Task.sleep(for: .milliseconds(200))
+        }
+
+        XCTAssertEqual(discovery.discoveredServers.count, firstCount,
+                       "A second probe must dedupe by server id, not stack duplicates")
+    }
+}

--- a/Shared/Services/ServerDiscovery.swift
+++ b/Shared/Services/ServerDiscovery.swift
@@ -1,129 +1,172 @@
 import Foundation
 import Network
+import os
 
-/// Discovers Jellyfin servers on the local network using mDNS/Bonjour
+private let logger = Logger(subsystem: "com.mondominator.sashimi", category: "ServerDiscovery")
+
+/// Discovers Jellyfin servers on the local network.
+///
+/// Uses Jellyfin's own auto-discovery protocol: broadcast the literal string
+/// `Who is JellyfinServer?` to UDP 7359 and collect the JSON replies.
+///
+/// This previously browsed Bonjour for `_jellyfin._tcp`, which finds nothing --
+/// Jellyfin does not advertise that service. Verified with `dns-sd -B` against a
+/// live 10.11 server on host networking: zero results, while the UDP broadcast
+/// replied immediately. The Roku client has always used this protocol.
+///
+/// `NSBonjourServices` / `NSLocalNetworkUsageDescription` are still required in
+/// Info.plist: the local-network privacy gate covers UDP broadcast too.
 @MainActor
 final class ServerDiscovery: ObservableObject {
     @Published private(set) var discoveredServers: [DiscoveredServer] = []
     @Published private(set) var isSearching = false
 
-    private var browser: NWBrowser?
+    private var listenTask: Task<Void, Never>?
+
+    private static let discoveryPort: UInt16 = 7359
+    private static let probe = "Who is JellyfinServer?"
+    /// Long enough for a busy server to answer, short enough that the UI does
+    /// not feel hung when nothing is there.
+    private static let listenSeconds: TimeInterval = 3
 
     struct DiscoveredServer: Identifiable, Hashable {
-        let id = UUID()
+        /// Jellyfin's own server id, so repeated probes dedupe to one entry
+        /// rather than stacking.
+        let id: String
         let name: String
         let address: String
         let port: Int
 
-        // Discovered servers are addressed over plain HTTP on purpose: mDNS
-        // discovery only finds servers on the local network, where Jellyfin's
-        // default setup is HTTP, and a self-signed HTTPS guess would fail
-        // validation anyway. Users can still type an https:// URL manually.
+        // Discovered servers are addressed over plain HTTP on purpose:
+        // discovery only reaches the local network, where Jellyfin's default
+        // setup is HTTP, and a self-signed HTTPS guess would fail validation
+        // anyway. Users can still type an https:// URL manually.
         var url: URL? {
             URL(string: "http://\(address):\(port)")
         }
     }
 
+    /// The subset of Jellyfin's discovery reply we act on.
+    private struct DiscoveryReply: Decodable {
+        let id: String
+        let name: String
+        let address: String?
+
+        enum CodingKeys: String, CodingKey {
+            case id = "Id"
+            case name = "Name"
+            case address = "Address"
+        }
+    }
+
     func startDiscovery() {
         guard !isSearching else { return }
-
         isSearching = true
         discoveredServers = []
 
-        // Browse for Jellyfin servers (they advertise as _jellyfin._tcp)
-        let parameters = NWParameters()
-        parameters.includePeerToPeer = true
-
-        browser = NWBrowser(for: .bonjour(type: "_jellyfin._tcp", domain: nil), using: parameters)
-
-        browser?.stateUpdateHandler = { [weak self] state in
-            Task { @MainActor in
-                switch state {
-                case .ready:
-                    break
-                case .failed, .cancelled:
-                    self?.isSearching = false
-                default:
-                    break
-                }
+        listenTask = Task { [weak self] in
+            let replies = await Self.probeNetwork()
+            guard let self, !Task.isCancelled else { return }
+            for reply in replies where !self.discoveredServers.contains(where: { $0.id == reply.id }) {
+                self.discoveredServers.append(reply)
             }
-        }
-
-        browser?.browseResultsChangedHandler = { [weak self] results, _ in
-            Task { @MainActor in
-                self?.processResults(results)
-            }
-        }
-
-        browser?.start(queue: .main)
-
-        // Stop after 10 seconds (weak self so the timeout doesn't keep a
-        // dismissed discovery screen's object alive for the full window)
-        Task { [weak self] in
-            try? await Task.sleep(for: .seconds(10))
-            self?.stopDiscovery()
+            self.isSearching = false
         }
     }
 
     func stopDiscovery() {
-        browser?.cancel()
-        browser = nil
+        listenTask?.cancel()
+        listenTask = nil
         isSearching = false
     }
 
-    private func processResults(_ results: Set<NWBrowser.Result>) {
-        for result in results {
-            if case let .service(name, _, _, _) = result.endpoint {
-                // Resolve the service to get the actual address
-                resolveService(result: result, name: name)
+    /// Broadcasts the probe and gathers replies.
+    ///
+    /// Runs off the main actor on a blocking BSD socket: Network.framework has
+    /// no first-class broadcast send, and a datagram listener would still need
+    /// the same receive loop.
+    nonisolated private static func probeNetwork() async -> [DiscoveredServer] {
+        await withCheckedContinuation { continuation in
+            DispatchQueue.global(qos: .userInitiated).async {
+                continuation.resume(returning: blockingProbe())
             }
         }
     }
 
-    private func resolveService(result: NWBrowser.Result, name: String) {
-        let connection = NWConnection(to: result.endpoint, using: .tcp)
+    nonisolated private static func blockingProbe() -> [DiscoveredServer] {
+        let sock = socket(AF_INET, SOCK_DGRAM, 0)
+        guard sock >= 0 else {
+            logger.error("discovery: socket() failed")
+            return []
+        }
+        defer { close(sock) }
 
-        connection.stateUpdateHandler = { [weak self] state in
-            switch state {
-            case .ready:
-                if let endpoint = connection.currentPath?.remoteEndpoint,
-                   case let .hostPort(host, port) = endpoint {
-                    let address: String
-                    switch host {
-                    case .ipv4(let ipv4):
-                        address = "\(ipv4)"
-                    case .ipv6(let ipv6):
-                        address = "\(ipv6)"
-                    case .name(let hostname, _):
-                        address = hostname
-                    @unknown default:
-                        address = "unknown"
-                    }
+        var yes: Int32 = 1
+        setsockopt(sock, SOL_SOCKET, SO_BROADCAST, &yes, socklen_t(MemoryLayout<Int32>.size))
 
-                    Task { @MainActor in
-                        let server = DiscoveredServer(
-                            name: name,
-                            address: address,
-                            port: Int(port.rawValue)
-                        )
-                        if let strongSelf = self,
-                           !strongSelf.discoveredServers.contains(where: { $0.address == address && $0.port == server.port }) {
-                            strongSelf.discoveredServers.append(server)
-                        }
-                    }
-                }
-                connection.cancel()
-            case .failed, .cancelled:
-                connection.cancel()
-            default:
-                break
+        // Bounded receive so the loop cannot outlive the window if replies stop.
+        var timeout = timeval(tv_sec: 0, tv_usec: 300_000)
+        setsockopt(sock, SOL_SOCKET, SO_RCVTIMEO, &timeout, socklen_t(MemoryLayout<timeval>.size))
+
+        var destination = sockaddr_in()
+        destination.sin_family = sa_family_t(AF_INET)
+        destination.sin_port = discoveryPort.bigEndian
+        destination.sin_addr.s_addr = INADDR_BROADCAST
+
+        let payload = Array(probe.utf8)
+        let sent = withUnsafePointer(to: &destination) { pointer in
+            pointer.withMemoryRebound(to: sockaddr.self, capacity: 1) { addr in
+                sendto(sock, payload, payload.count, 0, addr, socklen_t(MemoryLayout<sockaddr_in>.size))
             }
         }
+        guard sent > 0 else {
+            logger.error("discovery: broadcast send failed")
+            return []
+        }
 
-        connection.start(queue: .main)
+        var found: [DiscoveredServer] = []
+        var buffer = [UInt8](repeating: 0, count: 2048)
+        let deadline = Date().addingTimeInterval(listenSeconds)
+
+        while Date() < deadline {
+            var from = sockaddr_in()
+            var fromLength = socklen_t(MemoryLayout<sockaddr_in>.size)
+            let received = withUnsafeMutablePointer(to: &from) { pointer in
+                pointer.withMemoryRebound(to: sockaddr.self, capacity: 1) { addr in
+                    recvfrom(sock, &buffer, buffer.count, 0, addr, &fromLength)
+                }
+            }
+            guard received > 0 else { continue }   // timeout tick; keep waiting
+
+            guard let reply = try? JSONDecoder().decode(
+                DiscoveryReply.self,
+                from: Data(buffer[0..<received])
+            ) else { continue }
+
+            // Prefer the responder's source IP over the reply's `Address`: that
+            // field carries whatever the admin set as the public URL (often an
+            // external hostname), which is not what we want for a server we
+            // just found on the LAN.
+            let sourceIP = String(cString: inet_ntoa(from.sin_addr))
+            let port = Self.port(fromAdvertised: reply.address) ?? 8096
+
+            if !found.contains(where: { $0.id == reply.id }) {
+                found.append(DiscoveredServer(id: reply.id, name: reply.name, address: sourceIP, port: port))
+            }
+        }
+        return found
+    }
+
+    /// Pulls the port out of the advertised address, since the reply carries no
+    /// separate port field and the server may not be on the default 8096.
+    nonisolated static func port(fromAdvertised address: String?) -> Int? {
+        guard let address,
+              let components = URLComponents(string: address.contains("://") ? address : "http://\(address)")
+        else { return nil }
+        return components.port
     }
 
     deinit {
-        browser?.cancel()
+        listenTask?.cancel()
     }
 }


### PR DESCRIPTION
Closes #318.

`ServerDiscovery` browsed Bonjour for `_jellyfin._tcp` — **a service Jellyfin does not advertise**. Confirmed against a live 10.11 server on host networking: `dns-sd -B _jellyfin._tcp` returned zero results over 12s and `_services._dns-sd._udp` listed only `_http._tcp`, while a UDP broadcast to 7359 replied immediately.

So "Find Servers on Network" could never return a result on any network — which the tvOS client duly showed as *"No servers found on your network"*.

Replaced with Jellyfin's actual protocol: broadcast `Who is JellyfinServer?` to `255.255.255.255:7359` and collect JSON replies for 3s. This is what the Roku client has always done.

### Details worth knowing
- **Dedupe by the server's own `Id`**, so repeated probes don't stack entries.
- **The LAN address comes from the responder's source IP**, not the reply's `Address` field — that carries whatever the admin set as the public URL (here, `fin.bitstorm.ca`), which is useless for a server just found on the LAN. The advertised address is used only to recover a non-default port.
- **A blocking BSD socket on a background queue** rather than `NWConnection`: Network.framework has no first-class broadcast send, and a datagram listener would need the same receive loop anyway.
- **The #307 entitlements are still required** — the local-network privacy gate covers UDP broadcast too. That fix was necessary but not sufficient.

### Verified end to end, not reasoned about
Added `ServerDiscoveryTests` with a **live probe** that broadcasts on the real network and asserts a parsed reply:

```
testDiscoveryFindsAServerOnTheLocalNetwork      passed (3.119s)
testRepeatedProbesDoNotDuplicateTheSameServer   passed (6.254s)
Executed 156 tests, 0 failures
```

It **passed**, not skipped — so the broadcast genuinely went out, a reply came back, and the parsed address is a dotted-quad source IP. It uses `XCTSkipUnless` when nothing answers so CI stays green, matching the existing `KeychainHelperTests` pattern.

That test could never have passed against the Bonjour implementation, which is the point of adding it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XzUNvRCXML3DJe98KBCGkN
