### PR TITLE
fix: drop Continue Watching "See All", give the skip button a way back

### DIFF
--- a/Sashimi/Views/Home/ContinueWatchingRow.swift
+++ b/Sashimi/Views/Home/ContinueWatchingRow.swift
@@ -5,7 +5,6 @@ struct ContinueWatchingRow: View {
     var libraryNames: [String: String] = [:]  // Item ID -> Library name mapping
     let onSelect: (BaseItemDto) -> Void
     var onPlay: ((BaseItemDto) -> Void)?  // Optional: immediate playback on Play button
-    var onSeeAll: (() -> Void)?  // Optional: opens the full Continue Watching grid
 
     private func isYouTube(_ item: BaseItemDto) -> Bool {
         guard let libraryName = libraryNames[item.id] else { return false }
@@ -29,49 +28,11 @@ struct ContinueWatchingRow: View {
                             onPlayPause: onPlay != nil ? { onPlay?(item) } : nil
                         )
                     }
-
-                    // Trailing "See All" card opens the full grid (only when
-                    // the row is at its cap, so it isn't noise on short rows)
-                    if let onSeeAll, items.count >= 10 {
-                        SeeAllCard(action: onSeeAll)
-                    }
                 }
                 .padding(.horizontal, 80)
                 .padding(.vertical, 20)
             }
         }
-    }
-}
-
-/// Trailing card at the end of the Continue Watching row that opens the full
-/// grid (ContinueWatchingDetailView) — same footprint as a CW card.
-private struct SeeAllCard: View {
-    let action: () -> Void
-    @FocusState private var isFocused: Bool
-
-    var body: some View {
-        Button(action: action) {
-            VStack(spacing: 12) {
-                Image(systemName: "square.grid.2x2")
-                    .font(.system(size: 44))
-                Text("See All")
-                    .font(.system(size: 24, weight: .semibold))
-            }
-            .foregroundStyle(isFocused ? SashimiTheme.textPrimary : SashimiTheme.textSecondary)
-            .frame(width: 440, height: 248)
-            .background(SashimiTheme.cardBackground)
-            .clipShape(RoundedRectangle(cornerRadius: 16))
-            .overlay(
-                RoundedRectangle(cornerRadius: 16)
-                    .stroke(isFocused ? SashimiTheme.focus : .clear, lineWidth: 4)
-            )
-            .shadow(color: isFocused ? SashimiTheme.focusGlow : .clear, radius: 12)
-            .scaleEffect(isFocused ? 1.05 : 1.0)
-            .animation(.spring(response: 0.3, dampingFraction: 0.7), value: isFocused)
-        }
-        .buttonStyle(.plain)
-        .focused($isFocused)
-        .accessibilityLabel("See all Continue Watching")
     }
 }
 
@@ -244,46 +205,5 @@ struct ContinueWatchingCard: View {
         parts.append(remainingTimeString)
 
         return parts.joined(separator: ", ")
-    }
-}
-
-// MARK: - Continue Watching Detail View (See All)
-
-struct ContinueWatchingDetailView: View {
-    let items: [BaseItemDto]
-    let onSelect: (BaseItemDto) -> Void
-    @Environment(\.dismiss) private var dismiss
-
-    var body: some View {
-        ZStack {
-            SashimiTheme.background.ignoresSafeArea()
-
-            ScrollView {
-                VStack(alignment: .leading, spacing: 30) {
-                    // Header
-                    Text("Continue Watching")
-                        .font(.system(size: 48, weight: .bold))
-                        .foregroundStyle(SashimiTheme.textPrimary)
-                        .padding(.horizontal, 80)
-                        .padding(.top, 40)
-
-                    // Grid of items
-                    LazyVGrid(columns: [
-                        GridItem(.adaptive(minimum: 420, maximum: 480), spacing: 40)
-                    ], spacing: 40) {
-                        ForEach(items) { item in
-                            ContinueWatchingCard(item: item) {
-                                onSelect(item)
-                            }
-                        }
-                    }
-                    .padding(.horizontal, 80)
-                    .padding(.bottom, 60)
-                }
-            }
-        }
-        .onExitCommand {
-            dismiss()
-        }
     }
 }

