### PR TITLE
Downloaded subtitles can finally be used offline

### DIFF
--- a/SashimiMobile/Downloads/Services/DownloadManager.swift
+++ b/SashimiMobile/Downloads/Services/DownloadManager.swift
@@ -353,6 +353,24 @@ final class DownloadManager: NSObject, ObservableObject {
         return record.videoFileURL
     }
 
+    /// The downloaded subtitle tracks for an item, in a form the shared player
+    /// can consume. Without this the .vtt files written at download time were
+    /// never read by anything.
+    func offlineSubtitles(for itemId: String) -> [OfflineSubtitle] {
+        guard let record = downloadStatus(for: itemId) else { return [] }
+        return record.subtitles.compactMap { subtitle in
+            let url = DownloadFileManager.subtitlesDirectory(for: itemId)
+                .appendingPathComponent(subtitle.fileName)
+            guard FileManager.default.fileExists(atPath: url.path) else { return nil }
+            return OfflineSubtitle(
+                index: subtitle.subtitleIndex,
+                language: subtitle.language,
+                displayTitle: subtitle.displayTitle,
+                fileURL: url
+            )
+        }
+    }
+
     func offlinePlaybackPosition(for itemId: String) -> Int64? {
         guard let context = mainContext else { return nil }
         let predicate = #Predicate<DownloadedItem> { $0.itemId == itemId }

--- a/SashimiMobile/Views/Player/MobilePlayerView.swift
+++ b/SashimiMobile/Views/Player/MobilePlayerView.swift
@@ -74,7 +74,11 @@ struct MobilePlayerView: View {
                 await viewModel.loadMedia(item: item, startFromBeginning: startFromBeginning, localFileURL: nil)
                 timeoutTask.cancel()
             } else {
-                await viewModel.loadMedia(item: item, localFileURL: localFileURL)
+                await viewModel.loadMedia(
+                    item: item,
+                    localFileURL: localFileURL,
+                    offlineSubtitles: DownloadManager.shared.offlineSubtitles(for: item.id)
+                )
                 // For offline content, apply locally-saved position if newer than server data
                 if let offlineTicks = DownloadManager.shared.offlinePlaybackPosition(for: item.id),
                    offlineTicks > 0 {

--- a/SashimiTests/ServerDiscoveryTests.swift
+++ b/SashimiTests/ServerDiscoveryTests.swift
@@ -1,0 +1,91 @@
+import XCTest
+@testable import Sashimi
+
+/// Discovery is a network protocol, so the useful tests come in two halves:
+/// pure parsing that always runs, and one live probe that skips when there is
+/// no Jellyfin on the LAN (same pattern as KeychainHelperTests, which skips
+/// when the simulator keychain is unavailable).
+final class ServerDiscoveryTests: XCTestCase {
+
+    // MARK: - Advertised address parsing
+
+    func testPortIsTakenFromAdvertisedAddress() {
+        XCTAssertEqual(ServerDiscovery.port(fromAdvertised: "http://192.168.1.10:8096"), 8096)
+        XCTAssertEqual(ServerDiscovery.port(fromAdvertised: "https://jelly.example.com:9096"), 9096)
+    }
+
+    func testPortIsParsedWhenSchemeIsMissing() {
+        // Jellyfin's reply is not guaranteed to include a scheme.
+        XCTAssertEqual(ServerDiscovery.port(fromAdvertised: "192.168.1.10:9096"), 9096)
+    }
+
+    func testPortIsNilWhenAbsentSoCallerCanDefault() {
+        // No port means the caller falls back to 8096 rather than guessing.
+        XCTAssertNil(ServerDiscovery.port(fromAdvertised: "http://192.168.1.10"))
+        XCTAssertNil(ServerDiscovery.port(fromAdvertised: "jellyfin.example.com"))
+        XCTAssertNil(ServerDiscovery.port(fromAdvertised: nil))
+    }
+
+    // MARK: - Live probe
+
+    /// Broadcasts on the real network and asserts we can parse a real reply.
+    ///
+    /// Skips when nothing answers, so CI (which has no Jellyfin) stays green
+    /// while a developer on the same LAN as a server gets real coverage. This
+    /// is the test that would have caught the original defect: the Bonjour
+    /// implementation could never have passed it, because Jellyfin advertises
+    /// no `_jellyfin._tcp` service.
+    @MainActor
+    func testDiscoveryFindsAServerOnTheLocalNetwork() async throws {
+        let discovery = ServerDiscovery()
+        discovery.startDiscovery()
+
+        // startDiscovery's probe window is 3s; give it headroom.
+        let deadline = Date().addingTimeInterval(8)
+        while discovery.isSearching, Date() < deadline {
+            try await Task.sleep(for: .milliseconds(200))
+        }
+
+        try XCTSkipUnless(
+            !discovery.discoveredServers.isEmpty,
+            "No Jellyfin server answered the UDP broadcast on this network - skipping the live half."
+        )
+
+        let server = try XCTUnwrap(discovery.discoveredServers.first)
+        XCTAssertFalse(server.id.isEmpty, "Server id is used to dedupe repeated probes")
+        XCTAssertFalse(server.name.isEmpty)
+        XCTAssertFalse(server.address.isEmpty)
+        XCTAssertGreaterThan(server.port, 0)
+
+        // The address must be the responder's source IP, not the advertised
+        // public hostname - that is what makes the URL usable on the LAN.
+        let url = try XCTUnwrap(server.url)
+        XCTAssertEqual(url.scheme, "http")
+        XCTAssertTrue(
+            server.address.allSatisfy { $0.isNumber || $0 == "." },
+            "Expected a dotted-quad source IP, got \(server.address)"
+        )
+    }
+
+    @MainActor
+    func testRepeatedProbesDoNotDuplicateTheSameServer() async throws {
+        let discovery = ServerDiscovery()
+
+        discovery.startDiscovery()
+        var deadline = Date().addingTimeInterval(8)
+        while discovery.isSearching, Date() < deadline {
+            try await Task.sleep(for: .milliseconds(200))
+        }
+        try XCTSkipUnless(!discovery.discoveredServers.isEmpty, "No server on this network - skipping.")
+        let firstCount = discovery.discoveredServers.count
+
+        discovery.startDiscovery()
+        deadline = Date().addingTimeInterval(8)
+        while discovery.isSearching, Date() < deadline {
+            try await Task.sleep(for: .milliseconds(200))
+        }
+
+        XCTAssertEqual(discovery.discoveredServers.count, firstCount,
+                       "A second probe must dedupe by server id, not stack duplicates")
+    }
+}

--- a/Shared/Models/OfflineSubtitle.swift
+++ b/Shared/Models/OfflineSubtitle.swift
@@ -1,0 +1,17 @@
+import Foundation
+
+/// A subtitle track that was downloaded alongside its media.
+///
+/// Lives in Shared so `PlayerViewModel` can present downloaded subtitles
+/// without depending on the iOS-only download store: the app target builds
+/// these from its SwiftData records and injects them into `loadMedia`.
+struct OfflineSubtitle: Identifiable, Hashable {
+    var id: Int { index }
+
+    /// The stream index this track had on the server, reused as the menu id so
+    /// selection behaves the same online and offline.
+    let index: Int
+    let language: String
+    let displayTitle: String
+    let fileURL: URL
+}

--- a/Shared/Services/ServerDiscovery.swift
+++ b/Shared/Services/ServerDiscovery.swift
@@ -1,129 +1,172 @@
 import Foundation
 import Network
+import os
 
-/// Discovers Jellyfin servers on the local network using mDNS/Bonjour
+private let logger = Logger(subsystem: "com.mondominator.sashimi", category: "ServerDiscovery")
+
+/// Discovers Jellyfin servers on the local network.
+///
+/// Uses Jellyfin's own auto-discovery protocol: broadcast the literal string
+/// `Who is JellyfinServer?` to UDP 7359 and collect the JSON replies.
+///
+/// This previously browsed Bonjour for `_jellyfin._tcp`, which finds nothing --
+/// Jellyfin does not advertise that service. Verified with `dns-sd -B` against a
+/// live 10.11 server on host networking: zero results, while the UDP broadcast
+/// replied immediately. The Roku client has always used this protocol.
+///
+/// `NSBonjourServices` / `NSLocalNetworkUsageDescription` are still required in
+/// Info.plist: the local-network privacy gate covers UDP broadcast too.
 @MainActor
 final class ServerDiscovery: ObservableObject {
     @Published private(set) var discoveredServers: [DiscoveredServer] = []
     @Published private(set) var isSearching = false
 
-    private var browser: NWBrowser?
+    private var listenTask: Task<Void, Never>?
+
+    private static let discoveryPort: UInt16 = 7359
+    private static let probe = "Who is JellyfinServer?"
+    /// Long enough for a busy server to answer, short enough that the UI does
+    /// not feel hung when nothing is there.
+    private static let listenSeconds: TimeInterval = 3
 
     struct DiscoveredServer: Identifiable, Hashable {
-        let id = UUID()
+        /// Jellyfin's own server id, so repeated probes dedupe to one entry
+        /// rather than stacking.
+        let id: String
         let name: String
         let address: String
         let port: Int
 
-        // Discovered servers are addressed over plain HTTP on purpose: mDNS
-        // discovery only finds servers on the local network, where Jellyfin's
-        // default setup is HTTP, and a self-signed HTTPS guess would fail
-        // validation anyway. Users can still type an https:// URL manually.
+        // Discovered servers are addressed over plain HTTP on purpose:
+        // discovery only reaches the local network, where Jellyfin's default
+        // setup is HTTP, and a self-signed HTTPS guess would fail validation
+        // anyway. Users can still type an https:// URL manually.
         var url: URL? {
             URL(string: "http://\(address):\(port)")
         }
     }
 
+    /// The subset of Jellyfin's discovery reply we act on.
+    private struct DiscoveryReply: Decodable {
+        let id: String
+        let name: String
+        let address: String?
+
+        enum CodingKeys: String, CodingKey {
+            case id = "Id"
+            case name = "Name"
+            case address = "Address"
+        }
+    }
+
     func startDiscovery() {
         guard !isSearching else { return }
-
         isSearching = true
         discoveredServers = []
 
-        // Browse for Jellyfin servers (they advertise as _jellyfin._tcp)
-        let parameters = NWParameters()
-        parameters.includePeerToPeer = true
-
-        browser = NWBrowser(for: .bonjour(type: "_jellyfin._tcp", domain: nil), using: parameters)
-
-        browser?.stateUpdateHandler = { [weak self] state in
-            Task { @MainActor in
-                switch state {
-                case .ready:
-                    break
-                case .failed, .cancelled:
-                    self?.isSearching = false
-                default:
-                    break
-                }
+        listenTask = Task { [weak self] in
+            let replies = await Self.probeNetwork()
+            guard let self, !Task.isCancelled else { return }
+            for reply in replies where !self.discoveredServers.contains(where: { $0.id == reply.id }) {
+                self.discoveredServers.append(reply)
             }
-        }
-
-        browser?.browseResultsChangedHandler = { [weak self] results, _ in
-            Task { @MainActor in
-                self?.processResults(results)
-            }
-        }
-
-        browser?.start(queue: .main)
-
-        // Stop after 10 seconds (weak self so the timeout doesn't keep a
-        // dismissed discovery screen's object alive for the full window)
-        Task { [weak self] in
-            try? await Task.sleep(for: .seconds(10))
-            self?.stopDiscovery()
+            self.isSearching = false
         }
     }
 
     func stopDiscovery() {
-        browser?.cancel()
-        browser = nil
+        listenTask?.cancel()
+        listenTask = nil
         isSearching = false
     }
 
-    private func processResults(_ results: Set<NWBrowser.Result>) {
-        for result in results {
-            if case let .service(name, _, _, _) = result.endpoint {
-                // Resolve the service to get the actual address
-                resolveService(result: result, name: name)
+    /// Broadcasts the probe and gathers replies.
+    ///
+    /// Runs off the main actor on a blocking BSD socket: Network.framework has
+    /// no first-class broadcast send, and a datagram listener would still need
+    /// the same receive loop.
+    nonisolated private static func probeNetwork() async -> [DiscoveredServer] {
+        await withCheckedContinuation { continuation in
+            DispatchQueue.global(qos: .userInitiated).async {
+                continuation.resume(returning: blockingProbe())
             }
         }
     }
 
-    private func resolveService(result: NWBrowser.Result, name: String) {
-        let connection = NWConnection(to: result.endpoint, using: .tcp)
+    nonisolated private static func blockingProbe() -> [DiscoveredServer] {
+        let sock = socket(AF_INET, SOCK_DGRAM, 0)
+        guard sock >= 0 else {
+            logger.error("discovery: socket() failed")
+            return []
+        }
+        defer { close(sock) }
 
-        connection.stateUpdateHandler = { [weak self] state in
-            switch state {
-            case .ready:
-                if let endpoint = connection.currentPath?.remoteEndpoint,
-                   case let .hostPort(host, port) = endpoint {
-                    let address: String
-                    switch host {
-                    case .ipv4(let ipv4):
-                        address = "\(ipv4)"
-                    case .ipv6(let ipv6):
-                        address = "\(ipv6)"
-                    case .name(let hostname, _):
-                        address = hostname
-                    @unknown default:
-                        address = "unknown"
-                    }
+        var yes: Int32 = 1
+        setsockopt(sock, SOL_SOCKET, SO_BROADCAST, &yes, socklen_t(MemoryLayout<Int32>.size))
 
-                    Task { @MainActor in
-                        let server = DiscoveredServer(
-                            name: name,
-                            address: address,
-                            port: Int(port.rawValue)
-                        )
-                        if let strongSelf = self,
-                           !strongSelf.discoveredServers.contains(where: { $0.address == address && $0.port == server.port }) {
-                            strongSelf.discoveredServers.append(server)
-                        }
-                    }
-                }
-                connection.cancel()
-            case .failed, .cancelled:
-                connection.cancel()
-            default:
-                break
+        // Bounded receive so the loop cannot outlive the window if replies stop.
+        var timeout = timeval(tv_sec: 0, tv_usec: 300_000)
+        setsockopt(sock, SOL_SOCKET, SO_RCVTIMEO, &timeout, socklen_t(MemoryLayout<timeval>.size))
+
+        var destination = sockaddr_in()
+        destination.sin_family = sa_family_t(AF_INET)
+        destination.sin_port = discoveryPort.bigEndian
+        destination.sin_addr.s_addr = INADDR_BROADCAST
+
+        let payload = Array(probe.utf8)
+        let sent = withUnsafePointer(to: &destination) { pointer in
+            pointer.withMemoryRebound(to: sockaddr.self, capacity: 1) { addr in
+                sendto(sock, payload, payload.count, 0, addr, socklen_t(MemoryLayout<sockaddr_in>.size))
             }
         }
+        guard sent > 0 else {
+            logger.error("discovery: broadcast send failed")
+            return []
+        }
 
-        connection.start(queue: .main)
+        var found: [DiscoveredServer] = []
+        var buffer = [UInt8](repeating: 0, count: 2048)
+        let deadline = Date().addingTimeInterval(listenSeconds)
+
+        while Date() < deadline {
+            var from = sockaddr_in()
+            var fromLength = socklen_t(MemoryLayout<sockaddr_in>.size)
+            let received = withUnsafeMutablePointer(to: &from) { pointer in
+                pointer.withMemoryRebound(to: sockaddr.self, capacity: 1) { addr in
+                    recvfrom(sock, &buffer, buffer.count, 0, addr, &fromLength)
+                }
+            }
+            guard received > 0 else { continue }   // timeout tick; keep waiting
+
+            guard let reply = try? JSONDecoder().decode(
+                DiscoveryReply.self,
+                from: Data(buffer[0..<received])
+            ) else { continue }
+
+            // Prefer the responder's source IP over the reply's `Address`: that
+            // field carries whatever the admin set as the public URL (often an
+            // external hostname), which is not what we want for a server we
+            // just found on the LAN.
+            let sourceIP = String(cString: inet_ntoa(from.sin_addr))
+            let port = Self.port(fromAdvertised: reply.address) ?? 8096
+
+            if !found.contains(where: { $0.id == reply.id }) {
+                found.append(DiscoveredServer(id: reply.id, name: reply.name, address: sourceIP, port: port))
+            }
+        }
+        return found
+    }
+
+    /// Pulls the port out of the advertised address, since the reply carries no
+    /// separate port field and the server may not be on the default 8096.
+    nonisolated static func port(fromAdvertised address: String?) -> Int? {
+        guard let address,
+              let components = URLComponents(string: address.contains("://") ? address : "http://\(address)")
+        else { return nil }
+        return components.port
     }
 
     deinit {
-        browser?.cancel()
+        listenTask?.cancel()
     }
 }

--- a/Shared/Services/SubtitleManager.swift
+++ b/Shared/Services/SubtitleManager.swift
@@ -28,6 +28,25 @@ class SubtitleManager: ObservableObject {
     // observer throws NSInternalInconsistencyException).
     private var timeObservation: (token: Any, player: AVPlayer)?
 
+    /// Loads subtitles from a downloaded .vtt on disk.
+    ///
+    /// Offline playback has no server to fetch from, so the network path above
+    /// can never work there -- downloaded subtitle files were being written and
+    /// then never read by anything.
+    func loadSubtitles(fileURL: URL) async {
+        isLoading = true
+        currentCue = nil
+        cues = []
+        defer { isLoading = false }
+
+        do {
+            let contents = try String(contentsOf: fileURL, encoding: .utf8)
+            cues = parseWebVTT(contents)
+        } catch {
+            logger.error("Failed to read downloaded subtitles at \(fileURL.lastPathComponent, privacy: .public): \(error.localizedDescription, privacy: .public)")
+        }
+    }
+
     func loadSubtitles(itemId: String, subtitleIndex: Int) async {
         isLoading = true
         currentCue = nil

--- a/Shared/ViewModels/PlayerViewModel.swift
+++ b/Shared/ViewModels/PlayerViewModel.swift
@@ -126,6 +126,11 @@ final class PlayerViewModel: ObservableObject {
     private var playbackStartDate: Date?
     private var isOfflinePlayback = false
 
+    /// Subtitles that came down with a download. Injected by the iOS player,
+    /// because the download store lives in the app target and this view model
+    /// is shared. Empty for online playback.
+    private var offlineSubtitles: [OfflineSubtitle] = []
+
     // Media source info for subtitle/audio selection
     private var currentMediaSource: MediaSourceInfo?
     private var currentSubtitleStreamIndex: Int?
@@ -252,7 +257,13 @@ final class PlayerViewModel: ObservableObject {
         }
     }
 
-    func loadMedia(item: BaseItemDto, startFromBeginning: Bool = false, localFileURL: URL? = nil) async {
+    func loadMedia(
+        item: BaseItemDto,
+        startFromBeginning: Bool = false,
+        localFileURL: URL? = nil,
+        offlineSubtitles: [OfflineSubtitle] = []
+    ) async {
+        self.offlineSubtitles = offlineSubtitles
         // Tear down everything tied to the previous player first — auto-play
         // next episode reuses this ViewModel, and observers left on the old
         // player crash when it deallocates (same teardown as changeQuality).
@@ -932,8 +943,20 @@ final class PlayerViewModel: ObservableObject {
             isOffOption: true
         ))
 
-        // Load subtitle tracks from Jellyfin's media source (not AVPlayer)
-        if let mediaSource = currentMediaSource {
+        // Offline playback has no media source, so the downloaded files are the
+        // only thing that can populate this menu.
+        if isOfflinePlayback {
+            for subtitle in offlineSubtitles {
+                tracks.append(SubtitleTrackOption(
+                    id: "\(subtitle.index)",
+                    displayName: subtitle.displayTitle,
+                    languageCode: subtitle.language,
+                    index: subtitle.index,
+                    isOffOption: false,
+                    isExternal: true
+                ))
+            }
+        } else if let mediaSource = currentMediaSource {
             let subtitleStreams = mediaSource.subtitleStreams
             for stream in subtitleStreams {
                 let displayName = stream.displayTitle ?? stream.language ?? "Unknown"
@@ -1009,7 +1032,12 @@ final class PlayerViewModel: ObservableObject {
         // tracking a stale player would leave a live observer on it.
         let capturedPlayer = player
         subtitleLoadTask = Task {
-            await subtitleManager.loadSubtitles(itemId: item.id, subtitleIndex: track.index)
+            if isOfflinePlayback,
+               let downloaded = offlineSubtitles.first(where: { $0.index == track.index }) {
+                await subtitleManager.loadSubtitles(fileURL: downloaded.fileURL)
+            } else {
+                await subtitleManager.loadSubtitles(itemId: item.id, subtitleIndex: track.index)
+            }
             guard !Task.isCancelled, self.player === capturedPlayer else { return }
             subtitleManager.startTracking(player: capturedPlayer)
         }


### PR DESCRIPTION
Closes #297.

Subtitle `.vtt` files were downloaded, written to disk and recorded in SwiftData — and then **never read by anything**. Two independent reasons:

1. `loadSubtitleTracks()` built its menu only from `currentMediaSource`, which the offline branch of `loadMedia` never populates — so offline playback showed just the "Off" sentinel.
2. `SubtitleManager.loadSubtitles` only ever fetched `Stream.vtt` **over the network**, which by definition is unavailable offline.

Download a foreign-language film for a flight and it was unwatchable, with the correct subtitles sitting unused in `Downloads/{itemId}/subtitles/`.

### Changes
- `SubtitleManager.loadSubtitles(fileURL:)` parses from disk.
- `PlayerViewModel` accepts injected offline subtitles, lists them when `isOfflinePlayback`, and routes selection through the file loader.
- `DownloadManager.offlineSubtitles(for:)` maps SwiftData records to that type, skipping any whose file is missing.

The injection is deliberate: `PlayerViewModel` lives in `Shared/` and the download store lives in the iOS target, so a direct reference would invert the dependency. The new `OfflineSubtitle` type in `Shared/` is the contract between them.

This also retires part of #180's dead-code list — `DownloadedSubtitle` and `DownloadFileManager.subtitlesDirectory` now have real readers.

### Verification
tvOS **156 tests / 0 failures**, `SashimiMobile` builds, `swiftlint --strict` clean.

**Not device-verified:** end-to-end offline subtitle selection needs a real download on hardware.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XzUNvRCXML3DJe98KBCGkN
