### PR TITLE
fix: never POST PlaybackInfo with a Series id; resolve container items to episodes first

### DIFF
--- a/Sashimi/Views/Detail/MediaDetailView.swift
+++ b/Sashimi/Views/Detail/MediaDetailView.swift
@@ -1174,7 +1174,14 @@ struct MediaDetailView: View {
         } else if isEpisode {
             await loadEpisodeContent()
         }
-        await loadMediaInfo()
+        // Series pages have no media sources of their own — PlaybackInfo for a
+        // series id is a guaranteed server 500 (InvalidCastException to
+        // IHasMediaSources). This call also lands at the END of the load chain
+        // above, so it raced the real episode PlaybackInfo whenever the user
+        // pressed Play quickly. The iOS detail views already have this gate.
+        if !isSeries {
+            await loadMediaInfo()
+        }
     }
 
     private func loadSeriesContent() async {
@@ -1261,7 +1268,7 @@ struct MediaDetailView: View {
 
     private func loadMediaInfo() async {
         do {
-            let playbackInfo = try await JellyfinClient.shared.getPlaybackInfo(itemId: item.id)
+            let playbackInfo = try await JellyfinClient.shared.getPlaybackInfo(itemId: item.id, itemType: item.type)
             mediaInfo = playbackInfo.mediaSources?.first
         } catch {
             // Silently ignore media info loading failures - not critical for playback

--- a/SashimiMobile/Downloads/Services/DownloadManager.swift
+++ b/SashimiMobile/Downloads/Services/DownloadManager.swift
@@ -558,7 +558,7 @@ final class DownloadManager: NSObject, ObservableObject {
     }
 
     private func downloadSubtitles(for item: BaseItemDto) async {
-        guard let playbackInfo = try? await JellyfinClient.shared.getPlaybackInfo(itemId: item.id, maxBitrate: nil) else {
+        guard let playbackInfo = try? await JellyfinClient.shared.getPlaybackInfo(itemId: item.id, itemType: item.type, maxBitrate: nil) else {
             return
         }
 

--- a/SashimiMobile/Downloads/Views/DownloadButton.swift
+++ b/SashimiMobile/Downloads/Views/DownloadButton.swift
@@ -196,7 +196,7 @@ struct DownloadButton: View {
         determiningOptions = true
         defer { determiningOptions = false }
         do {
-            let info = try await JellyfinClient.shared.getPlaybackInfo(itemId: item.id)
+            let info = try await JellyfinClient.shared.getPlaybackInfo(itemId: item.id, itemType: item.type)
             let compatible = info.mediaSources?.first
                 .map { DeviceMediaCompatibility.canDirectPlayOnDevice($0) } ?? false
             originalAllowed = compatible ? .yes : .no

--- a/SashimiMobile/Views/Detail/MobileDetailView.swift
+++ b/SashimiMobile/Views/Detail/MobileDetailView.swift
@@ -327,7 +327,7 @@ struct MobileDetailView: View {
             return
         }
         do {
-            let info = try await JellyfinClient.shared.getPlaybackInfo(itemId: first.id)
+            let info = try await JellyfinClient.shared.getPlaybackInfo(itemId: first.id, itemType: first.type)
             seasonOriginalAllowed = info.mediaSources?.first
                 .map { DeviceMediaCompatibility.canDirectPlayOnDevice($0) } ?? false
         } catch {
@@ -1066,7 +1066,7 @@ struct MobileDetailView: View {
 
     private func loadMediaInfo() async {
         do {
-            let playbackInfo = try await JellyfinClient.shared.getPlaybackInfo(itemId: item.id)
+            let playbackInfo = try await JellyfinClient.shared.getPlaybackInfo(itemId: item.id, itemType: item.type)
             mediaInfo = playbackInfo.mediaSources?.first
         } catch {
             // Not critical

--- a/SashimiMobile/Views/Phone/PhoneDetailView.swift
+++ b/SashimiMobile/Views/Phone/PhoneDetailView.swift
@@ -257,7 +257,7 @@ struct PhoneDetailView: View {
             return
         }
         do {
-            let info = try await JellyfinClient.shared.getPlaybackInfo(itemId: first.id)
+            let info = try await JellyfinClient.shared.getPlaybackInfo(itemId: first.id, itemType: first.type)
             seasonOriginalAllowed = info.mediaSources?.first
                 .map { DeviceMediaCompatibility.canDirectPlayOnDevice($0) } ?? false
         } catch {
@@ -1105,7 +1105,7 @@ struct PhoneDetailView: View {
 
     private func loadMediaInfo() async {
         do {
-            let playbackInfo = try await JellyfinClient.shared.getPlaybackInfo(itemId: item.id)
+            let playbackInfo = try await JellyfinClient.shared.getPlaybackInfo(itemId: item.id, itemType: item.type)
             mediaInfo = playbackInfo.mediaSources?.first
         } catch {
             // Not critical

--- a/SashimiTests/JellyfinClientTests.swift
+++ b/SashimiTests/JellyfinClientTests.swift
@@ -189,6 +189,57 @@ final class JellyfinClientTests: XCTestCase {
         XCTAssertEqual(JellyfinError.sessionExpired.errorDescription, "Session expired. Please sign in again.")
     }
 
+    // MARK: - PlaybackInfo Non-Playable Type Guard (#345)
+
+    /// PlaybackInfo POSTed with a Series id is a guaranteed Jellyfin 500
+    /// (InvalidCastException to IHasMediaSources — seen in production).
+    /// The client must refuse locally, before any network call.
+    func testGetPlaybackInfoRefusesContainerTypes() async {
+        let client = JellyfinClient.shared
+
+        for type in [ItemType.series, .season, .boxSet, .folder, .collectionFolder] {
+            do {
+                _ = try await client.getPlaybackInfo(itemId: "some-series-id", itemType: type)
+                XCTFail("getPlaybackInfo should refuse \(type.rawValue)")
+            } catch {
+                guard case JellyfinError.nonPlayableItem(let refused) = error else {
+                    XCTFail("Expected nonPlayableItem for \(type.rawValue), got \(error)")
+                    continue
+                }
+                XCTAssertEqual(refused, type)
+            }
+        }
+    }
+
+    /// Playable types must pass the guard: on an unauthenticated client the
+    /// next failure is notConfigured (no userId), proving the type guard did
+    /// not trip. `.unknown` stays playable — server types the enum doesn't
+    /// model (e.g. "Trailer") are individual videos.
+    func testGetPlaybackInfoAllowsPlayableTypes() async {
+        let client = JellyfinClient.shared
+        await client.configure(serverURL: URL(string: "http://localhost:8096")!)
+
+        for type in [ItemType.movie, .episode, .video, .unknown] {
+            do {
+                _ = try await client.getPlaybackInfo(itemId: "some-item-id", itemType: type)
+                XCTFail("Unauthenticated client should have thrown")
+            } catch {
+                if case JellyfinError.nonPlayableItem = error {
+                    XCTFail("Type guard must not trip for playable type \(type.rawValue)")
+                }
+            }
+        }
+    }
+
+    func testNonPlayableItemErrorDescription() {
+        // The refusal must surface as a user-actionable message, not a
+        // generic server error.
+        XCTAssertEqual(
+            JellyfinError.nonPlayableItem(.series).errorDescription,
+            "This series can't be played directly. Pick an episode to play."
+        )
+    }
+
     // MARK: - Media Segment Type Tests
 
     func testMediaSegmentTypeRawValues() {

--- a/SashimiTests/ModelTests.swift
+++ b/SashimiTests/ModelTests.swift
@@ -125,4 +125,20 @@ final class ModelTests: XCTestCase {
         XCTAssertEqual(ItemType.video.rawValue, "Video")
     }
 
+    /// Container types have no media sources -- POSTing them to PlaybackInfo
+    /// is a guaranteed server 500 (#345). `.unknown` must stay playable:
+    /// server types the enum doesn't model (e.g. "Trailer") are single videos.
+    func testItemTypePlayability() {
+        XCTAssertTrue(ItemType.movie.isPlayableMediaType)
+        XCTAssertTrue(ItemType.episode.isPlayableMediaType)
+        XCTAssertTrue(ItemType.video.isPlayableMediaType)
+        XCTAssertTrue(ItemType.unknown.isPlayableMediaType)
+
+        XCTAssertFalse(ItemType.series.isPlayableMediaType)
+        XCTAssertFalse(ItemType.season.isPlayableMediaType)
+        XCTAssertFalse(ItemType.boxSet.isPlayableMediaType)
+        XCTAssertFalse(ItemType.folder.isPlayableMediaType)
+        XCTAssertFalse(ItemType.collectionFolder.isPlayableMediaType)
+    }
+
 }

--- a/Shared/Models/JellyfinModels.swift
+++ b/Shared/Models/JellyfinModels.swift
@@ -177,6 +177,21 @@ enum ItemType: String, Codable {
         let rawValue = try container.decode(String.self)
         self = ItemType(rawValue: rawValue) ?? .unknown
     }
+
+    /// Whether an item of this type has media sources of its own and can be
+    /// posted to `/Items/{id}/PlaybackInfo`. Container types (Series, Season,
+    /// BoxSet, folders) make the server throw `InvalidCastException … to
+    /// 'IHasMediaSources'` (HTTP 500) — they must be resolved to an episode
+    /// or movie first. `.unknown` stays playable on purpose: server types this
+    /// enum doesn't model (e.g. "Trailer") are individual videos.
+    var isPlayableMediaType: Bool {
+        switch self {
+        case .series, .season, .boxSet, .folder, .collectionFolder:
+            return false
+        case .movie, .episode, .video, .unknown:
+            return true
+        }
+    }
 }
 
 struct UserItemDataDto: Codable {

--- a/Shared/Services/JellyfinClient.swift
+++ b/Shared/Services/JellyfinClient.swift
@@ -641,19 +641,27 @@ actor JellyfinClient {
         return response.items
     }
 
-    func getNextUp(limit: Int = 50) async throws -> [BaseItemDto] {
+    /// Next-up episodes. Pass `seriesId` to ask the server for the next
+    /// episode of one specific series (used to resolve a Series handed to a
+    /// play action into the episode that should actually play).
+    func getNextUp(seriesId: String? = nil, limit: Int = 50) async throws -> [BaseItemDto] {
         guard let userId else { throw JellyfinError.notConfigured }
+
+        var queryItems = [
+            URLQueryItem(name: "UserId", value: userId),
+            URLQueryItem(name: "Limit", value: "\(limit)"),
+            URLQueryItem(name: "Fields", value: "Overview,PrimaryImageAspectRatio,CommunityRating,OfficialRating,Genres,Taglines,UserData,ParentBackdropImageTags,Path,MediaStreams"),
+            URLQueryItem(name: "EnableImageTypes", value: "Primary,Backdrop,Thumb"),
+            URLQueryItem(name: "EnableRewatching", value: "false"),
+            URLQueryItem(name: "DisableFirstEpisode", value: "false")
+        ]
+        if let seriesId {
+            queryItems.append(URLQueryItem(name: "SeriesId", value: seriesId))
+        }
 
         let data = try await request(
             path: "/Shows/NextUp",
-            queryItems: [
-                URLQueryItem(name: "UserId", value: userId),
-                URLQueryItem(name: "Limit", value: "\(limit)"),
-                URLQueryItem(name: "Fields", value: "Overview,PrimaryImageAspectRatio,CommunityRating,OfficialRating,Genres,Taglines,UserData,ParentBackdropImageTags,Path,MediaStreams"),
-                URLQueryItem(name: "EnableImageTypes", value: "Primary,Backdrop,Thumb"),
-                URLQueryItem(name: "EnableRewatching", value: "false"),
-                URLQueryItem(name: "DisableFirstEpisode", value: "false")
-            ]
+            queryItems: queryItems
         )
 
         let response = try JSONDecoder().decode(ItemsResponse.self, from: data)
@@ -873,11 +881,22 @@ actor JellyfinClient {
 
     func getPlaybackInfo(
         itemId: String,
+        itemType: ItemType? = nil,
         maxBitrate: Int? = nil,
         maxWidth: Int? = nil,
         forceDirectPlay: Bool = false,
         forceTranscode: Bool = false
     ) async throws -> PlaybackInfoResponse {
+        // Defensive guard: PlaybackInfo for a container type (Series, Season,
+        // BoxSet, folder) is a guaranteed server 500 — Jellyfin throws
+        // InvalidCastException casting it to IHasMediaSources. Seen in
+        // production when a series id reached this call. Callers must resolve
+        // to an episode/movie first; refuse here so the mistake is loud and
+        // local instead of a cryptic server error mid-playback.
+        if let itemType, !itemType.isPlayableMediaType {
+            logger.error("Refusing PlaybackInfo POST for non-playable item type \(itemType.rawValue, privacy: .public) (item \(itemId, privacy: .public)) — resolve to an episode/movie first")
+            throw JellyfinError.nonPlayableItem(itemType)
+        }
         guard let userId else { throw JellyfinError.notConfigured }
 
         // Auto (no explicit cap) uses the measured connection bandwidth so we
@@ -1275,11 +1294,14 @@ enum JellyfinError: LocalizedError {
     case invalidCredentials
     case sessionExpired
     case networkError(Error)
+    case nonPlayableItem(ItemType)
 
     var errorDescription: String? {
         switch self {
         case .notConfigured:
             return "Not connected to a server. Please sign in."
+        case .nonPlayableItem(let type):
+            return "This \(type.rawValue.lowercased()) can't be played directly. Pick an episode to play."
         case .invalidResponse:
             return "The server returned an unexpected response. Try again."
         case .invalidURL:

--- a/Shared/ViewModels/PlayerViewModel.swift
+++ b/Shared/ViewModels/PlayerViewModel.swift
@@ -364,8 +364,15 @@ final class PlayerViewModel: ObservableObject {
                 // and no way to surface a decode failure.
                 makePlayerAndObservers(for: playerItem)
             } else {
-                // Online playback - fetch fresh data from server
-                freshItem = try await client.getItem(itemId: item.id)
+                // Online playback - fetch fresh data from server.
+                // Resolve container types (Series/Season) to the episode that
+                // should actually play BEFORE any PlaybackInfo request — a
+                // series id posted to PlaybackInfo is a guaranteed server 500
+                // (InvalidCastException to IHasMediaSources, seen in
+                // production). Entry points like the Continue Watching Play
+                // button and Top Shelf deep links hand over whatever item the
+                // row carried, so the guarantee lives here, not in each caller.
+                freshItem = try await resolvePlayableItem(client.getItem(itemId: item.id))
                 currentItem = freshItem
 
                 let audioSession = AVAudioSession.sharedInstance()
@@ -704,6 +711,45 @@ final class PlayerViewModel: ObservableObject {
         }
     }
 
+    /// Maps a container item (Series/Season) to the episode that should play:
+    /// server next-up first, then first unwatched episode, then first episode
+    /// (fully-watched series). Playable items pass through untouched. Throws
+    /// rather than letting a non-playable id reach PlaybackInfo, so the
+    /// failure is a visible "couldn't find an episode" instead of a silent
+    /// server 500 mid-startup.
+    func resolvePlayableItem(_ item: BaseItemDto) async throws -> BaseItemDto {
+        guard let type = item.type, !type.isPlayableMediaType else { return item }
+
+        if type == .series, let next = try? await client.getNextUp(seriesId: item.id, limit: 1).first {
+            return next
+        }
+
+        if type == .series || type == .season {
+            // For a series this searches all episodes (getItems is recursive);
+            // for a season, just that season's.
+            if let unwatched = try? await client.getItems(
+                parentId: item.id,
+                includeTypes: [.episode],
+                sortBy: "ParentIndexNumber,IndexNumber",
+                limit: 1,
+                isPlayed: false
+            ).items.first {
+                return unwatched
+            }
+            if let first = try? await client.getItems(
+                parentId: item.id,
+                includeTypes: [.episode],
+                sortBy: "ParentIndexNumber,IndexNumber",
+                limit: 1
+            ).items.first {
+                return first
+            }
+        }
+
+        logger.error("Could not resolve \(type.rawValue, privacy: .public) \(item.id, privacy: .public) to a playable episode")
+        throw PlayerError.noPlayableEpisode(item.name)
+    }
+
     /// Shared player setup: resolves stream URL, creates AVPlayer with observers.
     private func setupPlayer(for item: BaseItemDto, maxBitrate: Int? = nil, maxWidth: Int? = nil, forceTranscode: Bool = false) async throws {
         // Bitrate precedence: explicit override (quality menu change) →
@@ -715,6 +761,7 @@ final class PlayerViewModel: ObservableObject {
         )
         let playbackInfo = try await client.getPlaybackInfo(
             itemId: item.id,
+            itemType: item.type,
             maxBitrate: effectiveBitrate,
             maxWidth: maxWidth,
             forceDirectPlay: playbackSettings.forceDirectPlay,
@@ -735,8 +782,18 @@ final class PlayerViewModel: ObservableObject {
             resolvedURL = await client.buildURL(path: transcodingPath)
         } else if let directPath = mediaSource.directStreamUrl, !directPath.isEmpty {
             resolvedURL = await client.buildURL(path: directPath)
-        } else {
+        } else if mediaSource.supportsDirectPlay != false {
             resolvedURL = await client.getPlaybackURL(itemId: item.id, mediaSourceId: mediaSource.id, container: mediaSource.container)
+        } else {
+            // The server offered no transcode/remux URL AND says the source
+            // can't direct play (e.g. Force Direct Play against a container
+            // this device can't decode). The old behavior built a static
+            // stream URL anyway — a stream that bypasses the device profile,
+            // which is what forces fMP4 for HEVC — and handed AVPlayer a file
+            // it can't render: audio over a black screen instead of an error.
+            // Fail loudly instead.
+            logger.error("Media source \(mediaSource.id, privacy: .public) is not playable: no stream URLs and SupportsDirectPlay=false")
+            throw PlayerError.sourceNotPlayable
         }
 
         guard let resolvedURL else {
@@ -1410,6 +1467,8 @@ final class PlayerViewModel: ObservableObject {
 enum PlayerError: LocalizedError {
     case noMediaSource
     case noStreamURL
+    case noPlayableEpisode(String)
+    case sourceNotPlayable
 
     var errorDescription: String? {
         switch self {
@@ -1417,6 +1476,10 @@ enum PlayerError: LocalizedError {
             return "No playable media source found"
         case .noStreamURL:
             return "Could not generate stream URL"
+        case .noPlayableEpisode(let name):
+            return "Couldn't find an episode of \"\(name)\" to play"
+        case .sourceNotPlayable:
+            return "This video can't be played on this device with the current playback settings"
         }
     }
 }


### PR DESCRIPTION
Fixes #345

## Production evidence

Captured on the live server during a playback failure on Sashimi tvOS 1.2.0:

> `POST /Items/06203ee8f1db2b31e2d489dba73d3a38/PlaybackInfo` returned **500** with
> `InvalidCastException: Unable to cast 'MediaBrowser.Controller.Entities.TV.Series' to 'IHasMediaSources'`

The id posted was the **series** id for House of the Dragon, not an episode id. A second capture showed the same 500 firing at 18:55:58 **during a playback start that succeeded** — the bogus series-level call is issued concurrently with the correct episode call. The same session logged repeated "task was canceled" on `GET /videos/{id}/...`.

## Root cause

`MediaDetailView.loadMediaInfo()` (tvOS) posted PlaybackInfo for whatever item the detail page shows — including a **Series** page. The iOS detail views (`MobileDetailView`, `PhoneDetailView`) already gate this with `if !isSeries`; tvOS never got the gate. Because it runs at the **end** of the series page's load chain (`getItem` → `getSeasons` → NextUp → episodes), it lands seconds after the page opens — exactly when a quick Play press starts the real episode PlaybackInfo. The 500 was swallowed silently (`catch {}`), so the only trace was server-side.

Independently, no play entry point resolved a Series to an episode: `PlayerViewModel.loadMedia` posts PlaybackInfo for whatever `BaseItemDto` it is handed (Continue Watching Play button → `HomeView.playingItem`, Top Shelf deep link → `ContentView`, `PlayerView(item: selectedEpisode ?? item)`), so any Series that reaches the player reproduces the 500 in the playback path itself.

## Audio-only connection

The PlaybackInfo **500 itself does not degrade the stream** — in the player path it throws and surfaces the error view. But the stream-URL fallback in `setupPlayer` could silently degrade: when the server returned a media source with **no `transcodingUrl`/`directStreamUrl` and `SupportsDirectPlay == false`** (e.g. Force Direct Play against a container this device can't decode), the client still built a static `/Videos/{id}/stream.{container}` URL — a stream that **bypasses the device profile**, which is what forces fMP4 for HEVC. Handing AVPlayer HEVC in TS/MKV that way produces exactly audio-over-black plus repeated aborted range requests ("task was canceled"). That path now fails loudly with a user-visible error instead.

## Changes

- **tvOS `MediaDetailView`**: `loadMediaInfo()` gated on `!isSeries` (parity with iOS) — removes the deterministic series-id 500 on every series page visit
- **`PlayerViewModel.loadMedia`**: resolves Series/Season → server NextUp (new `SeriesId` param on `getNextUp`) → first unwatched episode → first episode, **before** any PlaybackInfo request; unresolvable containers throw `PlayerError.noPlayableEpisode` (visible error view, not a silent 500)
- **`JellyfinClient.getPlaybackInfo`**: defensive guard — refuses non-playable container types (`ItemType.isPlayableMediaType`, `JellyfinError.nonPlayableItem`) with an os_log error, before any network I/O; all call sites now pass the item type
- **`setupPlayer`**: no longer constructs the profile-bypassing static stream URL when `SupportsDirectPlay == false`; throws `PlayerError.sourceNotPlayable`

## Tests

- `testGetPlaybackInfoRefusesContainerTypes` — Series/Season/BoxSet/Folder/CollectionFolder all throw `nonPlayableItem` locally
- `testGetPlaybackInfoAllowsPlayableTypes` — Movie/Episode/Video/`.unknown` (covers server types like "Trailer") pass the guard
- `testNonPlayableItemErrorDescription`, `testItemTypePlayability`

## Verified

- SwiftLint clean; tvOS build (`sashimi-verify`) and iOS build (`iPhone 17`) succeed; full `SashimiTests` suite passes on tvOS simulator (** TEST SUCCEEDED **)
- New tests cannot pass against the old code (they pin new API surface that did not exist)

## Not verified (hardware)

- Actual playback behavior on a device — Continue Watching Play, Top Shelf play action, series-page Play, and the Force-Direct-Play failure path all need a real Apple TV to exercise end to end
- That the audio-only symptom disappears in the user's environment (the static-URL gate closes the one profile-bypassing path the code contains, but the production audio-only occurrence was not reproduced locally)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XzUNvRCXML3DJe98KBCGkN