### PR TITLE
fix: five tvOS correctness defects from a fresh audit

### DIFF
--- a/Sashimi/App/SashimiApp.swift
+++ b/Sashimi/App/SashimiApp.swift
@@ -237,8 +237,22 @@ struct MainTabView: View {
     }
 
     private func loadLibraries() async {
-        if let libs = try? await JellyfinClient.shared.getLibraryViews() {
-            libraries = libs
+        // Retried rather than silently swallowed. This runs once from .task, so
+        // a single transient failure used to leave the sidebar with NO
+        // libraries for the entire session -- and because it renders as a
+        // plausible rail rather than an error, it reads as "my libraries are
+        // gone from the server". Force-quitting was the only recovery.
+        for attempt in 0..<3 {
+            do {
+                libraries = try await JellyfinClient.shared.getLibraryViews()
+                return
+            } catch is CancellationError {
+                return
+            } catch {
+                logger.error("Library rail load failed (attempt \(attempt + 1)): \(error.localizedDescription)")
+                guard attempt < 2 else { break }
+                try? await Task.sleep(for: .seconds(1 << attempt))
+            }
         }
     }
 

--- a/Sashimi/Views/Detail/MediaDetailView.swift
+++ b/Sashimi/Views/Detail/MediaDetailView.swift
@@ -226,6 +226,12 @@ struct MediaDetailView: View {
             if !isShowing {
                 // Reset startFromBeginning and refresh item data when returning from player
                 startFromBeginning = false
+                // selectedEpisode is what the player actually played (a trailer,
+                // a shuffled episode, or next-up). Leaving it set meant the NEXT
+                // press of Play replayed that instead of the item: play a movie's
+                // trailer, come back, press Play, and you got the trailer again
+                // with no way out short of leaving the detail view.
+                selectedEpisode = nil
                 Task { await refreshItemState() }
             }
         }
@@ -254,6 +260,15 @@ struct MediaDetailView: View {
             isFavorite = refreshedItem.userData?.isFavorite ?? false
         } catch {
             // Silently ignore - non-critical refresh
+        }
+
+        // Watching an episode changes which one is next, and whether the strip
+        // should show a checkmark. loadContent() is bound to .task, which does
+        // NOT re-run here: the player is a fullScreenCover, so it never removed
+        // this view and .task never re-fires. Without this the button still read
+        // "Play S1:E1" after finishing S1:E1, and pressing it replayed it.
+        if isSeries || isEpisode {
+            await loadContent()
         }
     }
 

--- a/Sashimi/Views/Library/LibraryView.swift
+++ b/Sashimi/Views/Library/LibraryView.swift
@@ -219,12 +219,6 @@ enum LibraryFilterOption: String, CaseIterable {
 // swiftlint:disable type_body_length
 // LibraryDetailView manages grid display, pagination, filtering, sorting, and alphabet navigation
 struct LibraryDetailView: View {
-    enum FocusArea: Hashable {
-        case grid
-        case alphabet
-        case sortPicker
-    }
-
     let library: LibraryView_Model
 
     @State private var items: [BaseItemDto] = []
@@ -240,7 +234,7 @@ struct LibraryDetailView: View {
     @State private var sortOption: LibrarySortOption = .name
     @State private var sortOrder: SortOrder = .ascending
     @State private var filterOption: LibraryFilterOption = .all
-    @FocusState private var focusedArea: FocusArea?
+    @State private var committedLetter: String?
     private let pageSize = 50
 
     // Alphabet for fast scroll
@@ -368,13 +362,19 @@ struct LibraryDetailView: View {
                         }
                     }
                 }
+                // Hover: scroll only if the letter is already loaded. Pressing
+                // is what may pull the rest of the library down.
                 .onChange(of: selectedLetter) { _, letter in
                     if let letter = letter {
-                        scrollToLetter(letter, proxy: proxy)
+                        scrollToLetter(letter, proxy: proxy, allowFullLoad: false)
+                    }
+                }
+                .onChange(of: committedLetter) { _, letter in
+                    if let letter = letter {
+                        scrollToLetter(letter, proxy: proxy, allowFullLoad: true)
                     }
                 }
                 .focusSection()
-                .focused($focusedArea, equals: .grid)
             }
 
             // Alphabet fast scroll bar (right side, aligned with grid)
