### PR TITLE
feat(ux): larger sidebar/header logos, iOS YouTube library icon, dead overlay removal

### DIFF
--- a/Sashimi/App/SashimiApp.swift
+++ b/Sashimi/App/SashimiApp.swift
@@ -337,7 +337,7 @@ struct MainTabView: View {
                 Image("SidebarLogoMark")
                     .resizable()
                     .aspectRatio(contentMode: .fit)
-                    .frame(width: expanded ? 60 : 46, height: expanded ? 60 : 46)
+                    .frame(width: expanded ? 76 : 56, height: expanded ? 76 : 56)
                 if expanded {
                     Text("Sashimi")
                         .font(.system(size: 32, weight: .heavy, design: .rounded))
@@ -346,7 +346,7 @@ struct MainTabView: View {
                 }
             }
             .frame(maxWidth: .infinity, alignment: expanded ? .leading : .center)
-            .frame(height: 60)
+            .frame(height: 76)
 
             // Balanced spacers put the logo at the top, avatar at the foot,
             // and the nav group vertically centered between them.
@@ -370,8 +370,9 @@ struct MainTabView: View {
                 .padding(.top, 4)
         }
         .padding(.vertical, 50)
-        .padding(.leading, expanded ? 36 : 38)
-        .padding(.trailing, expanded ? 28 : 38)
+        // Collapsed h-padding 32 (was 38) so the 56pt mark fits the 120pt rail.
+        .padding(.leading, expanded ? 36 : 32)
+        .padding(.trailing, expanded ? 28 : 32)
         .frame(width: expanded ? panelWidth : railWidth, alignment: .leading)
         .frame(maxHeight: .infinity, alignment: .top)
         // Dim the rail's contents when resting (not engaged); full on focus.

--- a/Sashimi/Views/Components/StateViews.swift
+++ b/Sashimi/Views/Components/StateViews.swift
@@ -170,27 +170,6 @@ struct OfflineStateView: View {
     }
 }
 
-// MARK: - Branded Loading Overlay
-
-struct BrandedLoadingOverlay: View {
-    var body: some View {
-        ZStack {
-            SashimiTheme.overlay
-                .ignoresSafeArea()
-
-            VStack(spacing: Spacing.md) {
-                Image("SashimiLogo")
-                    .resizable()
-                    .scaledToFit()
-                    .frame(width: 120, height: 120)
-
-                ProgressView()
-                    .scaleEffect(1.2)
-            }
-        }
-    }
-}
-
 // MARK: - Progress Bar
 
 struct SashimiProgressBar: View {

--- a/SashimiMobile/Views/Navigation/SidebarView.swift
+++ b/SashimiMobile/Views/Navigation/SidebarView.swift
@@ -137,10 +137,10 @@ struct MainNavigationView: View {
                 Image("SidebarLogo")
                     .resizable()
                     .aspectRatio(contentMode: .fit)
-                    .frame(width: 40, height: 40)
-                    .clipShape(RoundedRectangle(cornerRadius: 10))
+                    .frame(width: 52, height: 52)
+                    .clipShape(RoundedRectangle(cornerRadius: 12))
                 Text("Sashimi")
-                    .font(.system(size: 22, weight: .bold))
+                    .font(.system(size: 24, weight: .bold))
                     .foregroundStyle(MobileColors.textPrimary)
             }
             .padding(.horizontal, MobileSpacing.md)

--- a/SashimiMobile/Views/Navigation/SidebarView.swift
+++ b/SashimiMobile/Views/Navigation/SidebarView.swift
@@ -25,7 +25,10 @@ enum SidebarSelection: Hashable {
         case .search: return "magnifyingglass"
         case .downloads: return "arrow.down.circle"
         case .settings: return "gearshape"
-        case .library(_, _, let collectionType):
+        case .library(_, let name, let collectionType):
+            // YouTube libraries report collectionType "tvshows"; match by name,
+            // same as the tvOS rail.
+            if name.lowercased().contains("youtube") { return "play.rectangle.fill" }
             switch collectionType {
             case "movies": return "film"
             case "tvshows": return "tv"

--- a/SashimiMobile/Views/Phone/PhoneHomeView.swift
+++ b/SashimiMobile/Views/Phone/PhoneHomeView.swift
@@ -47,10 +47,10 @@ struct PhoneHomeView: View {
                         Image("SidebarLogo")
                             .resizable()
                             .aspectRatio(contentMode: .fit)
-                            .frame(width: 32, height: 32)
-                            .clipShape(RoundedRectangle(cornerRadius: 7))
+                            .frame(width: 40, height: 40)
+                            .clipShape(RoundedRectangle(cornerRadius: 9))
                         Text("Sashimi")
-                            .font(.system(size: 18, weight: .bold))
+                            .font(.system(size: 20, weight: .bold))
                             .foregroundStyle(MobileColors.textPrimary)
                     }
                 }


### PR DESCRIPTION
Apple half of the approved UX mockup round (Roku half: bitstorm-labs/sashimi-roku#92).

Fixes #343

## Changes (mapped to the approved mockup)

| Mockup section | Change |
|---|---|
| tvOS rail — larger logo mark | `SidebarLogoMark` 46→56 collapsed / 60→76 expanded, header row height 60→76, collapsed rail h-padding 38→32 so the 56pt mark fits its 120pt rail box. |
| iPhone header — larger logo | Logo 32→40 (corner radius 7→9), "Sashimi" title 18→20pt. |
| iPad sidebar — larger logo | Logo 40→52 (corner radius 10→12), title 22→24pt. |
| iOS sidebar — YouTube icon | Library whose name contains "youtube" gets `play.rectangle.fill` (tinted like every other row), matching the tvOS rail's treatment. Previously fell through to the generic `tv` icon because Pinchflat YouTube libraries report `collectionType == "tvshows"`. |
| Dead code | `BrandedLoadingOverlay` removed — zero references and it rendered a `SashimiLogo` asset that does not exist in the catalog. |

## Verified

- `xcodebuild build` — Sashimi (tvOS Simulator) and SashimiMobile (iPhone 16 Simulator): both succeed.
- `xcodebuild test` — Sashimi scheme unit tests (SashimiTests) on tvOS Simulator.
- `swiftlint lint` clean.

## Not verified

- No device/simulator visual verification: the new logo sizes, rail padding, and the YouTube sidebar icon were not eyeballed on hardware or in a simulator screenshot — sizes come straight from the approved mockup.
- tvOS focus traversal around the resized header (can only be judged with a physical remote).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XzUNvRCXML3DJe98KBCGkN