--- a/Sashimi/Views/Home/HomeView.swift
+++ b/Sashimi/Views/Home/HomeView.swift
@@ -17,7 +17,6 @@ struct HomeView: View {
     @State private var selectedItemIsYouTube: Bool = false
     @State private var refreshTimer: Timer?
     @State private var heroIndex: Int = 0
-    @State private var showContinueWatchingDetail = false
     @State private var playingItem: BaseItemDto?  // For immediate playback via Play button
 
     // Order libraries according to settings
@@ -76,19 +75,6 @@ struct HomeView: View {
             }
             .fullScreenCover(item: $playingItem) { item in
                 PlayerView(item: item, startFromBeginning: false)
-            }
-            .fullScreenCover(isPresented: $showContinueWatchingDetail) {
-                ContinueWatchingDetailView(
-                    items: viewModel.continueWatchingItems,
-                    onSelect: { item in
-                        let isYouTube = item.type == .episode && (item.parentBackdropImageTags ?? []).isEmpty
-                        showContinueWatchingDetail = false
-                        DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) {
-                            selectedItemIsYouTube = isYouTube
-                            selectedItem = item
-                        }
-                    }
-                )
             }
             .onChange(of: selectedItem) { oldValue, newValue in
                 if oldValue != nil && newValue == nil {
@@ -170,9 +156,6 @@ struct HomeView: View {
                         },
                         onPlay: { item in
                             playingItem = item
-                        },
-                        onSeeAll: {
-                            showContinueWatchingDetail = true
                         }
                     )
                     .focusSection()

--- a/Sashimi/Views/Player/TVPlayerViewController.swift
+++ b/Sashimi/Views/Player/TVPlayerViewController.swift
@@ -74,11 +74,13 @@ struct TVPlayerView: UIViewControllerRepresentable {
                 skipVC.updateTitle(title)
                 if wasHidden {
                     skipVC.view.isHidden = false
+                    skipVC.setGuideEnabled(true)
                     container.setNeedsFocusUpdate()
                     container.updateFocusIfNeeded()
                 }
             } else if !wasHidden {
                 skipVC.view.isHidden = true
+                skipVC.setGuideEnabled(false)
                 container.setNeedsFocusUpdate()
                 container.updateFocusIfNeeded()
             }
@@ -309,16 +311,48 @@ class SkipButtonViewController: UIViewController {
         view = passthrough
     }
 
+    /// Creates a navigation path BACK to the skip button.
+    ///
+    /// `preferredFocusEnvironments` only decides where focus goes when the
+    /// engine asks the container -- initial focus, or an explicit
+    /// setNeedsFocusUpdate. It is not bidirectional navigation. So once the
+    /// user swiped up to the transport bar there was no way to return to the
+    /// skip button: it stayed on screen, visibly unfocused, and no remote
+    /// direction could reach it.
+    ///
+    /// The guide occupies the band to the button's left, at the button's own
+    /// height, so a move that lands anywhere in that strip is redirected to the
+    /// button.
+    private let focusGuide = UIFocusGuide()
+
     override func viewDidLoad() {
         super.viewDidLoad()
 
         button.addTarget(self, action: #selector(tapped), for: .primaryActionTriggered)
         view.addSubview(button)
 
+        view.addLayoutGuide(focusGuide)
+        focusGuide.preferredFocusEnvironments = [button]
+
         NSLayoutConstraint.activate([
             button.trailingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.trailingAnchor, constant: -80),
             button.bottomAnchor.constraint(equalTo: view.safeAreaLayoutGuide.bottomAnchor, constant: -80),
+
+            focusGuide.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            focusGuide.trailingAnchor.constraint(equalTo: button.leadingAnchor),
+            focusGuide.topAnchor.constraint(equalTo: button.topAnchor),
+            focusGuide.bottomAnchor.constraint(equalTo: button.bottomAnchor),
         ])
+
+        // Disabled until a segment is actually showing, or the guide would
+        // silently swallow focus moves toward the transport bar whenever no
+        // skip button exists.
+        focusGuide.isEnabled = false
+    }
+
+    /// Keeps the focus guide in step with the button's visibility.
+    func setGuideEnabled(_ enabled: Bool) {
+        focusGuide.isEnabled = enabled
     }
 
     func updateTitle(_ title: String) {


### PR DESCRIPTION
Closes #133.

## 1. Continue Watching "See All" removed entirely

Per your call — the row is already a complete view of what you're watching, so a grid of the same items behind a trailing card earned nothing.

Removed: `SeeAllCard`, the `ContinueWatchingDetailView` it opened, the `fullScreenCover`, the `onSeeAll` parameter, and the `showContinueWatchingDetail` state. `ContinueWatchingRow.swift` drops from **289 to 209 lines**.

## 2. The skip button couldn't be reached again once focus left it (#133)

`preferredFocusEnvironments` only decides where focus goes when the engine **asks** the container — initial focus, or an explicit `setNeedsFocusUpdate`. It is not bidirectional navigation. So after swiping up to the transport bar, the Skip pill stayed on screen, visibly unfocused, and no remote direction could return to it.

Added a `UIFocusGuide` occupying the band to the button's left at the button's own height, redirecting to the button.

It is **disabled while no segment is showing** — otherwise the guide would silently swallow focus moves toward the transport bar for the entire rest of playback, which would be a worse bug than the one being fixed.

## The other half of #133 was already fixed

"Series missing trailers" — the gate is now `!isEpisode, (item.localTrailerCount ?? 0) > 0`, not `!isSeries`, so series with a local trailer do show the button. Changed in #253 (local-first trailer).

## Verification

tvOS build succeeds. Installed and launched on the **Living Room Apple TV** (4K 3rd gen) — app and Top Shelf extension both running, no crash.

**Not verified: the focus traversal itself.** Driving a physical Apple TV's remote isn't scriptable, and this is exactly the kind of change that can only be judged by pressing buttons. Worth confirming that with a Skip pill showing, swiping up to the transport bar and then pressing Down/Left returns focus to Skip — and that focus behaves normally when no Skip pill is present.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XzUNvRCXML3DJe98KBCGkN