### PR TITLE
fix: a cert-trust toggle could silently revoke the current server's allowance

### DIFF
--- a/SashimiTests/SettingsTests.swift
+++ b/SashimiTests/SettingsTests.swift
@@ -35,8 +35,10 @@ final class SettingsTests: XCTestCase {
         certSettings.untrustHost(testHost)
         XCTAssertFalse(certSettings.isHostTrusted(testHost))
 
-        // Restore original state
-        certSettings.trustedHosts = originalHosts
+        // Restore original state. trustedHosts is a read-only mirror of the
+        // defaults now, so restore through the defaults and re-read.
+        UserDefaults.standard.set(Array(originalHosts), forKey: CertificateTrustKeys.trustedHosts)
+        certSettings.reloadFromDefaults()
     }
 
     @MainActor
@@ -58,12 +60,49 @@ final class SettingsTests: XCTestCase {
         XCTAssertNil(remaining?[testHost])
 
         // Restore original state
-        certSettings.trustedHosts = originalHosts
+        UserDefaults.standard.set(Array(originalHosts), forKey: CertificateTrustKeys.trustedHosts)
+        certSettings.reloadFromDefaults()
         if let originalPins {
             defaults.set(originalPins, forKey: CertificateTrustKeys.fingerprints)
         } else {
             defaults.removeObject(forKey: CertificateTrustKeys.fingerprints)
         }
+    }
+
+    @MainActor
+    func testAToggleDoesNotClobberAHostAddedBehindItsBack() {
+        // The bug: CertificateTrustSettings loaded its Sets once in init, and a
+        // didSet wrote the whole Set back. CertificateValidationDelegate also
+        // writes those keys, from the URLSession delegate queue, when it
+        // migrates a legacy flag onto a host. So a toggle made afterwards
+        // overwrote the delegate's addition from a stale in-memory copy --
+        // silently revoking the current server's allowance, after which every
+        // request to it failed.
+        let certSettings = CertificateTrustSettings.shared
+        let defaults = UserDefaults.standard
+        let key = CertificateTrustKeys.selfSignedHosts
+        let original = defaults.array(forKey: key) as? [String]
+
+        defaults.set([String](), forKey: key)
+        certSettings.reloadFromDefaults()
+
+        // Simulate the delegate adding a host directly to the defaults while
+        // this object holds an older snapshot.
+        defaults.set(["added.behind.our.back"], forKey: key)
+
+        // Now a normal UI toggle for a different host.
+        certSettings.setSelfSignedAllowed(true, host: "user.toggled.host")
+
+        let stored = Set((defaults.array(forKey: key) as? [String]) ?? [])
+        XCTAssertTrue(stored.contains("added.behind.our.back"), "Concurrent addition must survive a later toggle")
+        XCTAssertTrue(stored.contains("user.toggled.host"))
+
+        if let original {
+            defaults.set(original, forKey: key)
+        } else {
+            defaults.removeObject(forKey: key)
+        }
+        certSettings.reloadFromDefaults()
     }
 
     func testLegacyGlobalAllowanceMigratesToChallengedHost() {

--- a/Shared/Services/JellyfinClient.swift
+++ b/Shared/Services/JellyfinClient.swift
@@ -25,19 +25,59 @@ enum CertificateTrustKeys {
 class CertificateTrustSettings: ObservableObject {
     static let shared = CertificateTrustSettings()
 
-    /// Hosts allowed to present certificates that fail system trust because
-    /// of an unknown (self-signed) root.
-    @Published var selfSignedAllowedHosts: Set<String> {
-        didSet { UserDefaults.standard.set(Array(selfSignedAllowedHosts), forKey: CertificateTrustKeys.selfSignedHosts) }
-    }
-    /// Hosts allowed to present expired certificates.
-    @Published var expiredAllowedHosts: Set<String> {
-        didSet { UserDefaults.standard.set(Array(expiredAllowedHosts), forKey: CertificateTrustKeys.expiredHosts) }
-    }
+    // These are a MIRROR of what is on disk, not the source of truth.
+    //
+    // CertificateValidationDelegate.hostAllowance also writes these keys, from
+    // the URLSession delegate queue, when it migrates a legacy global flag onto
+    // a host. This object loads its Sets once in init(), so a didSet that wrote
+    // `Array(set)` back would overwrite whatever the delegate had added in the
+    // meantime -- silently revoking the current server's allowance the next
+    // time the user touched any toggle, after which connections just start
+    // failing. Mutations therefore go through setAllowance/setTrusted, which
+    // read-modify-write the defaults and then re-read the mirror.
+    @Published private(set) var selfSignedAllowedHosts: Set<String>
+    @Published private(set) var expiredAllowedHosts: Set<String>
     /// Manually trusted hosts. These are pinned to the SHA-256 fingerprint of
     /// the leaf certificate they present on first acceptance.
-    @Published var trustedHosts: Set<String> {
-        didSet { UserDefaults.standard.set(Array(trustedHosts), forKey: CertificateTrustKeys.trustedHosts) }
+    @Published private(set) var trustedHosts: Set<String>
+
+    /// Read-modify-write a host list, so a concurrent write from the TLS
+    /// delegate queue cannot be clobbered by a stale in-memory copy.
+    private func mutateHostList(key: String, host: String, insert: Bool) {
+        let defaults = UserDefaults.standard
+        var hosts = Set((defaults.array(forKey: key) as? [String]) ?? [])
+        if insert { hosts.insert(host) } else { hosts.remove(host) }
+        defaults.set(Array(hosts), forKey: key)
+        reloadFromDefaults()
+    }
+
+    /// Re-reads all three lists from disk. Public so the Settings UI can call
+    /// it after a connection attempt, which is when the delegate may have
+    /// migrated a legacy flag underneath us.
+    func reloadFromDefaults() {
+        let defaults = UserDefaults.standard
+        selfSignedAllowedHosts = Set((defaults.array(forKey: CertificateTrustKeys.selfSignedHosts) as? [String]) ?? [])
+        expiredAllowedHosts = Set((defaults.array(forKey: CertificateTrustKeys.expiredHosts) as? [String]) ?? [])
+        trustedHosts = Set((defaults.array(forKey: CertificateTrustKeys.trustedHosts) as? [String]) ?? [])
+    }
+
+    func setSelfSignedAllowed(_ allowed: Bool, host: String) {
+        mutateHostList(key: CertificateTrustKeys.selfSignedHosts, host: host, insert: allowed)
+    }
+
+    func setExpiredAllowed(_ allowed: Bool, host: String) {
+        mutateHostList(key: CertificateTrustKeys.expiredHosts, host: host, insert: allowed)
+    }
+
+    func setTrusted(_ trusted: Bool, host: String) {
+        mutateHostList(key: CertificateTrustKeys.trustedHosts, host: host, insert: trusted)
+        if !trusted {
+            // Drop the pin too, so re-trusting the host pins whatever it
+            // presents next rather than matching a stale fingerprint forever.
+            var pins = (UserDefaults.standard.dictionary(forKey: CertificateTrustKeys.fingerprints) as? [String: String]) ?? [:]
+            pins.removeValue(forKey: host)
+            UserDefaults.standard.set(pins, forKey: CertificateTrustKeys.fingerprints)
+        }
     }
 
     /// Host of the currently configured server; the per-host toggles in the
@@ -57,11 +97,7 @@ class CertificateTrustSettings: ObservableObject {
         }
         set {
             guard let host = currentHost else { return }
-            if newValue {
-                selfSignedAllowedHosts.insert(host)
-            } else {
-                selfSignedAllowedHosts.remove(host)
-            }
+            setSelfSignedAllowed(newValue, host: host)
         }
     }
 
@@ -73,11 +109,7 @@ class CertificateTrustSettings: ObservableObject {
         }
         set {
             guard let host = currentHost else { return }
-            if newValue {
-                expiredAllowedHosts.insert(host)
-            } else {
-                expiredAllowedHosts.remove(host)
-            }
+            setExpiredAllowed(newValue, host: host)
         }
     }
 
@@ -100,27 +132,25 @@ class CertificateTrustSettings: ObservableObject {
         let legacyExpired = defaults.bool(forKey: CertificateTrustKeys.legacyExpired)
         guard legacySelfSigned || legacyExpired, let host = currentHost else { return }
 
+        // Must go through mutateHostList: the Sets are a mirror now, so a bare
+        // insert would update memory, never reach disk, and then the legacy
+        // flags below get cleared -- losing the allowance on the next launch.
         if legacySelfSigned {
-            selfSignedAllowedHosts.insert(host)
+            mutateHostList(key: CertificateTrustKeys.selfSignedHosts, host: host, insert: true)
         }
         if legacyExpired {
-            expiredAllowedHosts.insert(host)
+            mutateHostList(key: CertificateTrustKeys.expiredHosts, host: host, insert: true)
         }
         defaults.removeObject(forKey: CertificateTrustKeys.legacySelfSigned)
         defaults.removeObject(forKey: CertificateTrustKeys.legacyExpired)
     }
 
     func trustHost(_ host: String) {
-        trustedHosts.insert(host)
+        setTrusted(true, host: host)
     }
 
     func untrustHost(_ host: String) {
-        trustedHosts.remove(host)
-        // Drop the pinned fingerprint so re-trusting the host later pins
-        // whatever certificate it presents then.
-        var pins = (UserDefaults.standard.dictionary(forKey: CertificateTrustKeys.fingerprints) as? [String: String]) ?? [:]
-        pins.removeValue(forKey: host)
-        UserDefaults.standard.set(pins, forKey: CertificateTrustKeys.fingerprints)
+        setTrusted(false, host: host)
     }
 
     func isHostTrusted(_ host: String) -> Bool {


### PR DESCRIPTION
Closes #180.

## The bug

`CertificateTrustSettings` loaded its three host Sets once in `init()` and used `didSet` to write the whole Set back. But `CertificateValidationDelegate.hostAllowance` **also** writes those same UserDefaults keys — from the URLSession delegate queue — when it migrates a legacy global flag onto a host during a TLS challenge.

So:

1. The delegate adds the current server to `selfSignedAllowedHosts` **on disk**.
2. The settings object still holds the snapshot it loaded at launch, without that host.
3. The user touches any certificate toggle → `didSet` writes `Array(staleSet)` over the top.
4. The server's allowance is **gone**. Every subsequent request to it fails, with nothing in the UI explaining why.

The Sets are now an explicit read-only mirror of the defaults, and every mutation goes through a read-modify-write (`mutateHostList`) followed by a re-read. A concurrent addition from the delegate queue survives.

## A second bug that fix surfaced

`migrateLegacyGlobalFlags` inserted straight into the Sets. Once those no longer persisted on `didSet`, it would have updated memory, **never reached disk**, and then cleared the legacy flags anyway — losing the allowance on the next launch. Now goes through the same path.

Also folded `untrustHost`'s pin-clearing into `setTrusted`, so trust state and the pinned fingerprint can't drift apart.

## The rest of #180 was already done, or wrong

- **`loadAllTracks()` has callers now** (`MobilePlayerView:94` and `:112`), so `audioTracks` is populated and the iOS audio menu is reachable.
- **The `DownloadStatus.paused` branches are NOT unreachable.** A persisted legacy record maps to `downloadState = .paused` at `DownloadButton.swift:226`, which `:104` renders and `:150` handles. Removing them would have broken exactly the legacy records the issue said to keep working.

## Verification

**157 tests pass** (156 before, plus a regression test asserting that a host added behind the settings object's back survives a later toggle). tvOS and iOS both build; SwiftLint `--strict` clean.

**Left open:** the cert-rotation UX item — surfacing a "server certificate changed" alert instead of a generic network error — since it needs a real rotation to test against.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XzUNvRCXML3DJe98KBCGkN