### PR TITLE
fix: stop the previous episode's audio playing under the new one

### DIFF
--- a/Shared/ViewModels/PlayerViewModel.swift
+++ b/Shared/ViewModels/PlayerViewModel.swift
@@ -302,6 +302,20 @@ final class PlayerViewModel: ObservableObject {
         // player crash when it deallocates (same teardown as changeQuality).
         // The session subtitle intent is deliberately preserved so subtitles
         // stay on across episodes; only the overlay/tracking is cleared.
+        // Silence and release the outgoing player BEFORE anything awaits.
+        //
+        // This teardown removed the observers but never paused the player and
+        // never let go of it, so the previous episode kept playing its audio
+        // underneath the new one. The gap is not brief: everything below this
+        // point awaits the network — stopActiveEncoding, then the playback-info
+        // fetch — and the new AVPlayer is not created until well after that. On
+        // tvOS the AVPlayerViewController also goes on holding the old instance
+        // until the new one is assigned, so it really does keep decoding.
+        //
+        // changeQuality and the stop path both do this; only this one did not,
+        // which is how auto-play-next and skip-credits ended up with two
+        // players running.
+        player?.pause()
         progressReportTask?.cancel()
         subtitleLoadTask?.cancel()
         cleanupSegmentTracking()
@@ -313,6 +327,7 @@ final class PlayerViewModel: ObservableObject {
             NotificationCenter.default.removeObserver(endObserver)
             self.endObserver = nil
         }
+        player = nil
 
         // Kill the previous episode's transcode session, same as
         // changeQuality — auto-play-next otherwise leaves the old encode


### PR DESCRIPTION
Fixes #339.

Skipping credits, or auto-play-next reaching the end of an episode, left the outgoing video **still decoding** — you hear the old episode's audio underneath the new one.

## Cause

`loadMedia()` tears down the previous player's *observers* but never pauses it and never lets go of it:

```swift
progressReportTask?.cancel()
subtitleLoadTask?.cancel()
cleanupSegmentTracking()
subtitleManager.clear()
invalidatePlayerObservers()
if let endObserver { ... }
// ← no player?.pause(), no player = nil
```

The other two teardown sites — `changeQuality` and the stop path — both do `player?.pause()` … `player = nil`. **Only `loadMedia` didn't**, which is exactly why the symptom shows up on the two paths that route through it.

The window isn't brief. Everything after that teardown awaits the network (`stopActiveEncoding`, then the playback-info fetch), and the replacement `AVPlayer` isn't constructed until well afterwards. On tvOS the `AVPlayerViewController` also goes on holding the old instance until the new one is assigned, so it genuinely keeps playing.

## Fix

Pause before anything awaits; release once the observers are gone. Matches what the other two paths already do.

## Verification

Builds clean for tvOS.

⚠️ **Not verified on hardware.** Overlapping audio across an episode transition is exactly the class of thing only a real Apple TV can confirm — worth a look before this goes to TestFlight.