### PR TITLE
release: v1.2.0

### DIFF
--- a/project.yml
+++ b/project.yml
@@ -66,7 +66,7 @@ targets:
     settings:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.mondominator.sashimi
-        MARKETING_VERSION: 1.1.0
+        MARKETING_VERSION: 1.2.0
         CURRENT_PROJECT_VERSION: 2
         SWIFT_VERSION: 5.9
         SDKROOT: appletvos
@@ -136,7 +136,7 @@ targets:
         # Shared bundle ID with the tvOS app for Universal Purchase (one "Sashimi"
         # app spanning Apple TV + iPhone + iPad). Distinguished by platform.
         PRODUCT_BUNDLE_IDENTIFIER: com.mondominator.sashimi
-        MARKETING_VERSION: 1.1.0
+        MARKETING_VERSION: 1.2.0
         CURRENT_PROJECT_VERSION: 1
         SWIFT_VERSION: 5.9
         SDKROOT: iphoneos
@@ -178,7 +178,7 @@ targets:
     settings:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.mondominator.sashimi.topshelf
-        MARKETING_VERSION: 1.1.0
+        MARKETING_VERSION: 1.2.0
         CURRENT_PROJECT_VERSION: 2
         SWIFT_VERSION: 5.9
         SDKROOT: appletvos

--- a/scripts/bump-version.sh
+++ b/scripts/bump-version.sh
@@ -49,9 +49,9 @@ NEW_VERSION="$MAJOR.$MINOR.$PATCH"
 echo "Bumping version: $CURRENT_VERSION -> $NEW_VERSION"
 
 # Update project.yml. This bumps every target whose MARKETING_VERSION matches
-# the tvOS app's current version (Sashimi + TopShelf, which are kept in sync).
-# The iOS target (SashimiMobile) has an independently-managed MARKETING_VERSION
-# and is intentionally NOT touched here.
+# Global on purpose: Sashimi, SashimiMobile and TopShelf ship under ONE App Store
+# listing (Universal Purchase), so their marketing versions stay in lockstep.
+# This sed rewrites all three.
 sed -i '' "s/MARKETING_VERSION: $CURRENT_VERSION/MARKETING_VERSION: $NEW_VERSION/g" "$PROJECT_FILE"
 
 # Get current build number and increment
@@ -60,7 +60,7 @@ NEW_BUILD=$((CURRENT_BUILD + 1))
 
 echo "Bumping build: $CURRENT_BUILD -> $NEW_BUILD"
 
-# Same match-based behavior as above: bumps Sashimi + TopShelf, not SashimiMobile.
+# Same global rewrite as above -- all targets share the build number.
 sed -i '' "s/CURRENT_PROJECT_VERSION: $CURRENT_BUILD/CURRENT_PROJECT_VERSION: $NEW_BUILD/g" "$PROJECT_FILE"
 
 # Regenerate Xcode project


### PR DESCRIPTION
Marketing version 1.2.0 across all three targets — they share one App Store listing, so they stay in lockstep.

Full changelog in the commit message. Headline: both App Store submission blockers cleared, two data-loss bugs fixed, sign-out and server discovery actually work, 614 lines of dead code removed.

Also fixes #312's third item — `bump-version.sh` claimed it didn't touch the iOS target while running a global sed that did.

156 tests / 0 failures, both targets build, swiftlint --strict clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XzUNvRCXML3DJe98KBCGkN