### PR TITLE
perf: fix the four tvOS follow-ups from the audit

### DIFF
--- a/Sashimi/Views/Components/MediaRow.swift
+++ b/Sashimi/Views/Components/MediaRow.swift
@@ -62,11 +62,27 @@ struct MediaPosterButton: View {
 
     // Image types to try
     private var imageTypes: [String] {
-        if isLandscape {
+        let candidates: [String] = isLandscape
             // For YouTube/landscape, try Thumb first (more likely to have video thumbnail)
-            return ["Thumb", "Primary", "Backdrop", "Screenshot"]
+            ? ["Thumb", "Primary", "Backdrop", "Screenshot"]
+            : ["Primary", "Thumb"]
+
+        // The server already tells us which image types an item has, in
+        // ImageTags — and this probed blindly instead, so a tile whose item has
+        // no Thumb issued a doomed request and then waited 500ms before trying
+        // the next type. In a grid showing 30 tiles that is a lot of wasted
+        // round-trips and visible placeholder time.
+        //
+        // Only applied when the item itself is the sole candidate id. For
+        // episodes we also fall back to season/series ids, and we hold no tags
+        // for those, so those must still probe.
+        guard imageFallbackIds == [item.id], let tags = item.imageTags, !tags.isEmpty else {
+            return candidates
         }
-        return ["Primary", "Thumb"]
+        let available = candidates.filter { tags[$0] != nil }
+        // If the tags name none of our candidates, fall back to probing rather
+        // than rendering a guaranteed placeholder.
+        return available.isEmpty ? candidates : available
     }
 
     // VoiceOver accessibility description

--- a/Sashimi/Views/Detail/MediaDetailView.swift
+++ b/Sashimi/Views/Detail/MediaDetailView.swift
@@ -1046,7 +1046,12 @@ struct MediaDetailView: View {
 
                     ScrollViewReader { proxy in
                         ScrollView(.horizontal, showsIndicators: false) {
-                            HStack(spacing: 30) {
+                            // Lazy: a non-lazy HStack instantiates every child
+                            // immediately, so a 24-episode season fired 24
+                            // concurrent image requests on appear, ~20 of them
+                            // off-screen — saturating the queue ahead of the
+                            // images actually on screen.
+                            LazyHStack(spacing: 30) {
                                 ForEach(episodes) { episode in
                                     EpisodeCard(episode: episode, isCurrentEpisode: episode.id == nextEpisodeToPlay?.id, showEpisodeThumbnail: true) {
                                         showingEpisodeDetail = episode
@@ -1097,7 +1102,8 @@ struct MediaDetailView: View {
             } else if !episodes.isEmpty {
                 ScrollViewReader { proxy in
                     ScrollView(.horizontal, showsIndicators: false) {
-                        HStack(spacing: 30) {
+                        // Lazy for the same reason as the season strip above.
+                        LazyHStack(spacing: 30) {
                             ForEach(episodes) { episode in
                                 EpisodeCard(
                                     episode: episode,

--- a/Sashimi/Views/Home/HomeView.swift
+++ b/Sashimi/Views/Home/HomeView.swift
@@ -671,17 +671,30 @@ struct RecentlyAddedLibraryRow: View {
             return nil
         })
 
-        // Fetch each series to get its unplayed count
-        for seriesId in seriesIds {
-            do {
-                let series = try await JellyfinClient.shared.getItem(itemId: seriesId)
-                if let unplayedCount = series.userData?.unplayedItemCount, unplayedCount > 0 {
-                    counts[seriesId] = unplayedCount
+        // Fetch each series' unplayed count CONCURRENTLY. Serially this was up
+        // to 20 round-trips per Recently-Added row, per TV library, purely to
+        // decorate a badge -- and it re-ran on every return to Home, delaying
+        // the images the user is actually looking at.
+        let fetched = await withTaskGroup(of: (String, Int)?.self) { group in
+            for seriesId in seriesIds {
+                group.addTask {
+                    do {
+                        let series = try await JellyfinClient.shared.getItem(itemId: seriesId)
+                        guard let unplayedCount = series.userData?.unplayedItemCount, unplayedCount > 0 else { return nil }
+                        return (seriesId, unplayedCount)
+                    } catch {
+                        // Ignore errors for individual series
+                        return nil
+                    }
                 }
-            } catch {
-                // Ignore errors for individual series
             }
+            var out: [String: Int] = [:]
+            for await result in group {
+                if let (seriesId, count) = result { out[seriesId] = count }
+            }
+            return out
         }
+        counts.merge(fetched) { _, new in new }
 
         episodeCounts = counts
     }

--- a/Sashimi/Views/Library/LibraryView.swift
+++ b/Sashimi/Views/Library/LibraryView.swift
@@ -339,7 +339,6 @@ struct LibraryDetailView: View {
                                     }
                                     .id(item.id)
                                     .prefersDefaultFocus(index == 0, in: namespace)
-                                    .transition(.opacity.combined(with: .scale(scale: 0.95)))
                                     .onAppear {
                                         // Load more when approaching the end
                                         if item.id == items.last?.id && hasMore && !isLoadingMore {
@@ -350,7 +349,13 @@ struct LibraryDetailView: View {
                             }
                             .padding(.horizontal, 60)
                             .padding(.bottom, 60)
-                            .animation(.easeOut(duration: 0.3), value: items.count)
+                            // No blanket animation on items.count. An alphabet
+                            // jump can insert several thousand items in one go,
+                            // and SwiftUI must resolve the opacity+scale
+                            // transition for every inserted identity -- not just
+                            // the visible ones -- which froze the UI for
+                            // seconds. Paging in 50 at a time never needed an
+                            // animation to feel right anyway.
 
                             // Loading indicator for infinite scroll
                             if isLoadingMore {
@@ -406,9 +411,9 @@ struct LibraryDetailView: View {
             MediaDetailView(item: item, forceYouTubeStyle: selectedItemIsYouTube)
         }
         .onChange(of: selectedItem) { oldValue, newValue in
-            // Refresh item data when returning from detail view
-            if oldValue != nil && newValue == nil {
-                Task { await refreshCurrentItems() }
+            // Refresh only the item that was open, not the whole grid.
+            if let dismissed = oldValue, newValue == nil {
+                Task { await refreshItem(id: dismissed.id) }
             }
         }
     }
@@ -582,27 +587,28 @@ struct LibraryDetailView: View {
         isLoadingMore = false
     }
 
-    private func refreshCurrentItems() async {
-        // Just refresh userData for watched status, don't reload all
+    /// Refresh the single item the user just came back from.
+    ///
+    /// This used to do what its comment said it didn't: request `limit:
+    /// items.count, startIndex: 0` -- the entire loaded grid, with
+    /// `Fields=...,MediaStreams` -- and replace the whole array. With 500 items
+    /// scrolled in, backing out of a detail view issued one request for 500 full
+    /// items and made every `BaseItemDto` a new value, so every cell re-evaluated
+    /// and every visible image reloaded. That is the most repeated interaction in
+    /// the app.
+    ///
+    /// Only watched/favourite state can have changed, and only for the item that
+    /// was open, so fetch just that one and patch it in place.
+    private func refreshItem(id: String) async {
+        guard let index = items.firstIndex(where: { $0.id == id }) else { return }
         do {
-            let includeTypes: [ItemType]? = switch library.collectionType {
-            case "tvshows": [.series]
-            case "movies": [.movie]
-            default: nil
+            let refreshed = try await JellyfinClient.shared.getItem(itemId: id)
+            // The index can move if a load landed while the detail view was up.
+            if let current = items.firstIndex(where: { $0.id == id }) {
+                items[current] = refreshed
+            } else {
+                items[index] = refreshed
             }
-
-            let filter = filterParams
-            let response = try await JellyfinClient.shared.getItems(
-                parentId: library.id,
-                includeTypes: includeTypes,
-                sortBy: sortOption.rawValue,
-                sortOrder: sortOrder.rawValue,
-                limit: items.count,
-                startIndex: 0,
-                isPlayed: filter.isPlayed,
-                isFavorite: filter.isFavorite
-            )
-            items = response.items
         } catch {
             // Silent fail - non-critical refresh
         }


### PR DESCRIPTION
Closes #329. Closes #330. Closes #331. Closes #332.

## 1. Backing out of a detail view reloaded the entire grid (#329)

`refreshCurrentItems`' own comment said *"just refresh userData for watched status, don't reload all"* — and then requested `limit: items.count, startIndex: 0` with `Fields=...,MediaStreams` and assigned `items = response.items`.

With 500 items scrolled in, closing a detail view fetched **500 full items** and made every `BaseItemDto` a new value, so every cell re-evaluated and every visible image reloaded. Backing out of an item is the most repeated interaction in the app.

Only the item that was open can have changed, and only its watched/favourite state — so it fetches that one and patches it in place. It re-locates the index after the await, since a paged load can land while the detail view is up.

## 2. Episode strips instantiated every card at once (#331)

Two horizontal strips used a plain `HStack`, so a 24-episode season fired 24 concurrent image requests on appear — ~20 off-screen, saturating the queue ahead of the images actually visible. Both are `LazyHStack` now, matching `MediaRow` and `ContinueWatchingRow` which already were.

The unplayed-count badge fetch was also serial: up to 20 `getItem` calls per Recently-Added row, per TV library, purely to decorate a badge — re-run on every return to Home. Now a `withTaskGroup`.

## 3. A bulk insert was animated per element (#330)

The grid carried `.animation(.easeOut, value: items.count)` plus a per-item opacity+scale transition. An alphabet jump can insert **several thousand** items at once, and SwiftUI resolves the transition for every inserted identity — not just the visible ones — which froze the UI for seconds. Paging in 50 at a time never needed the animation to feel right.

## 4. Images were probed blind (#332)

The server reports which image types an item has in `ImageTags`. The models decode it; tvOS never read it. Instead each tile walked a fallback matrix, waiting **500 ms after every failure** before trying the next type — so a tile whose item has no Thumb burned several doomed round-trips and seconds of placeholder, in a grid showing 30 tiles at once.

Candidate types are now filtered by `ImageTags`. **Deliberately narrow:** only when the item itself is the sole candidate id (every movie and series grid). Episodes also fall back to season/series ids and we hold no tags for those, so they still probe. Falls back to probing if the tags name none of the candidates, rather than rendering a guaranteed placeholder.

## Verification

**157 tests pass.** tvOS and iOS both build; SwiftLint `--strict` clean.

**Not measured on device.** These are structural — one request instead of 500, lazy instantiation, concurrent instead of serial, no per-element transition on a bulk insert — rather than micro-optimisations, but I haven't profiled before/after on an Apple TV.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XzUNvRCXML3DJe98KBCGkN