### PR TITLE
fix: stop Auto quality guessing 20 Mbps when the bandwidth probe fails

### DIFF
--- a/Sashimi/Views/Library/SettingsView.swift
+++ b/Sashimi/Views/Library/SettingsView.swift
@@ -640,6 +640,8 @@ struct SettingsToggleRow: View {
 
 struct PlaybackSettingsView: View {
     @StateObject private var settings = PlaybackSettings.shared
+    /// Nil until the client answers; drives the Auto-quality diagnostics row.
+    @State private var bandwidthStatus: JellyfinClient.BandwidthStatus?
 
     var body: some View {
         SettingsContainer {
@@ -655,6 +657,11 @@ struct PlaybackSettingsView: View {
                         VideoQualitySettingsView()
                     }
                     SettingsToggleRow(title: "Always Play Original", isOn: $settings.forceDirectPlay)
+                    // Auto's real ceiling was invisible: a stream capped by a
+                    // failed bandwidth probe looked like a struggling server.
+                    if settings.maxBitrate == 0 {
+                        SettingsInfoRow(label: "Auto Limit", value: autoLimitLabel)
+                    }
                 }
 
                 Text("Plays the original file untouched, never converted. If your connection cannot keep up, playback may stall rather than drop quality.")
@@ -709,6 +716,15 @@ struct PlaybackSettingsView: View {
             .padding(.horizontal, 60)
             .padding(.bottom, 60)
         }
+        .task { bandwidthStatus = await JellyfinClient.shared.bandwidthStatus }
+    }
+
+    /// The cap Auto is actually sending, and whether it came from a real
+    /// measurement or the fallback default.
+    private var autoLimitLabel: String {
+        guard let bandwidthStatus else { return "Checking…" }
+        let mbps = Int(round(Double(bandwidthStatus.cap) / 1_000_000))
+        return bandwidthStatus.isMeasured ? "\(mbps) Mbps measured" : "\(mbps) Mbps (not measured)"
     }
 
     private var bitrateLabel: String {

--- a/SashimiTests/PlaybackSelectionTests.swift
+++ b/SashimiTests/PlaybackSelectionTests.swift
@@ -48,6 +48,102 @@ final class PlaybackSelectionTests: XCTestCase {
         XCTAssertNil(PlaybackSelection.effectiveMaxBitrate(sessionOverride: nil, settingsMaxBitrate: 0))
     }
 
+    // MARK: - autoBitrateCap
+
+    func testUnmeasuredLocalServerGetsOptimisticCap() {
+        // The bug: a failed probe looked identical to a slow link, so a 24.9
+        // Mbps 4K source on a gigabit LAN was capped at 20 Mbps and re-encoded.
+        let cap = PlaybackSelection.autoBitrateCap(measuredBitrate: nil, isLocalServer: true)
+        XCTAssertEqual(cap, PlaybackSelection.unmeasuredLocalBitrateCap)
+        XCTAssertGreaterThan(cap, 24_879_906)
+    }
+
+    func testUnmeasuredRemoteServerStaysConservative() {
+        XCTAssertEqual(
+            PlaybackSelection.autoBitrateCap(measuredBitrate: nil, isLocalServer: false),
+            PlaybackSelection.unmeasuredRemoteBitrateCap
+        )
+    }
+
+    func testMeasuredBitrateKeepsHeadroom() {
+        XCTAssertEqual(
+            PlaybackSelection.autoBitrateCap(measuredBitrate: 40_000_000, isLocalServer: true),
+            34_000_000
+        )
+    }
+
+    func testMeasuredSlowLinkIsHonoredOnALocalServer() {
+        // A measurement is evidence; a LAN server does not override it.
+        XCTAssertEqual(
+            PlaybackSelection.autoBitrateCap(measuredBitrate: 10_000_000, isLocalServer: true),
+            8_500_000
+        )
+    }
+
+    func testMeasuredBitrateIsClampedBothWays() {
+        XCTAssertEqual(
+            PlaybackSelection.autoBitrateCap(measuredBitrate: 500_000, isLocalServer: false),
+            PlaybackSelection.minimumMeasuredBitrateCap
+        )
+        XCTAssertEqual(
+            PlaybackSelection.autoBitrateCap(measuredBitrate: 1_000_000_000, isLocalServer: false),
+            PlaybackSelection.maximumMeasuredBitrateCap
+        )
+    }
+
+    func testNonPositiveMeasurementIsTreatedAsNoMeasurement() {
+        XCTAssertEqual(
+            PlaybackSelection.autoBitrateCap(measuredBitrate: 0, isLocalServer: true),
+            PlaybackSelection.unmeasuredLocalBitrateCap
+        )
+    }
+
+    // MARK: - autoMaxWidth
+
+    func testHighCapDoesNotConstrainWidth() {
+        // 4K must stay 4K when the link can carry it — this is the path a LAN
+        // client takes, and it must not start downscaling.
+        XCTAssertNil(PlaybackSelection.autoMaxWidth(forBitrateCap: 100_000_000))
+        XCTAssertNil(PlaybackSelection.autoMaxWidth(forBitrateCap: 25_000_000))
+    }
+
+    func testLowCapsPickAResolutionTheCapCanCarry() {
+        // Without a width the server re-encodes at source resolution, so a
+        // capped 4K stream was re-encoded at full 4K.
+        XCTAssertEqual(PlaybackSelection.autoMaxWidth(forBitrateCap: 20_000_000), 1920)
+        XCTAssertEqual(PlaybackSelection.autoMaxWidth(forBitrateCap: 8_000_000), 1280)
+        XCTAssertEqual(PlaybackSelection.autoMaxWidth(forBitrateCap: 3_000_000), 854)
+    }
+
+    // MARK: - isLocalServer
+
+    func testPrivateAddressesAreLocal() {
+        for host in ["192.168.86.151", "10.0.0.5", "172.16.4.2", "172.31.255.254", "127.0.0.1", "169.254.1.1"] {
+            XCTAssertTrue(
+                PlaybackSelection.isLocalServer(URL(string: "http://\(host):8096")),
+                "\(host) should be treated as local"
+            )
+        }
+    }
+
+    func testLocalNamesAreLocal() {
+        XCTAssertTrue(PlaybackSelection.isLocalServer(URL(string: "http://localhost:8096")))
+        XCTAssertTrue(PlaybackSelection.isLocalServer(URL(string: "http://popcorn.local:8096")))
+        XCTAssertTrue(PlaybackSelection.isLocalServer(URL(string: "http://popcorn:8096")))
+        XCTAssertTrue(PlaybackSelection.isLocalServer(URL(string: "http://[::1]:8096")))
+        XCTAssertTrue(PlaybackSelection.isLocalServer(URL(string: "http://[fd00::1]:8096")))
+    }
+
+    func testPublicAddressesAreNotLocal() {
+        for host in ["jellyfin.example.com", "8.8.8.8", "172.32.0.1", "192.169.0.1", "fc.example.com"] {
+            XCTAssertFalse(
+                PlaybackSelection.isLocalServer(URL(string: "https://\(host)")),
+                "\(host) should be treated as remote"
+            )
+        }
+        XCTAssertFalse(PlaybackSelection.isLocalServer(nil))
+    }
+
     // MARK: - languagesMatch
 
     func testMatchesIso639TwoVsThreeLetterCodes() {

--- a/Shared/Services/JellyfinClient.swift
+++ b/Shared/Services/JellyfinClient.swift
@@ -328,6 +328,7 @@ actor JellyfinClient {
     /// silently failed.
     let certificateDelegate: CertificateValidationDelegate
     private let maxRetries = 3
+    private let logger = Logger(subsystem: "com.mondominator.sashimi", category: "JellyfinClient")
 
     static let shared = JellyfinClient()
 
@@ -394,34 +395,85 @@ actor JellyfinClient {
         self.serverURL = serverURL
         self.accessToken = accessToken
         self.userId = userId
-        // A new server means a new link — force a fresh measurement.
+        // A new server means a new link — force a fresh measurement, and drop
+        // any probe still in flight so it can't write the old server's result.
+        bandwidthProbeTask?.cancel()
+        bandwidthProbeTask = nil
         measuredBitrate = nil
     }
 
     /// Measured downstream bandwidth (bits/sec) from the last BitrateTest.
     private var measuredBitrate: Int?
 
+    /// Retry schedule for the bandwidth probe: one immediate attempt, then
+    /// these delays. A single failure (a router reboot, a Wi-Fi handoff, a
+    /// server still starting up) must not leave Auto guessing all session.
+    private static let bandwidthProbeBackoff: [Duration] = [.seconds(3), .seconds(15), .seconds(60)]
+
+    /// The retrying probe, so a reconnect replaces it rather than racing it.
+    private var bandwidthProbeTask: Task<Void, Never>?
+
+    /// Where the Auto bitrate cap currently comes from. Read by Settings and
+    /// logged with every PlaybackInfo request: a cap in force used to be
+    /// invisible, so an unexplained transcode sent debugging to the server.
+    struct BandwidthStatus: Equatable, Sendable {
+        /// nil until a probe succeeds — the cap is a default until then.
+        let measuredBitrate: Int?
+        let cap: Int
+        let isLocalServer: Bool
+
+        var isMeasured: Bool { measuredBitrate != nil }
+    }
+
+    var bandwidthStatus: BandwidthStatus {
+        BandwidthStatus(
+            measuredBitrate: measuredBitrate,
+            cap: autoBitrateCap(),
+            isLocalServer: PlaybackSelection.isLocalServer(serverURL)
+        )
+    }
+
     /// The bitrate to request on "Auto": the measured bandwidth with headroom,
-    /// clamped to a sane range. Falls back to a conservative default until a
-    /// measurement lands (measureBandwidth runs on connect).
+    /// clamped to a sane range. Until a measurement lands the default is keyed
+    /// on where the server is, because a failed probe says nothing about the
+    /// link (see PlaybackSelection.autoBitrateCap).
     private func autoBitrateCap() -> Int {
-        guard let measured = measuredBitrate else { return 20_000_000 }
-        let withHeadroom = Int(Double(measured) * 0.85)
-        return min(max(withHeadroom, 3_000_000), 100_000_000)
+        PlaybackSelection.autoBitrateCap(
+            measuredBitrate: measuredBitrate,
+            isLocalServer: PlaybackSelection.isLocalServer(serverURL)
+        )
+    }
+
+    /// Starts measuring the connection, retrying with backoff until a probe
+    /// succeeds. Returns immediately; the Auto cap updates when one lands.
+    /// Any probe already running is cancelled first.
+    func startBandwidthMeasurement() {
+        bandwidthProbeTask?.cancel()
+        bandwidthProbeTask = Task { await self.runBandwidthProbes() }
+    }
+
+    private func runBandwidthProbes() async {
+        if await measureBandwidth() { return }
+        for delay in Self.bandwidthProbeBackoff {
+            guard (try? await Task.sleep(for: delay)) != nil else { return }
+            if await measureBandwidth() { return }
+        }
+        logger.warning("Bandwidth probe failed after all retries; Auto uses the default cap")
     }
 
     /// Time a fixed-size download from the server's BitrateTest endpoint to
     /// estimate the connection bandwidth, then cache it for Auto bitrate.
-    /// Best-effort: on any failure the previous/​default cap stands.
-    func measureBandwidth() async {
-        guard let serverURL else { return }
+    /// Best-effort: returns false on any failure, leaving the previous/default
+    /// cap standing for the caller to retry against.
+    private func measureBandwidth() async -> Bool {
+        guard let serverURL else { return false }
         let sizeBytes = 8_000_000
         guard var components = URLComponents(
             url: serverURL.appendingPathComponent("Playback/BitrateTest"),
             resolvingAgainstBaseURL: false
-        ) else { return }
+        ) else { return false }
         components.queryItems = [URLQueryItem(name: "Size", value: String(sizeBytes))]
-        guard let url = components.url else { return }
+        guard let url = components.url else { return false }
 
         var req = URLRequest(url: url)
         req.setValue(authorizationHeader, forHTTPHeaderField: "Authorization")
@@ -429,12 +481,14 @@ actor JellyfinClient {
 
         let start = Date()
         guard let (data, response) = try? await urlSession.data(for: req),
-              let http = response as? HTTPURLResponse, http.statusCode == 200 else { return }
+              let http = response as? HTTPURLResponse, http.statusCode == 200 else { return false }
         let elapsed = Date().timeIntervalSince(start)
-        guard elapsed > 0.01, !data.isEmpty else { return }
+        guard elapsed > 0.01, !data.isEmpty else { return false }
 
         let bitsPerSecond = Int((Double(data.count) * 8.0) / elapsed)
         measuredBitrate = bitsPerSecond
+        logger.info("Bandwidth probe measured \(bitsPerSecond) bps")
+        return true
     }
 
     var isConfigured: Bool {
@@ -747,26 +801,10 @@ actor JellyfinClient {
         return response.items.first
     }
 
-    func getPlaybackInfo(
-        itemId: String,
-        maxBitrate: Int? = nil,
-        maxWidth: Int? = nil,
-        forceDirectPlay: Bool = false,
-        forceTranscode: Bool = false
-    ) async throws -> PlaybackInfoResponse {
-        guard let userId else { throw JellyfinError.notConfigured }
-
-        // Auto (no explicit cap) uses the measured connection bandwidth so we
-        // don't request more than the link can carry (the cause of remote
-        // stalls); explicit picks are honored as-is.
-        let streamingBitrate = maxBitrate ?? autoBitrateCap()
-
-        // An explicit quality pick (forceTranscode) beats the global Force
-        // Direct Play setting for this request — otherwise the pick could
-        // never take effect.
-        let effectiveForceDirectPlay = forceDirectPlay && !forceTranscode
-
-        let deviceProfile: [String: Any] = [
+    /// The device profile sent with every PlaybackInfo request: what this
+    /// client can play natively, and the ceilings the server must respect.
+    private func videoDeviceProfile(streamingBitrate: Int, maxWidth: Int?) -> [String: Any] {
+        [
             "MaxStreamingBitrate": streamingBitrate,
             "MaxStaticBitrate": 100000000,
             "MusicStreamingTranscodingBitrate": 384000,
@@ -816,6 +854,51 @@ actor JellyfinClient {
                 ["Format": "srt", "Method": "External"]
             ]
         ]
+    }
+
+    /// Records what Auto is actually asking the server for. Without this the
+    /// only symptom of a bogus cap is an unexplained transcode, which reads as
+    /// "the server is struggling" and sends debugging to the wrong place.
+    private func logAutoBitrateCap(width: Int?) {
+        let status = bandwidthStatus
+        logger.info(
+            """
+            Auto bitrate cap \(status.cap, privacy: .public) bps \
+            (\(status.isMeasured ? "measured" : "no measurement", privacy: .public), \
+            \(status.isLocalServer ? "local" : "remote", privacy: .public) server), \
+            width \(width.map(String.init) ?? "unrestricted", privacy: .public)
+            """
+        )
+    }
+
+    func getPlaybackInfo(
+        itemId: String,
+        maxBitrate: Int? = nil,
+        maxWidth: Int? = nil,
+        forceDirectPlay: Bool = false,
+        forceTranscode: Bool = false
+    ) async throws -> PlaybackInfoResponse {
+        guard let userId else { throw JellyfinError.notConfigured }
+
+        // Auto (no explicit cap) uses the measured connection bandwidth so we
+        // don't request more than the link can carry (the cause of remote
+        // stalls); explicit picks are honored as-is.
+        let streamingBitrate = maxBitrate ?? autoBitrateCap()
+
+        // A bitrate cap with no width condition makes the server re-encode at
+        // the source resolution, so a capped 4K stream was re-encoded at full
+        // 4K — the most expensive way to reach the ceiling. When the caller
+        // picked no tier, derive a width the cap can actually carry.
+        let effectiveMaxWidth = maxWidth ?? PlaybackSelection.autoMaxWidth(forBitrateCap: streamingBitrate)
+
+        if maxBitrate == nil { logAutoBitrateCap(width: effectiveMaxWidth) }
+
+        // An explicit quality pick (forceTranscode) beats the global Force
+        // Direct Play setting for this request — otherwise the pick could
+        // never take effect.
+        let effectiveForceDirectPlay = forceDirectPlay && !forceTranscode
+
+        let deviceProfile = videoDeviceProfile(streamingBitrate: streamingBitrate, maxWidth: effectiveMaxWidth)
 
         // Jellyfin's PlaybackInfo API has no "force direct play" flag.
         // Disabling DirectStream and Transcoding leaves direct play as the

--- a/Shared/Services/PlaybackSelection.swift
+++ b/Shared/Services/PlaybackSelection.swift
@@ -15,6 +15,96 @@ enum PlaybackSelection {
         return settingsMaxBitrate > 0 ? settingsMaxBitrate : nil
     }
 
+    // MARK: - Auto bitrate
+
+    /// Cap requested on "Auto" when the bandwidth probe has never succeeded and
+    /// the server is on the local network.
+    ///
+    /// A failed probe is not evidence of a slow link, and treating it as one is
+    /// what forced a 24.9 Mbps 4K HEVC source through a full re-encode on a
+    /// gigabit LAN: the old 20 Mbps fallback sits below almost every good 4K
+    /// release, so the server could no longer satisfy the request by copying
+    /// the video stream. A LAN client that has measured nothing assumes it is
+    /// fast — the same value a measured gigabit link clamps to.
+    static let unmeasuredLocalBitrateCap = 100_000_000
+
+    /// Cap on "Auto" with no measurement and a server reached over the
+    /// internet, where guessing high really can stall playback.
+    static let unmeasuredRemoteBitrateCap = 20_000_000
+
+    /// Clamp applied to a measured link. The floor keeps a badly timed probe
+    /// (a probe that raced a buffering stream) from pinning quality to nothing.
+    static let minimumMeasuredBitrateCap = 3_000_000
+    static let maximumMeasuredBitrateCap = 100_000_000
+
+    /// Fraction of the measured bandwidth to request, leaving headroom for
+    /// protocol overhead and other traffic on the link.
+    static let measuredBitrateHeadroom = 0.85
+
+    /// The bitrate cap sent on "Auto": the measured bandwidth with headroom,
+    /// clamped to a sane range, or a default keyed on where the server is when
+    /// nothing has been measured yet.
+    static func autoBitrateCap(measuredBitrate: Int?, isLocalServer: Bool) -> Int {
+        guard let measuredBitrate, measuredBitrate > 0 else {
+            return isLocalServer ? unmeasuredLocalBitrateCap : unmeasuredRemoteBitrateCap
+        }
+        let withHeadroom = Int(Double(measuredBitrate) * measuredBitrateHeadroom)
+        return min(max(withHeadroom, minimumMeasuredBitrateCap), maximumMeasuredBitrateCap)
+    }
+
+    /// Width cap to pair with a bitrate cap when the caller did not pick a
+    /// resolution tier of its own.
+    ///
+    /// A bitrate cap alone is only a ceiling — with no width condition the
+    /// server re-encodes at the source resolution, so a capped 4K stream is
+    /// re-encoded at full 4K: the most expensive possible way to reach the
+    /// ceiling, and a worse picture than the same bitrate at 1080p. Returns nil
+    /// above 25 Mbps, where 4K is plausible and nothing should be downscaled.
+    static func autoMaxWidth(forBitrateCap cap: Int) -> Int? {
+        switch cap {
+        case ..<6_000_000: return 854
+        case ..<12_000_000: return 1280
+        case ..<25_000_000: return 1920
+        default: return nil
+        }
+    }
+
+    /// Whether the server is reached over the local network. This is what
+    /// separates "the probe failed" from "the link is slow" without a
+    /// measurement: a LAN path is fast until proven otherwise.
+    ///
+    /// Matches loopback, RFC 1918 / link-local / unique-local addresses,
+    /// `.local` (mDNS) names, and single-label hostnames — none of which
+    /// resolve anywhere but the local network.
+    static func isLocalServer(_ url: URL?) -> Bool {
+        guard let host = url?.host?.lowercased(), !host.isEmpty else { return false }
+        if host.contains(":") { return isLocalIPv6(host) }
+        if host == "localhost" || host.hasSuffix(".local") { return true }
+        if let octets = ipv4Octets(host) { return isPrivateIPv4(octets) }
+        return !host.contains(".")
+    }
+
+    /// Loopback, fe80::/10 link-local, fc00::/7 unique-local.
+    private static func isLocalIPv6(_ host: String) -> Bool {
+        host == "::1" || host.hasPrefix("fe80:") || host.hasPrefix("fc") || host.hasPrefix("fd")
+    }
+
+    private static func ipv4Octets(_ host: String) -> [Int]? {
+        let parts = host.split(separator: ".", omittingEmptySubsequences: false)
+        guard parts.count == 4 else { return nil }
+        let octets = parts.compactMap { Int($0) }
+        guard octets.count == 4, octets.allSatisfy({ (0...255).contains($0) }) else { return nil }
+        return octets
+    }
+
+    private static func isPrivateIPv4(_ octets: [Int]) -> Bool {
+        switch (octets[0], octets[1]) {
+        case (127, _), (10, _), (192, 168), (169, 254): return true
+        case (172, 16...31): return true
+        default: return false
+        }
+    }
+
     /// Case-insensitive language comparison tolerant of ISO 639-1 vs 639-2
     /// codes: Jellyfin streams report three-letter codes ("eng"), while the
     /// settings picker and AVFoundation locales use two-letter codes ("en").

--- a/Shared/Services/SessionManager.swift
+++ b/Shared/Services/SessionManager.swift
@@ -168,8 +168,10 @@ final class SessionManager: ObservableObject {
         self.currentUser = UserDto(id: server.userId, name: server.username, serverID: nil, primaryImageTag: nil)
         self.isAuthenticated = true
         // Measure the connection in the background so the first play uses a
-        // bandwidth-appropriate Auto bitrate (no stall on remote links).
-        Task { await JellyfinClient.shared.measureBandwidth() }
+        // bandwidth-appropriate Auto bitrate (no stall on remote links). Runs
+        // on every activation — login, restore, server switch — and retries
+        // internally, so one failed probe no longer stands for the session.
+        await JellyfinClient.shared.startBandwidthMeasurement()
     }
 
     // MARK: - Add / switch / remove


### PR DESCRIPTION
Fixes #341

## The diagnosis held up

I traced the mechanism before changing anything, and the issue's analysis is correct:

- `getPlaybackInfo` uses `autoBitrateCap()` whenever `maxBitrate` is nil, which is exactly the Auto path (`QualityOption.auto.maxBitrate` is nil, and Settings `maxBitrate == 0` maps to nil via `PlaybackSelection.effectiveMaxBitrate`).
- `autoBitrateCap()` returned a flat `20_000_000` whenever `measuredBitrate` was nil, so a failed probe was indistinguishable from a genuinely slow link. `measuredBitrate` is in-memory only, reset on every `configure()`, and the sole probe was one best-effort `Task` fired from `SessionManager.activate` — one failure stood for the whole session.
- The cap is sent both top-level and inside the device profile, so the server cannot copy a video stream that exceeds it. A 24.9 Mbps source against a 20 Mbps cap must be re-encoded.
- The `maxWidth` half is real too: `CodecProfiles` was populated only when the caller passed a resolution tier. On Auto that is nil, so the forced re-encode ran at full 4K.

## Changes

**`PlaybackSelection`** (pure, unit-tested — the existing home for playback selection logic):

- `autoBitrateCap(measuredBitrate:isLocalServer:)` — splits "no measurement" by where the server is. A local server starts at 100 Mbps (the same ceiling a measured gigabit link clamps to); only a server reached over the internet keeps the cautious 20 Mbps. A measurement, when one exists, always wins — a measured 10 Mbps LAN link still caps at 8.5 Mbps.
- `isLocalServer(_:)` — RFC 1918 / loopback / link-local / unique-local / `.local` / single-label hostnames. Deliberately *not* CGNAT (100.64/10), because that is usually a Tailscale-style tunnel over a WAN.
- `autoMaxWidth(forBitrateCap:)` — width to pair with a cap when the caller picked no tier. Returns nil above 25 Mbps, so nothing on a healthy link is downscaled; the ladder below that (1920 / 1280 / 854) happens to line up exactly with the labels already in the Settings bitrate picker.

**`JellyfinClient`**:

- `startBandwidthMeasurement()` retries with backoff (immediate, +3s, +15s, +60s). `configure()` cancels any probe in flight so a server switch cannot land a stale measurement.
- `SessionManager.activate` calls it on every activation — login, session restore, server switch.
- `bandwidthStatus` exposes the cap and whether it was measured.
- `videoDeviceProfile(streamingBitrate:maxWidth:)` extracted from `getPlaybackInfo` (it had grown past the SwiftLint function-length limit); no behaviour change beyond using the derived width.
- Every Auto `PlaybackInfo` request logs the cap, its provenance, and the width.

**Settings** (tvOS): an "Auto Limit" row under Video Quality showing e.g. `100 Mbps (not measured)` or `94 Mbps measured`, visible only when Auto is in effect.

## What I deliberately did not do

I did not add tolerance for sources that *marginally* exceed the cap (issue suggestion 3). On a measured link the cap is evidence and exceeding it is what stalls playback; the defect was fabricating a cap from a failed probe, not honouring a real one. The width ladder covers the "maximally expensive resolution" half of the same complaint.

## Verified

- `swiftlint lint` clean (strict).
- `xcodebuild build` succeeds for both the tvOS (`Sashimi`) and iOS (`SashimiMobile`) schemes. No new warnings in any changed file.
- Full `SashimiTests` suite passes; 10 new cases in `PlaybackSelectionTests`.
- The new tests were run against the old value: reverting `unmeasuredLocalBitrateCap` to `20_000_000` makes `testUnmeasuredLocalServerGetsOptimisticCap` fail with `("20000000") is not greater than ("24879906")` — the exact production source from the issue. The test catches the reported bug rather than merely restating the new code.

## What I could not verify

- **Not run on an Apple TV or any real device.** Everything here is simulator build + unit tests.
- **No end-to-end playback check.** I did not confirm against a live Jellyfin server that a 24.9 Mbps 4K HEVC source now comes back with `IsVideoDirect: true`. That is the actual claim of the fix and it is unverified. The way to check it is the log line this PR adds, plus the server's session view.
- **The retry schedule is untested under real failure.** I did not simulate a probe failing and later succeeding; the backoff loop is only reasoned-about, not exercised.
- **`isLocalServer` heuristic on real deployments.** Reverse proxies, split-horizon DNS and VPN setups can put a LAN server behind a public hostname, in which case it is classified remote and keeps the 20 Mbps default — the old behaviour, so no regression, but also no improvement for those users.
- **The Settings row is tvOS only.** `MobileSettingsView` has its own bitrate picker and did not get the diagnostics row; the log line covers iOS.
- **Width-ladder side effects.** A user with an explicit low Settings cap will now get a downscaled stream where they previously got a source-resolution re-encode. I believe that is strictly better, but nobody has watched it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XzUNvRCXML3DJe98KBCGkN