@@ -382,14 +382,17 @@ struct LibraryDetailView: View {
                 ScrollView(showsIndicators: false) {
                     AlphabetScrollBar(
                         alphabet: alphabet,
-                        selectedLetter: $selectedLetter
+                        selectedLetter: $selectedLetter,
+                        committedLetter: $committedLetter
                     )
                 }
                 .focusSection()
-                .focused($focusedArea, equals: .alphabet)
-                .onExitCommand {
-                    focusedArea = .grid
-                }
+                // No .onExitCommand here. It used to set focusedArea = .grid,
+                // which moved nothing -- focusedArea is never read, and it was
+                // bound to ScrollViews, which aren't focusable on tvOS -- while
+                // still CONSUMING the Menu press. So Menu was dead inside the
+                // A-Z bar and could not return the user to Home. Left already
+                // reaches the grid geometrically.
                 .padding(.top, 100)  // Align with grid (below header)
                 .padding(.trailing, 20)
             }
@@ -410,7 +413,7 @@ struct LibraryDetailView: View {
         }
     }
 
-    private func scrollToLetter(_ letter: String, proxy: ScrollViewProxy) {
+    private func scrollToLetter(_ letter: String, proxy: ScrollViewProxy, allowFullLoad: Bool) {
         // Try to find in already-loaded items
         if let item = findItem(for: letter) {
             withAnimation(.easeOut(duration: 0.5)) {
@@ -419,8 +422,11 @@ struct LibraryDetailView: View {
             return
         }
 
-        // Not found — load all remaining items, then retry
-        guard items.count < totalCount else { return }
+        // Not found — load all remaining items, then retry.
+        // Gated on an actual button press: this used to fire on FOCUS, so
+        // holding Down through the A-Z bar kicked a full-library fetch at every
+        // letter that wasn't in the loaded page, queued one behind another.
+        guard allowFullLoad, items.count < totalCount else { return }
         Task {
             await loadAllRemainingItems()
             if let item = findItem(for: letter) {
@@ -607,14 +613,20 @@ struct LibraryDetailView: View {
 // MARK: - Alphabet Scroll Bar
 struct AlphabetScrollBar: View {
     let alphabet: [String]
+    /// Set on hover as well as press — drives scroll-if-already-loaded.
     @Binding var selectedLetter: String?
+    /// Set only on press — the one that may trigger a full-library load.
+    @Binding var committedLetter: String?
     @FocusState private var focusedLetter: String?
 
     var body: some View {
         VStack(spacing: 0) {
             ForEach(alphabet, id: \.self) { letter in
                 Button {
+                    // A press is an explicit request, so it may pull in the
+                    // rest of the library; hovering must not.
                     selectedLetter = letter
+                    committedLetter = letter
                 } label: {
                     Text(letter)
                         .font(.system(size: 18, weight: focusedLetter == letter ? .bold : .medium))

--- a/Sashimi/Views/Library/SearchView.swift
+++ b/Sashimi/Views/Library/SearchView.swift
@@ -326,11 +326,27 @@ struct SearchView: View {
             let searchResults = try await JellyfinClient.shared.search(query: searchText)
             // Detect YouTube items by checking ancestors for "YouTube" library
             await detectYouTubeItems(for: searchResults)
+            // A search cancelled by the next keystroke must not publish its
+            // results or clear the spinner — otherwise a slow older query that
+            // finishes late overwrites the newer one's results.
+            guard !Task.isCancelled else { return }
             results = searchResults
             // Add to history on successful search
             if !results.isEmpty {
                 historyManager.addSearch(searchText)
             }
+        } catch is CancellationError {
+            // Superseded by the next keystroke — not a failure, and showing the
+            // user an error toast for their own typing is worse than useless.
+            // On the tvOS on-screen keyboard, where keystrokes are naturally
+            // further apart than the 300ms debounce, this fired on most
+            // characters. LibraryView and HomeView already swallow this; only
+            // SearchView surfaced it.
+            return
+        } catch let urlError as URLError where urlError.code == .cancelled {
+            // URLSession reports cancellation as URLError(.cancelled) rather
+            // than CancellationError, so both have to be caught.
+            return
         } catch {
             logger.error("Search failed: \(error.localizedDescription)")
             ToastManager.shared.show("Search failed. Try again.")


### PR DESCRIPTION
All five verified against the source before fixing. Several other audit claims did **not** survive that check and were dropped — see the note at the end.

## 1. Pressing Play after Trailer replayed the trailer — HIGH

`selectedEpisode` is set by `playLocalTrailer`, `shuffleEpisode` and the series next-episode path, and was **never cleared**. The player is presented as `PlayerView(item: selectedEpisode ?? item)`, and the movie Play / Start Over buttons set only `startFromBeginning` — so they inherited whatever was last played.

Repro: open a movie with a local trailer → **Trailer** → back out → **Play**. You get the trailer again, with no way to reach the movie short of leaving the detail view entirely.

## 2. Series detail kept offering the episode you'd just finished — HIGH

On return from the player, `refreshItemState()` refreshed three booleans for `item.id` and nothing else — not the item, not the episode strip, not `nextEpisodeToPlay`. `loadContent()` is bound to `.task`, which does **not** re-run, because the player is a `fullScreenCover` and never removed the view.

Repro: series → "Play S1:E1" → watch to the end → back out. Button still reads **"Play S1:E1"**, strip shows no checkmark, and pressing it replays the finished episode.

## 3. Cancelling a search told the user the search had failed — MEDIUM

Every keystroke cancels the previous task, and the catch-all showed *"Search failed. Try again."* Cancellation arrives two ways — `CancellationError` **and** `URLError(.cancelled)` — and neither was distinguished.

On the tvOS on-screen keyboard, where keystrokes are naturally further apart than the 300 ms debounce, this fired on **most characters**. `LibraryView` and `HomeView` already swallow cancellation; `SearchView` was the outlier.

Also added a `Task.isCancelled` guard before publishing, so a slow older query can't overwrite a newer one's results.

## 4. Travelling the A-Z bar fetched the entire library at every letter — MEDIUM

`.onChange(of: focusedLetter)` set `selectedLetter`, so merely **hovering** a letter ran `scrollToLetter`, which for any letter outside the loaded 50-item page requested `limit: totalCount - items.count` — the whole library.

Repro: library with a few thousand items → press Right into the A-Z bar → hold Down from A to Z. Each miss queues a full-library fetch behind the last.

Split hover from press: hovering scrolls only within what's already loaded; only an actual press may pull the rest down.

## 5. Menu was dead inside the A-Z bar — MEDIUM

`.onExitCommand { focusedArea = .grid }` consumed the press but moved nothing — `focusedArea` was never *read* anywhere, and was bound to `ScrollView`s, which aren't focusable on tvOS. So Menu couldn't return you to Home from that region.

Removed, along with the now-unreferenced `FocusArea` enum. Left already reaches the grid geometrically.

## Bonus: the library rail silently emptied

`loadLibraries()` was a single `try?` called once from `.task`. One transient failure left the sidebar with **no libraries for the entire session** — and because it renders as a plausible empty rail rather than an error, it reads as "my libraries are gone from the server". Only recovery was force-quitting. Now retried with backoff and logged.

## Claims I dropped after checking

- **"Overview has no way to read the rest"** — false. "Full Overview" already exists in the More menu (`MediaDetailView.swift:922`). The 4-line cap is a layout choice, not a dead end.
- **"Series missing trailers" (#133)** — already fixed in #253; the gate is `!isEpisode` + `localTrailerCount`, not `!isSeries`.

## Verification

tvOS build succeeds, SwiftLint `--strict` clean.

**Not verified:** the focus behaviour in 5 and the interaction in 4 need a remote in hand — driving a physical Apple TV isn't scriptable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XzUNvRCXML3DJe98KBCGkN