### PR TITLE
Quality tiers actually change resolution

### DIFF
--- a/Shared/Services/JellyfinClient.swift
+++ b/Shared/Services/JellyfinClient.swift
@@ -704,6 +704,7 @@ actor JellyfinClient {
     func getPlaybackInfo(
         itemId: String,
         maxBitrate: Int? = nil,
+        maxWidth: Int? = nil,
         forceDirectPlay: Bool = false,
         forceTranscode: Bool = false
     ) async throws -> PlaybackInfoResponse {
@@ -750,7 +751,20 @@ actor JellyfinClient {
                 ]
             ],
             "ContainerProfiles": [],
-            "CodecProfiles": [],
+            // A width condition is what actually downscales. MaxStreamingBitrate
+            // is only a ceiling, so a 1080p source already under the cap was
+            // passed straight through and "720p" changed nothing.
+            "CodecProfiles": maxWidth.map { width in
+                [[
+                    "Type": "Video",
+                    "Conditions": [[
+                        "Condition": "LessThanEqual",
+                        "Property": "Width",
+                        "Value": "\(width)",
+                        "IsRequired": true
+                    ]]
+                ]]
+            } ?? [],
             "SubtitleProfiles": [
                 ["Format": "vtt", "Method": "External"],
                 ["Format": "srt", "Method": "External"]
@@ -776,7 +790,11 @@ actor JellyfinClient {
             "EnableDirectPlay": !forceTranscode,
             "EnableDirectStream": !effectiveForceDirectPlay && !forceTranscode,
             "EnableTranscoding": !effectiveForceDirectPlay,
-            "AllowVideoStreamCopy": true,
+            // The real reason picking a tier did nothing: with video stream copy
+            // allowed, the server satisfied a "transcode" by remuxing the
+            // original video untouched (IsVideoDirect=true) whenever the source
+            // already fit under the bitrate cap. An explicit pick must re-encode.
+            "AllowVideoStreamCopy": !forceTranscode,
             "AllowAudioStreamCopy": true,
             "AutoOpenLiveStream": true
         ]

--- a/Shared/ViewModels/PlayerViewModel.swift
+++ b/Shared/ViewModels/PlayerViewModel.swift
@@ -62,6 +62,21 @@ enum QualityOption: String, CaseIterable, Identifiable {
         case .quality480p: return 4_000_000   // 4 Mbps
         }
     }
+
+    /// Pixel width cap for the tier.
+    ///
+    /// The bitrate cap alone does not change resolution: a 1080p source already
+    /// under the cap is simply passed through, so picking "720p" on a 7 Mbps
+    /// 1080p file produced a 1080p stream and the OSD correctly kept saying
+    /// 1080p. The width is what actually makes the tier mean what it says.
+    var maxWidth: Int? {
+        switch self {
+        case .auto: return nil
+        case .quality1080p: return 1920
+        case .quality720p: return 1280
+        case .quality480p: return 854
+        }
+    }
 }
 
 // Playback reporting is best-effort by design -- a failed report must never
@@ -613,7 +628,7 @@ final class PlayerViewModel: ObservableObject {
             // An explicit non-Auto pick forces a transcode so the selection
             // visibly takes effect: the tiers are caps, and a direct-played
             // source under the cap would otherwise make the pick a no-op.
-            try await setupPlayer(for: item, maxBitrate: quality.maxBitrate, forceTranscode: quality != .auto)
+            try await setupPlayer(for: item, maxBitrate: quality.maxBitrate, maxWidth: quality.maxWidth, forceTranscode: quality != .auto)
             isLoading = false
             updateNowPlayingInfo(item: item)
 
@@ -675,7 +690,7 @@ final class PlayerViewModel: ObservableObject {
     }
 
     /// Shared player setup: resolves stream URL, creates AVPlayer with observers.
-    private func setupPlayer(for item: BaseItemDto, maxBitrate: Int? = nil, forceTranscode: Bool = false) async throws {
+    private func setupPlayer(for item: BaseItemDto, maxBitrate: Int? = nil, maxWidth: Int? = nil, forceTranscode: Bool = false) async throws {
         // Bitrate precedence: explicit override (quality menu change) →
         // session quality selection → global Settings cap. QualityOption.auto
         // has a nil bitrate, so "Auto" defers to Settings, where 0 = no cap.
@@ -686,6 +701,7 @@ final class PlayerViewModel: ObservableObject {
         let playbackInfo = try await client.getPlaybackInfo(
             itemId: item.id,
             maxBitrate: effectiveBitrate,
+            maxWidth: maxWidth,
             forceDirectPlay: playbackSettings.forceDirectPlay,
             forceTranscode: forceTranscode
         )


### PR DESCRIPTION
Found by device testing: picking 720p mid-movie appeared to work, but the OSD still said 1080p. **The OSD was right** — the pick did nothing.

Server-side, while it was happening:
```
transcode -> 1920x800 h264   videoDirect=true   reasons=[ContainerNotSupported]
source    -> 1920x800 h264 @ 7,093,852 bps
```

`videoDirect=true` means the video was being **stream-copied**, not re-encoded.

### Two causes, both needed fixing

**1. `AllowVideoStreamCopy` was unconditionally `true`.** So the server satisfied a "transcode" by remuxing the original video untouched whenever the source already fit under the bitrate cap. Now `false` when a tier is explicitly chosen.

The comment directly above that flag claimed `forceTranscode` already prevented exactly this. It didn't — disabling DirectPlay/DirectStream still permits a *stream-copying transcode*.

**2. The tiers were bitrate-only.** `MaxStreamingBitrate` is a ceiling, not a target, so a 1080p source at 7.09 Mbps sailed under an 8 Mbps "720p" cap unchanged. Resolution is limited by a device-profile `CodecProfile` width condition, which was absent entirely. Added `QualityOption.maxWidth` (1920/1280/854) and the condition.

Same defect class as the **download** tiers fixed in #304 — labels promising a resolution while the request only constrained bitrate. Worth noting neither was caught by the other's fix.

### Verified against the live server
Replayed the exact PlaybackInfo request both ways:

```
OLD  bitrate cap only, copy allowed  -> transcodingUrl with NO maxWidth
NEW  bitrate cap + width, no copy    -> transcodingUrl with maxWidth=1280
```

tvOS **156 tests / 0 failures**, `SashimiMobile` builds, `swiftlint --strict` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XzUNvRCXML3DJe98KBCGkN
