### PR TITLE
perf: stop the Home screen doing 4x the work it needs to

### DIFF
--- a/Sashimi/Views/Detail/MediaDetailView.swift
+++ b/Sashimi/Views/Detail/MediaDetailView.swift
@@ -127,7 +127,10 @@ struct MediaDetailView: View {
                             AsyncItemImage(
                                 itemId: backdropId,
                                 imageType: backdropImageType,
-                                maxWidth: 3840,
+                                // Rendered into geometry.size.width * 0.45; a 4K
+                                // decode here is ~33 MB of backing store for no
+                                // visible gain on a 1080p layout space.
+                                maxWidth: 1920,
                                 contentMode: .fit,
                                 fallbackImageTypes: isYouTubeSeriesStyle ? ["Backdrop", "Thumb", "Primary"] : ["Thumb", "Backdrop", "Primary"]
                             )

--- a/Sashimi/Views/Home/HomeView.swift
+++ b/Sashimi/Views/Home/HomeView.swift
@@ -20,17 +20,6 @@ struct HomeView: View {
     @State private var playingItem: BaseItemDto?  // For immediate playback via Play button
 
     // Order libraries according to settings
-    private var orderedLibraries: [JellyfinLibrary] {
-        let orderedIds = homeSettings.orderedLibraryIds()
-        if orderedIds.isEmpty {
-            return viewModel.libraries
-        }
-        return viewModel.libraries.sorted { lib1, lib2 in
-            let index1 = orderedIds.firstIndex(of: lib1.id) ?? Int.max
-            let index2 = orderedIds.firstIndex(of: lib2.id) ?? Int.max
-            return index1 < index2
-        }
-    }
 
     var body: some View {
         NavigationStack {
@@ -174,6 +163,14 @@ struct HomeView: View {
     private func startAutoRefresh() {
         refreshTimer?.invalidate()
         refreshTimer = Timer.scheduledTimer(withTimeInterval: 30, repeats: true) { _ in
+            // Skip while something is presented over Home. The player and the
+            // detail view are fullScreenCovers, which do NOT remove the
+            // presenting view -- so .onDisappear never fires and this timer used
+            // to keep running for the entire duration of a movie, firing ~25
+            // requests every 30 seconds at the same server that is transcoding
+            // it. Each tick also republished every @Published on the view model,
+            // re-evaluating the whole LazyVStack behind the cover.
+            guard selectedItem == nil, playingItem == nil else { return }
             Task {
                 await viewModel.refresh()
             }
@@ -303,7 +300,14 @@ struct HeroSection: View {
                         Spacer()
                         SmartPosterImage(
                             itemIds: heroFallbackIds,
-                            maxWidth: 3840,
+                            // 1920, not 3840. tvOS lays out in a 1920x1080 space
+                            // and this slot renders ~910x512pt, so a 4K request
+                            // was a 33 MB RGBA decode (3840*2160*4) for an image
+                            // that is downsampled on sight. Jellyfin treats
+                            // maxWidth as a cap, so any item with 4K artwork
+                            // really did return 4K -- and the hero rotates every
+                            // 6 seconds.
+                            maxWidth: 1920,
                             imageTypes: heroImageTypes,
                             contentMode: .fit
                         )

--- a/Shared/ViewModels/HomeViewModel.swift
+++ b/Shared/ViewModels/HomeViewModel.swift
@@ -14,7 +14,6 @@ final class HomeViewModel: ObservableObject {
     @Published var recentlyAddedItems: [BaseItemDto] = []
     @Published var heroItems: [BaseItemDto] = []
     @Published var heroItemLibraryNames: [String: String] = [:]  // itemId -> libraryName
-    @Published var libraryItems: [String: [BaseItemDto]] = [:]  // libraryId -> items
     @Published var libraries: [JellyfinLibrary] = []
     @Published var isLoading = false
     @Published var error: Error?
@@ -68,19 +67,34 @@ final class HomeViewModel: ObservableObject {
             return item.id
         })
 
-        for seriesId in seriesIds {
-            do {
-                let ancestors = try await client.getItemAncestors(itemId: seriesId)
-                if let library = ancestors.first(where: { $0.type == .collectionFolder }) {
-                    for item in continueWatchingItems {
-                        if item.seriesId == seriesId || item.id == seriesId {
-                            libraryNames[item.id] = library.name
-                        }
+        // Concurrent, not serial. Continue Watching holds up to 20 items, so
+        // this was up to 20 sequential round-trips gating the first render --
+        // ~0.9s on a 30ms LAN, ~3.5s at 120ms. Nothing here depends on the
+        // previous iteration.
+        let resolved = await withTaskGroup(of: (String, String)?.self) { group in
+            for seriesId in seriesIds {
+                group.addTask { [client] in
+                    do {
+                        let ancestors = try await client.getItemAncestors(itemId: seriesId)
+                        guard let library = ancestors.first(where: { $0.type == .collectionFolder }) else { return nil }
+                        return (seriesId, library.name)
+                    } catch {
+                        // Non-fatal: the row just renders without a library name
+                        return nil
                     }
                 }
-            } catch {
-                // Non-fatal: the row just renders without a library name
-                logger.error("Failed to load ancestors for \(seriesId, privacy: .public): \(error.localizedDescription, privacy: .public)")
+            }
+            var out: [String: String] = [:]
+            for await result in group {
+                if let (seriesId, name) = result { out[seriesId] = name }
+            }
+            return out
+        }
+
+        for item in continueWatchingItems {
+            let key = item.type == .episode ? item.seriesId : item.id
+            if let key, let name = resolved[key] {
+                libraryNames[item.id] = name
             }
         }
 
@@ -137,28 +151,58 @@ final class HomeViewModel: ObservableObject {
         #endif
     }
 
+    /// One library's latest-media result, tagged with its position so the
+    /// concurrent fetches can be put back into the original library order.
+    private struct LibraryLatest {
+        let index: Int
+        let items: [BaseItemDto]
+    }
+
     private func loadHeroItems() async {
         var allHeroItems: [BaseItemDto] = []
         var libraryNames: [String: String] = [:]
-        var itemsPerLibrary: [String: [BaseItemDto]] = [:]
 
-        for library in libraries {
-            do {
-                let items = try await client.getLatestMedia(parentId: library.id, limit: 10)
-                itemsPerLibrary[library.id] = items
-                for item in items {
-                    libraryNames[item.id] = library.name
+        // Concurrent, but collected in the ORIGINAL library order: the hero
+        // rotation should not reorder itself based on which server response
+        // happened to land first.
+        let perLibrary = await withTaskGroup(of: LibraryLatest?.self) { group in
+            for (index, library) in libraries.enumerated() {
+                group.addTask { [client] in
+                    do {
+                        let items = try await client.getLatestMedia(parentId: library.id, limit: 10)
+                        return LibraryLatest(index: index, items: items)
+                    } catch {
+                        // Non-fatal: this library is just missing from the rotation
+                        return nil
+                    }
                 }
-                allHeroItems.append(contentsOf: items.prefix(5))
-            } catch {
-                // Non-fatal: this library is just missing from the hero rotation
-                logger.error("Failed to load latest media for library \(library.name, privacy: .public): \(error.localizedDescription, privacy: .public)")
             }
+            var out: [LibraryLatest] = []
+            for await result in group {
+                if let result { out.append(result) }
+            }
+            return out.sorted { $0.index < $1.index }
         }
 
-        heroItems = allHeroItems.shuffled()
+        for entry in perLibrary {
+            let library = libraries[entry.index]
+            for item in entry.items {
+                libraryNames[item.id] = library.name
+            }
+            allHeroItems.append(contentsOf: entry.items.prefix(5))
+        }
+
+        // Shuffled only on the FIRST load. Reshuffling on every refresh
+        // republished a reordered array while the view's currentIndex stayed
+        // put, so the hero cut to an unrelated title every 30 seconds,
+        // off-cadence from its own 6-second rotation -- and the .id(currentItem.id)
+        // change tore down and re-downloaded the backdrop each time.
+        if heroItems.isEmpty {
+            heroItems = allHeroItems.shuffled()
+        } else {
+            heroItems = allHeroItems
+        }
         heroItemLibraryNames = libraryNames
-        libraryItems = itemsPerLibrary
     }
 
     func refresh() async {


### PR DESCRIPTION
Findings from a tvOS performance audit, each verified against the source. Apple TV has far less RAM than a phone and a 4K panel, so oversized decodes and serialized round-trips hurt much more here.

Stacked on #326.

## 1. Backdrops requested at 3840px for a slot that renders ~910×512pt

tvOS lays out in a **1920×1080** space. The hero renders about 910×512pt and the detail backdrop into `geometry.size.width * 0.45` — but both asked Jellyfin for `maxWidth: 3840`.

`maxWidth` is a cap, not a resize, so any item whose artwork is 4K really did return 4K: a **3840·2160·4 = 33 MB** RGBA backing store per image, downsampled on sight. Both dropped to 1920.

This compounds badly: the hero rotates every 6 seconds and the tvOS target has no image cache, so it's a fresh 33 MB decode each time rather than a cache hit.

## 2. The hero reshuffled itself every 30 seconds

`loadHeroItems` ended with `heroItems = allHeroItems.shuffled()`, and `refresh()` calls it. `currentIndex` is separate `@State` and doesn't move, so the same index resolved to a *different* item — the banner cut to an unrelated title off-cadence from its own 6-second rotation, and the `.id(currentItem.id)` change tore down and re-downloaded the backdrop each time.

Now shuffled on first load only. **This was a visible bug as much as a perf one.**

## 3. The 30-second refresh ran through entire movies

The player and detail view are `fullScreenCover`s, which do **not** remove the presenting view — so `HomeView`'s `.onDisappear` never fired and the timer kept going.

Each tick is ~25 requests, aimed at the same server that's busy transcoding the film being watched, plus a republish of every `@Published` on the view model, re-evaluating the whole `LazyVStack` behind the cover. Now skipped while anything is presented over Home.

## 4. Two N+1 loops ran serially before the first render

- `loadContinueWatchingLibraryNames` — one `getItemAncestors` per series, **up to 20, in sequence**
- `loadHeroItems` — one `getLatestMedia` per library, also in sequence

Both sit inside `loadContent()` ahead of `isLoading = false`, and `JellyfinClient` sets `urlCache = nil`, so there was nothing to soften them. At 30 ms LAN latency with 8 libraries that's ~0.9 s of pure waiting; ~3.5 s at 120 ms.

Both are now `withTaskGroup`. The hero one collects results back into the **original library order** rather than completion order, so the rotation doesn't depend on which response landed first.

## 5. Dead code that cost real work

`HomeViewModel.libraryItems` was `@Published`, written on every load and read **nowhere** — forcing an extra view-tree invalidation per load for nothing. `HomeView.orderedLibraries` was an unreferenced computed property.

## Verification

tvOS and iOS both build; SwiftLint `--strict` clean.

**Not measured on device.** These are structural (fewer bytes decoded, fewer serialized round-trips, fewer timer ticks) rather than micro-optimisations, but I haven't profiled before/after on an Apple TV.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XzUNvRCXML3DJe98KBCGkN