### PR TITLE
feat(player): structured PII-safe playback diagnostics, and one resume seek instead of two

### DIFF
--- a/Sashimi/Views/Player/PlayerView.swift
+++ b/Sashimi/Views/Player/PlayerView.swift
@@ -8,6 +8,15 @@ struct PlayerView: View {
     @StateObject private var viewModel = PlayerViewModel()
     @Environment(\.dismiss) private var dismiss
 
+    /// Distinguishes THIS presentation of the player in the log.
+    ///
+    /// SwiftUI recreating this view (a `fullScreenCover` whose binding changes,
+    /// a parent whose identity moves) produces a second `@StateObject` and a
+    /// second `.task`, and therefore a second server play session — which from
+    /// the server's side is indistinguishable from one session restarting.
+    /// A view tag plus the view model's own tag separates the two cases.
+    @State private var viewTag = String(UUID().uuidString.prefix(8))
+
     var body: some View {
         ZStack {
             Color.black.ignoresSafeArea()
@@ -21,15 +30,56 @@ struct PlayerView: View {
                     player: player,
                     viewModel: viewModel,
                     item: item,
-                    onDismiss: { Task { await viewModel.stop(); dismiss() } }
+                    onDismiss: {
+                        PlayerDiagnostics.event(.viewDismiss, [
+                            PlayerDiagnostics.field("view", viewTag),
+                            PlayerDiagnostics.field("trigger", "menu-button")
+                        ])
+                        Task { await viewModel.stop(reason: .userStop); dismiss() }
+                    }
                 )
                 .ignoresSafeArea()
                 .onAppear { viewModel.loadSubtitleTracks() }
             }
         }
-        .task { await viewModel.loadMedia(item: item, startFromBeginning: startFromBeginning) }
-        .onDisappear { Task { await viewModel.stop() } }
-        .onChange(of: viewModel.playbackEnded) { _, ended in if ended { dismiss() } }
+        .task {
+            // One `view.task` line per presentation. Two lines with different
+            // `view` tags for the same item means SwiftUI rebuilt the player;
+            // two `load.begin` lines under the same `vm` tag means one view
+            // model was asked to load twice. Those need different fixes, and
+            // the server cannot tell them apart.
+            PlayerDiagnostics.event(.viewTask, [
+                PlayerDiagnostics.field("view", viewTag),
+                PlayerDiagnostics.field("item", item.id),
+                PlayerDiagnostics.field("type", item.type?.rawValue),
+                PlayerDiagnostics.field("startFromBeginning", startFromBeginning)
+            ])
+            await viewModel.loadMedia(item: item, startFromBeginning: startFromBeginning)
+        }
+        .onDisappear {
+            PlayerDiagnostics.event(.viewDisappear, [
+                PlayerDiagnostics.field("view", viewTag),
+                PlayerDiagnostics.field("item", item.id)
+            ])
+            Task { await viewModel.stop(reason: .viewDisappeared) }
+        }
+        .onChange(of: viewModel.playbackEnded) { _, ended in
+            if ended {
+                PlayerDiagnostics.event(.viewDismiss, [
+                    PlayerDiagnostics.field("view", viewTag),
+                    PlayerDiagnostics.field("trigger", "playback-ended")
+                ])
+                dismiss()
+            }
+        }
+        .onChange(of: viewModel.errorMessage) { _, message in
+            guard let message else { return }
+            PlayerDiagnostics.failure(.viewError, [
+                PlayerDiagnostics.field("view", viewTag),
+                PlayerDiagnostics.field("item", item.id),
+                PlayerDiagnostics.field("message", message)
+            ])
+        }
     }
 
     private var errorView: some View {
@@ -37,7 +87,13 @@ struct PlayerView: View {
             Image(systemName: "exclamationmark.triangle").font(.system(size: 60)).foregroundStyle(.red)
             Text("Playback Error").font(.title2)
             Text(viewModel.errorMessage ?? "Unknown error").foregroundStyle(.secondary)
-            Button("Dismiss") { Task { await viewModel.stop(); dismiss() } }
+            Button("Dismiss") {
+                PlayerDiagnostics.event(.viewDismiss, [
+                    PlayerDiagnostics.field("view", viewTag),
+                    PlayerDiagnostics.field("trigger", "error-dismiss")
+                ])
+                Task { await viewModel.stop(reason: .userStop); dismiss() }
+            }
         }
     }
 }

--- a/SashimiMobile/Views/Player/MobilePlayerView.swift
+++ b/SashimiMobile/Views/Player/MobilePlayerView.swift
@@ -79,13 +79,15 @@ struct MobilePlayerView: View {
                     localFileURL: localFileURL,
                     offlineSubtitles: DownloadManager.shared.offlineSubtitles(for: item.id)
                 )
-                // For offline content, apply locally-saved position if newer than server data
+                // For offline content, apply locally-saved position if newer than server data.
+                // Goes through the view model rather than seeking directly: the
+                // resume position is applied when the item reports .readyToPlay,
+                // so a seek issued here would be overwritten a moment later.
                 if let offlineTicks = DownloadManager.shared.offlinePlaybackPosition(for: item.id),
                    offlineTicks > 0 {
                     let serverTicks = item.userData?.playbackPositionTicks ?? 0
                     if offlineTicks > serverTicks {
-                        let seekTime = CMTime(value: offlineTicks / 10000, timescale: 1000)
-                        await viewModel.player?.seek(to: seekTime)
+                        viewModel.overrideResumePosition(ticks: offlineTicks)
                     }
                 }
             }
@@ -99,7 +101,7 @@ struct MobilePlayerView: View {
             viewModel.player?.pause()
             saveOfflinePositionIfNeeded()
             Task {
-                await viewModel.stop()
+                await viewModel.stop(reason: .viewDisappeared)
                 NotificationCenter.default.post(name: .playbackDidStop, object: nil)
             }
         }
@@ -175,7 +177,7 @@ struct MobilePlayerView: View {
                 // where the offline save lives. The position was silently lost
                 // every time the X was used.
                 saveOfflinePositionIfNeeded()
-                Task { await viewModel.stop() }
+                Task { await viewModel.stop(reason: .userStop) }
                 dismiss()
             } label: {
                 Image(systemName: "xmark")
@@ -329,7 +331,7 @@ struct MobilePlayerView: View {
                 // where the offline save lives. The position was silently lost
                 // every time the X was used.
                 saveOfflinePositionIfNeeded()
-                Task { await viewModel.stop() }
+                Task { await viewModel.stop(reason: .userStop) }
                 dismiss()
             } label: {
                 Image(systemName: "xmark")

--- a/SashimiTests/PlayerDiagnosticsTests.swift
+++ b/SashimiTests/PlayerDiagnosticsTests.swift
@@ -1,0 +1,263 @@
+import AVFoundation
+import XCTest
+@testable import Sashimi
+
+/// The load-bearing claim of the player diagnostics is that they are safe to
+/// leave enabled in a release build: the stream URL carries `api_key`, so a
+/// single unredacted URL in the log is a leaked credential. These tests pin
+/// that claim down.
+final class PlayerDiagnosticsTests: XCTestCase {
+
+    // MARK: - scrub
+
+    func testScrubRemovesFullURLs() {
+        let text = "Failed to open https://jelly.example.com/videos/abc/master.m3u8?api_key=SECRET123&DeviceId=x"
+        let scrubbed = PlayerDiagnostics.scrub(text)
+
+        XCTAssertFalse(scrubbed.contains("SECRET123"), "api_key must never survive scrubbing")
+        XCTAssertFalse(scrubbed.contains("https://"), "URLs must be replaced wholesale")
+        XCTAssertFalse(scrubbed.contains("jelly.example.com"), "host must not leak")
+        XCTAssertTrue(scrubbed.contains("<url-redacted>"))
+        XCTAssertTrue(scrubbed.hasPrefix("Failed to open"), "non-URL text must be preserved")
+    }
+
+    func testScrubRemovesBareSecretParameters() {
+        // A description that names the parameter without a full URL around it.
+        let scrubbed = PlayerDiagnostics.scrub("request failed api_key=abc123 status=401")
+
+        XCTAssertFalse(scrubbed.contains("abc123"))
+        XCTAssertTrue(scrubbed.contains("<secret-redacted>"))
+        XCTAssertTrue(scrubbed.contains("status=401"), "unrelated fields must survive")
+    }
+
+    func testScrubRemovesTokenVariants() {
+        for parameter in ["api_key", "ApiKey", "X-Emby-Token", "token", "access_token", "accessToken", "password"] {
+            let scrubbed = PlayerDiagnostics.scrub("\(parameter)=topsecret")
+            XCTAssertFalse(scrubbed.contains("topsecret"), "\(parameter) was not redacted")
+        }
+    }
+
+    func testScrubHandlesNonASCIIAndKeepsOneLine() {
+        let scrubbed = PlayerDiagnostics.scrub("línea uno\nlínea dos\r\ntres")
+
+        XCTAssertFalse(scrubbed.contains("\n"), "a diagnostic event must stay on one log line")
+        XCTAssertFalse(scrubbed.contains("\r"))
+        XCTAssertTrue(scrubbed.contains("línea uno"))
+        XCTAssertTrue(scrubbed.contains("tres"))
+    }
+
+    func testScrubLeavesOrdinaryTextAlone() {
+        let text = "The operation couldn't be completed. (CoreMediaErrorDomain error -12939.)"
+        XCTAssertEqual(PlayerDiagnostics.scrub(text), text)
+    }
+
+    // MARK: - describe(url:)
+
+    func testDescribeURLKeepsPathAndDropsQuery() {
+        let url = URL(string: "https://jelly.example.com/videos/abc123/master.m3u8?api_key=SECRET&MediaSourceId=zzz")
+        let described = PlayerDiagnostics.describe(url: url)
+
+        XCTAssertFalse(described.contains("SECRET"), "the query string must never be logged")
+        XCTAssertFalse(described.contains("api_key"))
+        XCTAssertFalse(described.contains("jelly.example.com"))
+        XCTAssertTrue(described.contains("path=/videos/abc123/master.m3u8"))
+        XCTAssertTrue(described.contains("ext=m3u8"), "the container is the whole point of this field")
+        XCTAssertTrue(described.contains("queryparams=2"), "count is enough to spot a malformed URL")
+    }
+
+    func testDescribeURLReportsMatroskaContainer() {
+        // AVPlayer has no Matroska demuxer; a direct-stream URL that ends .mkv
+        // is a stream it cannot render, and the log has to make that visible.
+        let url = URL(string: "https://host/Videos/abc/stream.mkv?api_key=SECRET&Static=true")
+        let described = PlayerDiagnostics.describe(url: url)
+
+        XCTAssertTrue(described.contains("ext=mkv"))
+        XCTAssertFalse(described.contains("SECRET"))
+    }
+
+    func testDescribeNilURL() {
+        XCTAssertEqual(PlayerDiagnostics.describe(url: nil), "path=nil")
+    }
+
+    func testDescribeStreamPathDropsQuery() {
+        let described = PlayerDiagnostics.describe(
+            streamPath: "/videos/abc/master.m3u8?api_key=SECRET&PlaySessionId=1"
+        )
+
+        XCTAssertFalse(described.contains("SECRET"))
+        XCTAssertTrue(described.contains("path=/videos/abc/master.m3u8"))
+        XCTAssertTrue(described.contains("ext=m3u8"))
+    }
+
+    func testDescribeStreamPathWithoutExtension() {
+        let described = PlayerDiagnostics.describe(streamPath: "/videos/abc/stream")
+        XCTAssertTrue(described.contains("ext=none"))
+    }
+
+    // MARK: - field rendering
+
+    func testFieldScrubsStringValues() {
+        let rendered = PlayerDiagnostics.field("errorDescription", "cannot open https://host/x?api_key=SECRET")
+        XCTAssertFalse(rendered.contains("SECRET"))
+        XCTAssertTrue(rendered.hasPrefix("errorDescription="))
+    }
+
+    func testFieldRendersNilsExplicitly() {
+        // "absent" and "false"/"0" are different diagnostic facts, so nil is
+        // never rendered as a default value.
+        XCTAssertEqual(PlayerDiagnostics.field("a", nil as String?), "a=nil")
+        XCTAssertEqual(PlayerDiagnostics.field("b", nil as Int?), "b=nil")
+        XCTAssertEqual(PlayerDiagnostics.field("c", nil as Bool?), "c=nil")
+        XCTAssertEqual(PlayerDiagnostics.field("d", nil as Double?), "d=nil")
+        XCTAssertEqual(PlayerDiagnostics.field("e", "" as String?), "e=nil")
+    }
+
+    func testFieldRendersValues() {
+        XCTAssertEqual(PlayerDiagnostics.field("bitrate", 8_000_000), "bitrate=8000000")
+        XCTAssertEqual(PlayerDiagnostics.field("direct", true), "direct=true")
+        XCTAssertEqual(PlayerDiagnostics.field("direct", false), "direct=false")
+        XCTAssertEqual(PlayerDiagnostics.field("pos", 12.3456), "pos=12.35")
+    }
+
+    func testFieldRendersNonFiniteDoublesAsNil() {
+        // CMTime.seconds is NaN for an indefinite duration, which is routine
+        // for a live/transcoding HLS item — it must not print as "nan".
+        XCTAssertEqual(PlayerDiagnostics.field("dur", Double.nan), "dur=nil")
+        XCTAssertEqual(PlayerDiagnostics.field("dur", Double.infinity), "dur=nil")
+    }
+
+    // MARK: - status naming
+
+    func testStatusNames() {
+        XCTAssertEqual(PlayerDiagnostics.name(itemStatus: .unknown), "unknown")
+        XCTAssertEqual(PlayerDiagnostics.name(itemStatus: .readyToPlay), "readyToPlay")
+        XCTAssertEqual(PlayerDiagnostics.name(itemStatus: .failed), "failed")
+        XCTAssertEqual(PlayerDiagnostics.name(playerStatus: .failed), "failed")
+        XCTAssertEqual(PlayerDiagnostics.name(timeControlStatus: .paused), "paused")
+        XCTAssertEqual(PlayerDiagnostics.name(timeControlStatus: .waitingToPlayAtSpecifiedRate), "waiting")
+        XCTAssertEqual(PlayerDiagnostics.name(timeControlStatus: .playing), "playing")
+    }
+
+    // MARK: - error fields
+
+    func testErrorFieldsCarryDomainAndCode() {
+        let underlying = NSError(domain: "CoreMediaErrorDomain", code: -12939)
+        let error = NSError(
+            domain: NSURLErrorDomain,
+            code: -1001,
+            userInfo: [
+                NSLocalizedDescriptionKey: "timed out loading https://host/master.m3u8?api_key=SECRET",
+                NSUnderlyingErrorKey: underlying
+            ]
+        )
+        let joined = PlayerDiagnostics.fields(for: error).joined(separator: " ")
+
+        XCTAssertTrue(joined.contains("errorDomain=NSURLErrorDomain"))
+        XCTAssertTrue(joined.contains("errorCode=-1001"))
+        XCTAssertTrue(joined.contains("underlyingDomain=CoreMediaErrorDomain"))
+        XCTAssertTrue(joined.contains("underlyingCode=-12939"))
+        XCTAssertFalse(joined.contains("SECRET"), "the description must be scrubbed")
+    }
+
+    func testErrorFieldsForNil() {
+        XCTAssertEqual(PlayerDiagnostics.fields(for: nil), ["error=none"])
+    }
+
+    // MARK: - track summary
+
+    func testTrackSummaryFieldsNameTheAudioOnlyCase() {
+        let summary = PlayerDiagnostics.TrackSummary(
+            videoCount: 1,
+            audioCount: 1,
+            enabledVideoCount: 0,
+            enabledAudioCount: 1,
+            presentationWidth: 0,
+            presentationHeight: 0
+        )
+        let joined = summary.fields.joined(separator: " ")
+
+        XCTAssertTrue(joined.contains("audioOnly=true"), "zero enabled video tracks IS the audio-only failure")
+        XCTAssertTrue(joined.contains("videoEnabled=0"))
+        XCTAssertTrue(joined.contains("presentation=0x0"))
+    }
+
+    func testTrackSummaryHealthyPlayback() {
+        let summary = PlayerDiagnostics.TrackSummary(
+            videoCount: 1,
+            audioCount: 2,
+            enabledVideoCount: 1,
+            enabledAudioCount: 1,
+            presentationWidth: 3840,
+            presentationHeight: 2160
+        )
+        let joined = summary.fields.joined(separator: " ")
+
+        XCTAssertTrue(joined.contains("audioOnly=false"))
+        XCTAssertTrue(joined.contains("presentation=3840x2160"))
+    }
+
+    // MARK: - vocabulary stability
+
+    func testStageAndReasonRawValuesAreGreppable() {
+        // These strings are what a support capture is filtered on, so they are
+        // API: renaming one silently breaks every saved grep.
+        XCTAssertEqual(PlayerDiagnostics.prefix, "SASHIMI-PLAYER")
+        XCTAssertEqual(PlayerDiagnostics.category, "player")
+        XCTAssertEqual(PlayerDiagnostics.Stage.playbackInfoResponse.rawValue, "pbinfo.response")
+        XCTAssertEqual(PlayerDiagnostics.Stage.streamSelected.rawValue, "stream.selected")
+        XCTAssertEqual(PlayerDiagnostics.Stage.encodingStop.rawValue, "encoding.stop")
+        XCTAssertEqual(PlayerDiagnostics.Stage.accessLog.rawValue, "avlog.access")
+        XCTAssertEqual(PlayerDiagnostics.Stage.errorLog.rawValue, "avlog.error")
+        XCTAssertEqual(PlayerDiagnostics.TeardownReason.newItem.rawValue, "new-item")
+        XCTAssertEqual(PlayerDiagnostics.StreamKind.transcodeHLS.rawValue, "transcode-hls")
+    }
+
+    // MARK: - emit
+
+    func testEmittingEventsDoesNotTrapAndRedactsFields() {
+        // Exercises the real os_log path. There is no public API to read back
+        // the unified log from a test, so the assertion here is only that the
+        // emit path runs; that the lines actually appear at default level was
+        // verified out-of-band with:
+        //   log show --predicate 'subsystem == "com.mondominator.sashimi"
+        //                         AND category == "player"'
+        PlayerDiagnostics.event(.loadBegin, [
+            PlayerDiagnostics.field("item", "abc"),
+            PlayerDiagnostics.field("url", "https://host/x?api_key=SECRET")
+        ])
+        PlayerDiagnostics.failure(.loadFailed, PlayerDiagnostics.fields(for: NSError(domain: "d", code: 1)))
+        PlayerDiagnostics.detail(.accessLog, [PlayerDiagnostics.field("observedBitrate", 1.0)])
+        PlayerDiagnostics.event(.teardown)
+    }
+
+    // MARK: - model decoding
+
+    func testMediaSourceDecodesTranscodeReasons() {
+        // Newly decoded so the diagnostics can state WHY the server transcoded
+        // instead of leaving it to be reconstructed from server logs.
+        let json = """
+        {
+          "Id": "src1",
+          "Container": "mkv",
+          "SupportsDirectPlay": false,
+          "SupportsDirectStream": true,
+          "TranscodeReasons": ["ContainerNotSupported", "AudioCodecNotSupported"]
+        }
+        """.data(using: .utf8)!
+
+        let source = try? JSONDecoder().decode(MediaSourceInfo.self, from: json)
+
+        XCTAssertEqual(source?.transcodeReasons, ["ContainerNotSupported", "AudioCodecNotSupported"])
+    }
+
+    func testMediaSourceWithoutTranscodeReasonsStillDecodes() {
+        let json = """
+        { "Id": "src1", "Container": "mp4" }
+        """.data(using: .utf8)!
+
+        let source = try? JSONDecoder().decode(MediaSourceInfo.self, from: json)
+
+        XCTAssertEqual(source?.id, "src1")
+        XCTAssertNil(source?.transcodeReasons)
+    }
+}

--- a/Shared/Models/JellyfinModels.swift
+++ b/Shared/Models/JellyfinModels.swift
@@ -243,6 +243,11 @@ struct MediaSourceInfo: Codable {
     let directStreamUrl: String?
     let mediaStreams: [MediaStream]?
     let bitrate: Int?
+    /// Why the server decided this source cannot be played as-is
+    /// (e.g. "ContainerNotSupported", "ContainerBitrateExceedsLimit").
+    /// Decoded purely so the player's diagnostics can record it: without it,
+    /// an unexplained transcode had to be reconstructed from server logs.
+    let transcodeReasons: [String]?
 
     var videoCodec: String? {
         mediaStreams?.first(where: { $0.type == "Video" })?.codec
@@ -305,6 +310,7 @@ struct MediaSourceInfo: Codable {
         case directStreamUrl = "DirectStreamUrl"
         case mediaStreams = "MediaStreams"
         case bitrate = "Bitrate"
+        case transcodeReasons = "TranscodeReasons"
     }
 }
 

--- a/Shared/Services/JellyfinClient.swift
+++ b/Shared/Services/JellyfinClient.swift
@@ -809,6 +809,19 @@ actor JellyfinClient {
         return response.items.first
     }
 
+    /// Whether the HLS TranscodingProfile lets the server cut segments on
+    /// non-key frames.
+    ///
+    /// Named rather than inlined below because it is a real behavioural lever
+    /// and the player's diagnostics record it with every negotiation: when the
+    /// server STREAM-COPIES the video (`IsVideoDirect`) it cannot insert key
+    /// frames, so with this enabled a segment can begin mid-GOP — which is the
+    /// leading hypothesis for seeking failing on stream-copied 4K while a real
+    /// re-encode (an explicit quality tier) seeks fine. Changing it is a
+    /// server-behaviour experiment, so it is deliberately left as-is here and
+    /// only made observable.
+    nonisolated static let transcodingProfileBreaksOnNonKeyFrames = true
+
     /// The device profile sent with every PlaybackInfo request: what this
     /// client can play natively, and the ceilings the server must respect.
     private func videoDeviceProfile(streamingBitrate: Int, maxWidth: Int?) -> [String: Any] {
@@ -839,7 +852,7 @@ actor JellyfinClient {
                     "Context": "Streaming",
                     "MaxAudioChannels": "6",
                     "MinSegments": "2",
-                    "BreakOnNonKeyFrames": true
+                    "BreakOnNonKeyFrames": Self.transcodingProfileBreaksOnNonKeyFrames
                 ]
             ],
             "ContainerProfiles": [],

--- a/Shared/Services/PlayerDiagnostics.swift
+++ b/Shared/Services/PlayerDiagnostics.swift
@@ -1,0 +1,374 @@
+import AVFoundation
+import Foundation
+import os
+
+/// Structured, PII-safe logging for the whole playback lifecycle.
+///
+/// Why this exists: until now the tvOS player logged almost nothing, so a
+/// failed play could only be reconstructed from the Jellyfin server's ffmpeg
+/// logs — which show the server obeying the client ("Stopping ffmpeg process
+/// with q command" means the CLIENT abandoned that transcode) without ever
+/// saying which client code path did it or why. Everything here exists to make
+/// that answerable from the device alone.
+///
+/// Reading the logs on a real device (works for Release builds too):
+///
+///     log stream --predicate 'subsystem == "com.mondominator.sashimi" AND category == "player"' --style compact
+///     log show --last 30m --predicate 'subsystem == "com.mondominator.sashimi" AND category == "player"'
+///
+/// or filter Console.app on the `SASHIMI-PLAYER` prefix.
+///
+/// **Level policy.** Lifecycle events use `.notice` (os_log default level), so
+/// they are captured without enabling anything and survive into the persisted
+/// store — `log show` after the fact finds them. Failures use `.error`. Only
+/// the high-volume AVPlayerItem access-log sampling uses `.debug`, which is
+/// NOT persisted; to see those, stream live with `--level debug`:
+///
+///     log stream --level debug --predicate 'subsystem == "com.mondominator.sashimi" AND category == "player"'
+///
+/// **Privacy policy.** Every value logged here is `privacy: .public`, which
+/// makes it the caller's job never to hand this type a secret. Stream URLs
+/// carry `api_key` in the query string, so a URL is NEVER logged: use
+/// `describe(url:)`, which keeps the path and drops the query entirely. Free
+/// text that came from the system (error descriptions) goes through `scrub`,
+/// which strips anything URL-shaped. Item ids, media source ids and play
+/// session ids ARE logged — they are server-side identifiers, not user data,
+/// and they are the only way to line a device log up against a server log.
+enum PlayerDiagnostics {
+    static let subsystem = "com.mondominator.sashimi"
+    static let category = "player"
+
+    /// Grep handle. Every line this type emits starts with it.
+    static let prefix = "SASHIMI-PLAYER"
+
+    private static let logger = Logger(subsystem: subsystem, category: category)
+
+    // MARK: - Emit
+
+    /// A key lifecycle event. Default os_log level: present in release builds
+    /// without any extra configuration.
+    static func event(_ stage: Stage, _ fields: [String] = []) {
+        logger.notice("\(prefix, privacy: .public) \(stage.rawValue, privacy: .public) \(join(fields), privacy: .public)")
+    }
+
+    /// A failure. Same shape as `event`, logged at error level.
+    static func failure(_ stage: Stage, _ fields: [String] = []) {
+        logger.error("\(prefix, privacy: .public) \(stage.rawValue, privacy: .public) \(join(fields), privacy: .public)")
+    }
+
+    /// High-volume detail (AVPlayerItem access-log sampling). Debug level, so
+    /// it costs nothing unless someone is actively streaming the log.
+    static func detail(_ stage: Stage, _ fields: [String] = []) {
+        logger.debug("\(prefix, privacy: .public) \(stage.rawValue, privacy: .public) \(join(fields), privacy: .public)")
+    }
+
+    private static func join(_ fields: [String]) -> String {
+        fields.filter { !$0.isEmpty }.joined(separator: " ")
+    }
+
+    // MARK: - Stages
+
+    /// The lifecycle stage a line belongs to. Kept as a closed enum so the
+    /// vocabulary stays greppable — `SASHIMI-PLAYER pbinfo.response` finds
+    /// every negotiation, across every build.
+    enum Stage: String {
+        // View lifecycle (who asked for a player, and who took it away)
+        case viewTask = "view.task"
+        case viewDisappear = "view.disappear"
+        case viewDismiss = "view.dismiss"
+        case viewError = "view.error"
+
+        // Load lifecycle
+        case loadBegin = "load.begin"
+        case loadResolved = "load.resolved"
+        case loadReady = "load.ready"
+        case loadFailed = "load.failed"
+
+        // Server negotiation
+        case playbackInfoRequest = "pbinfo.request"
+        case playbackInfoResponse = "pbinfo.response"
+        case streamSelected = "stream.selected"
+
+        // AVFoundation
+        case assetCreated = "asset.created"
+        case playerCreated = "player.created"
+        case itemStatus = "item.status"
+        case playerStatus = "player.status"
+        case tracks = "tracks"
+        case errorLog = "avlog.error"
+        case accessLog = "avlog.access"
+        case timeControl = "timecontrol"
+
+        // Playback control
+        case play = "play"
+        case seek = "seek"
+        case qualityChange = "quality.change"
+        case playbackEnded = "playback.ended"
+        case nextEpisode = "next.episode"
+
+        // Teardown
+        case teardown = "teardown"
+        case encodingStop = "encoding.stop"
+        case deinitialized = "deinit"
+    }
+
+    /// Why a player was torn down. The production restart loop looks identical
+    /// from the server side whichever of these fired, so the reason has to come
+    /// from the client.
+    enum TeardownReason: String {
+        /// Viewer pressed Menu / Done, or tapped the close button.
+        case userStop = "user-stop"
+        /// The SwiftUI view left the hierarchy.
+        case viewDisappeared = "view-disappeared"
+        /// A new item is being loaded into this same view model (auto-play
+        /// next, or a replay).
+        case newItem = "new-item"
+        /// The quality menu rebuilt the player against a new media source.
+        case qualityChange = "quality-change"
+        /// Playback reached the end of the item.
+        case playbackEnded = "playback-ended"
+        /// The view model was deallocated.
+        case deallocated = "deallocated"
+        /// Caller did not say. Should not appear; if it does, a call site is
+        /// missing a reason.
+        case unspecified = "unspecified"
+    }
+
+    /// Which URL the client actually asked AVPlayer to fetch. The production
+    /// evidence showed one attempt against an HLS transcode and a second
+    /// against a Matroska remux seconds later — indistinguishable in the app
+    /// today, obvious with this field.
+    enum StreamKind: String {
+        case transcodeHLS = "transcode-hls"
+        case directStream = "direct-stream"
+        case directPlayStatic = "direct-play-static"
+        case localFile = "local-file"
+    }
+
+    // MARK: - Field builders
+
+    static func field(_ name: String, _ value: String?) -> String {
+        guard let value, !value.isEmpty else { return "\(name)=nil" }
+        return "\(name)=\(scrub(value))"
+    }
+
+    static func field(_ name: String, _ value: Int?) -> String {
+        "\(name)=\(value.map(String.init) ?? "nil")"
+    }
+
+    // Optional on purpose: Jellyfin models these as tri-state (true / false /
+    // absent), and "the server did not say" is a different diagnostic fact
+    // from "the server said false".
+    // swiftlint:disable:next discouraged_optional_boolean
+    static func field(_ name: String, _ value: Bool?) -> String {
+        "\(name)=\(value.map { $0 ? "true" : "false" } ?? "nil")"
+    }
+
+    static func field(_ name: String, _ value: Double?) -> String {
+        guard let value, value.isFinite else { return "\(name)=nil" }
+        return "\(name)=\(String(format: "%.2f", value))"
+    }
+
+    // MARK: - Redaction
+
+    private static let urlPattern = try? NSRegularExpression(
+        pattern: "[a-zA-Z][a-zA-Z0-9+.-]*://[^\\s\"'<>]+",
+        options: []
+    )
+    private static let secretParamPattern = try? NSRegularExpression(
+        pattern: "(?i)\\b(api_key|apikey|x-emby-token|token|access_?token|password)=[^\\s&\"']*",
+        options: []
+    )
+
+    /// Removes anything URL-shaped or secret-shaped from free text before it is
+    /// logged. AVFoundation error descriptions routinely embed the failing
+    /// request URL, which for this app carries `api_key` — so every string that
+    /// did not originate in our own code goes through here.
+    static func scrub(_ text: String) -> String {
+        var result = text
+        if let urlPattern {
+            result = urlPattern.stringByReplacingMatches(
+                in: result,
+                options: [],
+                range: NSRange(result.startIndex..., in: result),
+                withTemplate: "<url-redacted>"
+            )
+        }
+        if let secretParamPattern {
+            result = secretParamPattern.stringByReplacingMatches(
+                in: result,
+                options: [],
+                range: NSRange(result.startIndex..., in: result),
+                withTemplate: "<secret-redacted>"
+            )
+        }
+        // Collapse newlines so one event stays one log line.
+        return result
+            .replacingOccurrences(of: "\n", with: " ")
+            .replacingOccurrences(of: "\r", with: " ")
+            .trimmingCharacters(in: .whitespaces)
+    }
+
+    /// The only sanctioned way to describe a stream URL: path and extension
+    /// only, with the query string reduced to a parameter count. The query is
+    /// where `api_key` lives, so it is dropped wholesale rather than filtered —
+    /// an allowlist would leak the day Jellyfin adds a new auth parameter.
+    static func describe(url: URL?) -> String {
+        guard let url else { return "path=nil" }
+        guard let components = URLComponents(url: url, resolvingAgainstBaseURL: false) else {
+            return "path=<unparseable>"
+        }
+        let queryCount = components.queryItems?.count ?? 0
+        let ext = url.pathExtension.isEmpty ? "none" : url.pathExtension
+        return "path=\(components.path) ext=\(ext) queryparams=\(queryCount)"
+    }
+
+    /// Describes a path taken from a Jellyfin media source (already relative,
+    /// but it still carries the api_key query).
+    static func describe(streamPath: String?) -> String {
+        guard let streamPath, !streamPath.isEmpty else { return "path=nil" }
+        let pathOnly = streamPath.split(separator: "?", maxSplits: 1).first.map(String.init) ?? streamPath
+        let ext = (pathOnly as NSString).pathExtension
+        return "path=\(pathOnly) ext=\(ext.isEmpty ? "none" : ext)"
+    }
+
+    // MARK: - AVFoundation summaries
+
+    /// Summary of an AVPlayerItem error-log entry.
+    ///
+    /// This is the layer that explains "it played audio but no picture" and
+    /// "it stalled at 43 minutes": AVPlayer records HTTP/transport failures
+    /// here without ever moving the item to `.failed`, so nothing in the app
+    /// used to see them.
+    static func summarize(errorEvent event: AVPlayerItemErrorLogEvent) -> [String] {
+        [
+            field("errorStatusCode", event.errorStatusCode),
+            field("errorDomain", event.errorDomain),
+            field("errorComment", event.errorComment),
+            field("uri", event.uri == nil ? nil : "<redacted>"),
+            field("serverAddress", event.serverAddress == nil ? nil : "<redacted>")
+        ]
+    }
+
+    /// Summary of an AVPlayerItem access-log entry. `numberOfStalls` climbing
+    /// while `observedBitrate` sits below `indicatedBitrate` is the signature of
+    /// a link that cannot carry the stream the server was asked to produce.
+    static func summarize(accessEvent event: AVPlayerItemAccessLogEvent) -> [String] {
+        [
+            field("indicatedBitrate", event.indicatedBitrate),
+            field("observedBitrate", event.observedBitrate),
+            field("switchBitrate", event.switchBitrate),
+            field("numberOfStalls", event.numberOfStalls),
+            field("numberOfDroppedVideoFrames", event.numberOfDroppedVideoFrames),
+            field("durationWatched", event.durationWatched),
+            field("segmentsDownloadedDuration", event.segmentsDownloadedDuration),
+            field("startupTime", event.startupTime),
+            field("playbackType", event.playbackType)
+        ]
+    }
+
+    /// Counts of the tracks AVPlayer actually decided to render.
+    ///
+    /// Zero enabled video tracks with one or more enabled audio tracks IS the
+    /// audio-only failure, stated directly instead of inferred from the
+    /// viewer's description of a black screen.
+    struct TrackSummary {
+        let videoCount: Int
+        let audioCount: Int
+        let enabledVideoCount: Int
+        let enabledAudioCount: Int
+        let presentationWidth: Int
+        let presentationHeight: Int
+
+        var fields: [String] {
+            [
+                PlayerDiagnostics.field("video", videoCount),
+                PlayerDiagnostics.field("audio", audioCount),
+                PlayerDiagnostics.field("videoEnabled", enabledVideoCount),
+                PlayerDiagnostics.field("audioEnabled", enabledAudioCount),
+                PlayerDiagnostics.field("presentation", "\(presentationWidth)x\(presentationHeight)"),
+                PlayerDiagnostics.field("audioOnly", enabledVideoCount == 0 && enabledAudioCount > 0)
+            ]
+        }
+    }
+
+    /// Reads the track state off a ready item. Uses `AVPlayerItem.tracks`
+    /// rather than the asset's tracks on purpose: for HLS the asset exposes no
+    /// tracks at all, and HLS is exactly the case being debugged.
+    static func trackSummary(for item: AVPlayerItem) -> TrackSummary {
+        var video = 0
+        var audio = 0
+        var enabledVideo = 0
+        var enabledAudio = 0
+
+        for track in item.tracks {
+            switch track.assetTrack?.mediaType {
+            case .some(.video):
+                video += 1
+                if track.isEnabled { enabledVideo += 1 }
+            case .some(.audio):
+                audio += 1
+                if track.isEnabled { enabledAudio += 1 }
+            default:
+                continue
+            }
+        }
+
+        let size = item.presentationSize
+        return TrackSummary(
+            videoCount: video,
+            audioCount: audio,
+            enabledVideoCount: enabledVideo,
+            enabledAudioCount: enabledAudio,
+            presentationWidth: Int(size.width),
+            presentationHeight: Int(size.height)
+        )
+    }
+
+    /// Human name for an AVPlayerItem/AVPlayer status.
+    static func name(itemStatus: AVPlayerItem.Status) -> String {
+        switch itemStatus {
+        case .unknown: return "unknown"
+        case .readyToPlay: return "readyToPlay"
+        case .failed: return "failed"
+        @unknown default: return "unhandled(\(itemStatus.rawValue))"
+        }
+    }
+
+    static func name(playerStatus: AVPlayer.Status) -> String {
+        switch playerStatus {
+        case .unknown: return "unknown"
+        case .readyToPlay: return "readyToPlay"
+        case .failed: return "failed"
+        @unknown default: return "unhandled(\(playerStatus.rawValue))"
+        }
+    }
+
+    static func name(timeControlStatus: AVPlayer.TimeControlStatus) -> String {
+        switch timeControlStatus {
+        case .paused: return "paused"
+        case .waitingToPlayAtSpecifiedRate: return "waiting"
+        case .playing: return "playing"
+        @unknown default: return "unhandled(\(timeControlStatus.rawValue))"
+        }
+    }
+
+    /// Domain/code/description for an error, with the description scrubbed.
+    /// The domain and code are the parts that identify the failure
+    /// (`CoreMediaErrorDomain -12939` etc.); the description is the part that
+    /// can contain a URL.
+    static func fields(for error: Error?) -> [String] {
+        guard let error else { return [field("error", "none")] }
+        let nsError = error as NSError
+        var out = [
+            field("errorDomain", nsError.domain),
+            field("errorCode", nsError.code),
+            field("errorDescription", nsError.localizedDescription)
+        ]
+        if let underlying = nsError.userInfo[NSUnderlyingErrorKey] as? NSError {
+            out.append(field("underlyingDomain", underlying.domain))
+            out.append(field("underlyingCode", underlying.code))
+        }
+        return out
+    }
+}

--- a/Shared/ViewModels/PlayerViewModel.swift
+++ b/Shared/ViewModels/PlayerViewModel.swift
@@ -91,7 +91,6 @@ final class PlayerViewModel: ObservableObject {
     @Published var error: Error?
     @Published var currentItem: BaseItemDto?
     @Published var errorMessage: String?
-    @Published var attemptedURL: String?
     @Published var audioTracks: [AudioTrackOption] = []
     @Published var selectedAudioTrackId: String?
     @Published var subtitleTracks: [SubtitleTrackOption] = []
@@ -202,8 +201,53 @@ final class PlayerViewModel: ObservableObject {
     private var errorObserver: NSKeyValueObservation?
     private var rateObserver: NSKeyValueObservation?
     private var endObserver: NSObjectProtocol?
+    /// AVPlayerItem error/access log observers — see observeItemLogs.
+    private var itemErrorLogObserver: NSObjectProtocol?
+    private var itemAccessLogObserver: NSObjectProtocol?
+    /// Time-jump / stall / failed-to-end observers, kept together because they
+    /// share a lifetime with the current player item.
+    private var stallObservers: [NSObjectProtocol] = []
+    /// Last stall count already reported, so a climbing counter is logged once
+    /// per new stall instead of on every access-log entry.
+    private var lastReportedStallCount = 0
     private let client = JellyfinClient.shared
     private let playbackSettings = PlaybackSettings.shared
+
+    // MARK: - Diagnostics
+
+    /// Identifies THIS view model instance in the log.
+    ///
+    /// The production restart loop (transcode starts, client abandons it ~1s
+    /// later, a different transcode starts) has two very different causes that
+    /// are indistinguishable server-side: one view model loading twice, or two
+    /// view models each loading once (SwiftUI recreating the player view).
+    /// Tagging every line with the instance is what tells them apart.
+    nonisolated private let sessionTag = String(UUID().uuidString.prefix(8))
+
+    /// Incremented by every path that builds a player (loadMedia,
+    /// changeQuality). Two `load.begin` lines with the same `vm` and different
+    /// `attempt` values mean this instance was asked to load twice.
+    private var playbackAttempt = 0
+
+    /// Fields stamped on every diagnostic line from this instance.
+    private var diagContext: [String] {
+        [
+            PlayerDiagnostics.field("vm", sessionTag),
+            PlayerDiagnostics.field("attempt", playbackAttempt)
+        ]
+    }
+
+    private func diag(_ stage: PlayerDiagnostics.Stage, _ fields: [String] = []) {
+        PlayerDiagnostics.event(stage, diagContext + fields)
+    }
+
+    private func diagFailure(_ stage: PlayerDiagnostics.Stage, _ fields: [String] = []) {
+        PlayerDiagnostics.failure(stage, diagContext + fields)
+    }
+
+    private func diagDetail(_ stage: PlayerDiagnostics.Stage, _ fields: [String] = []) {
+        PlayerDiagnostics.detail(stage, diagContext + fields)
+    }
 
     /// Refreshes the stream-info chip from the server's own session view.
     /// Called when the player overlay becomes visible; cheap single GET.
@@ -290,12 +334,47 @@ final class PlayerViewModel: ObservableObject {
         }
     }
 
+    /// Ends the server-side transcode belonging to the CURRENT play session, if
+    /// there is one, and records why.
+    ///
+    /// This is the client action Jellyfin logs as "Stopping ffmpeg process with
+    /// q command" (it is a DELETE /Videos/ActiveEncodings). From the server's
+    /// side it is indistinguishable from the client simply walking away, which
+    /// is why every call site has to name its reason here.
+    private func stopActiveEncodingIfNeeded(reason: PlayerDiagnostics.TeardownReason) async {
+        guard !isOfflinePlayback,
+              let playSessionId,
+              currentMediaSource?.transcodingUrl != nil else { return }
+
+        diag(.encodingStop, [
+            PlayerDiagnostics.field("reason", reason.rawValue),
+            PlayerDiagnostics.field("playSession", playSessionId)
+        ])
+        do {
+            try await client.stopActiveEncoding(playSessionId: playSessionId)
+        } catch {
+            logger.error("stopActiveEncoding failed: \(error.localizedDescription, privacy: .public)")
+            diagFailure(.encodingStop, [
+                PlayerDiagnostics.field("reason", reason.rawValue)
+            ] + PlayerDiagnostics.fields(for: error))
+        }
+    }
+
     func loadMedia(
         item: BaseItemDto,
         startFromBeginning: Bool = false,
         localFileURL: URL? = nil,
         offlineSubtitles: [OfflineSubtitle] = []
     ) async {
+        playbackAttempt += 1
+        diag(.loadBegin, [
+            PlayerDiagnostics.field("item", item.id),
+            PlayerDiagnostics.field("type", item.type?.rawValue),
+            PlayerDiagnostics.field("startFromBeginning", startFromBeginning),
+            PlayerDiagnostics.field("offline", localFileURL != nil),
+            PlayerDiagnostics.field("hadPlayer", player != nil),
+            PlayerDiagnostics.field("previousItem", currentItem?.id)
+        ])
         self.offlineSubtitles = offlineSubtitles
         // Tear down everything tied to the previous player first — auto-play
         // next episode reuses this ViewModel, and observers left on the old
@@ -315,6 +394,13 @@ final class PlayerViewModel: ObservableObject {
         // changeQuality and the stop path both do this; only this one did not,
         // which is how auto-play-next and skip-credits ended up with two
         // players running.
+        if player != nil {
+            diag(.teardown, [
+                PlayerDiagnostics.field("reason", PlayerDiagnostics.TeardownReason.newItem.rawValue),
+                PlayerDiagnostics.field("outgoingItem", currentItem?.id),
+                PlayerDiagnostics.field("incomingItem", item.id)
+            ])
+        }
         player?.pause()
         progressReportTask?.cancel()
         subtitleLoadTask?.cancel()
@@ -332,13 +418,7 @@ final class PlayerViewModel: ObservableObject {
         // Kill the previous episode's transcode session, same as
         // changeQuality — auto-play-next otherwise leaves the old encode
         // running until the server times it out.
-        if let playSessionId, currentMediaSource?.transcodingUrl != nil {
-            do {
-                try await client.stopActiveEncoding(playSessionId: playSessionId)
-            } catch {
-                logger.error("stopActiveEncoding failed: \(error.localizedDescription, privacy: .public)")
-            }
-        }
+        await stopActiveEncodingIfNeeded(reason: .newItem)
 
         isLoading = true
         error = nil
@@ -356,7 +436,12 @@ final class PlayerViewModel: ObservableObject {
                 try audioSession.setCategory(.playback, mode: .moviePlayback)
                 try audioSession.setActive(true)
 
+                diag(.streamSelected, [
+                    PlayerDiagnostics.field("kind", PlayerDiagnostics.StreamKind.localFile.rawValue),
+                    PlayerDiagnostics.field("ext", localFileURL.pathExtension)
+                ])
                 let asset = AVURLAsset(url: localFileURL)
+                diag(.assetCreated, [PlayerDiagnostics.field("kind", PlayerDiagnostics.StreamKind.localFile.rawValue)])
                 let playerItem = AVPlayerItem(asset: asset, automaticallyLoadedAssetKeys: ["playable", "duration"])
                 // Same observer wiring as the online path. loadMedia has already
                 // torn down the previous endObserver, so building the player
@@ -395,6 +480,12 @@ final class PlayerViewModel: ObservableObject {
             isOfflinePlayback = localFileURL != nil
             let isOffline = isOfflinePlayback
 
+            diag(.loadReady, [
+                PlayerDiagnostics.field("item", freshItem.id),
+                PlayerDiagnostics.field("playSession", playSessionId),
+                PlayerDiagnostics.field("offline", isOffline)
+            ])
+
             // Fetch media segments for skip intro/credits (skip when offline)
             if !isOffline {
                 await fetchSegments(itemId: freshItem.id)
@@ -416,15 +507,41 @@ final class PlayerViewModel: ObservableObject {
                 }
                 setupSegmentTracking()
                 playbackStartDate = Date()
-                player?.play()
+                logAndPlay(positionTicks: resumePositionTicks)
             } else if let startTicks = freshItem.userData?.playbackPositionTicks, startTicks > thresholdTicks {
                 // Auto-resume from saved position (no dialog)
                 resumePositionTicks = startTicks
                 pendingResumeTicks = startTicks
-                let startTime = CMTime(value: startTicks / 10000, timescale: 1000)
-                // Best-effort immediate seek (lands for direct play); the
-                // status observer re-applies it once HLS/transcode is ready.
-                await player?.seek(to: startTime)
+                // NO seek here. The resume position is applied exactly once,
+                // from the status observer, when the item reports .readyToPlay.
+                //
+                // What used to be here was `await player?.seek(to: startTime)`,
+                // and it was wrong twice over:
+                //
+                //  1. It AWAITED a seek completion inside startup. AVFoundation
+                //     only promises to call that completion when the seek
+                //     finishes or is superseded, and on a stream that is not
+                //     ready yet that can be seconds — or never, if the item is
+                //     replaced first. Everything below it (reportPlaybackStart,
+                //     progress reporting, segment tracking, and play() itself)
+                //     was blocked behind it. That is a resume-only stall, and
+                //     resume-only is exactly the failure boundary reported.
+                //
+                //  2. It armed pendingResumeTicks as well, so the SAME resume
+                //     position was seeked to twice: once here, and again from
+                //     applyPendingResumeSeekIfNeeded — which compares against
+                //     player.currentTime(), still 0 while the first seek is in
+                //     flight, so the 3-second guard never suppressed it. On a
+                //     Jellyfin HLS session every seek makes the server kill the
+                //     running ffmpeg and restart it at the new offset, so two
+                //     seeks a second apart produce precisely the captured
+                //     start -> "Stopping ffmpeg with q command" -> start ->
+                //     stop pattern.
+                diag(.seek, [
+                    PlayerDiagnostics.field("phase", "resume-armed"),
+                    PlayerDiagnostics.field("targetSeconds", Double(startTicks) / 10_000_000),
+                    PlayerDiagnostics.field("startTimeTicksSentToServer", false)
+                ])
                 if !isOffline {
                     do {
                         try await client.reportPlaybackStart(itemId: freshItem.id, positionTicks: startTicks, playSessionId: playSessionId, playMethod: currentPlayMethod)
@@ -435,7 +552,7 @@ final class PlayerViewModel: ObservableObject {
                 }
                 setupSegmentTracking()
                 playbackStartDate = Date()
-                player?.play()
+                logAndPlay(positionTicks: resumePositionTicks)
             } else {
                 // No saved progress - start playing immediately
                 resumePositionTicks = 0
@@ -450,13 +567,43 @@ final class PlayerViewModel: ObservableObject {
                 }
                 setupSegmentTracking()
                 playbackStartDate = Date()
-                player?.play()
+                logAndPlay(positionTicks: resumePositionTicks)
             }
         } catch {
+            diagFailure(.loadFailed, [PlayerDiagnostics.field("item", item.id)] + PlayerDiagnostics.fields(for: error))
             self.error = error
             self.errorMessage = error.localizedDescription
             isLoading = false
         }
+    }
+
+    /// Starts playback and records the position it starts from, so a stream
+    /// that begins at 0:00 when it should have resumed is visible in the log
+    /// rather than only in the server's `-ss` argument.
+    private func logAndPlay(positionTicks: Int64) {
+        diag(.play, [
+            PlayerDiagnostics.field("resumeTargetSeconds", Double(positionTicks) / 10_000_000),
+            PlayerDiagnostics.field("currentSeconds", player?.currentTime().seconds),
+            PlayerDiagnostics.field("hasPlayer", player != nil),
+            PlayerDiagnostics.field("timeControl", player.map { PlayerDiagnostics.name(timeControlStatus: $0.timeControlStatus) })
+        ])
+        player?.play()
+    }
+
+    /// Replaces the position the item will resume to once it is ready.
+    ///
+    /// The iOS player uses this when a locally-saved offline position is newer
+    /// than the server's. It must go through here rather than seeking the
+    /// player directly: the resume seek is applied on `.readyToPlay`, so a
+    /// direct seek issued before that is simply undone a moment later.
+    func overrideResumePosition(ticks: Int64) {
+        guard ticks > 0 else { return }
+        resumePositionTicks = ticks
+        pendingResumeTicks = ticks
+        diag(.seek, [
+            PlayerDiagnostics.field("phase", "resume-override"),
+            PlayerDiagnostics.field("targetSeconds", Double(ticks) / 10_000_000)
+        ])
     }
 
     private func startProgressReporting() {
@@ -492,8 +639,16 @@ final class PlayerViewModel: ObservableObject {
     private func handlePlaybackEnded() async {
         // Guard against firing twice (e.g. a skip-to-end and the natural end
         // notification for the same item). Reset when the next item loads.
-        if isHandlingEnd { return }
+        if isHandlingEnd {
+            diag(.playbackEnded, [PlayerDiagnostics.field("suppressed", true)])
+            return
+        }
         isHandlingEnd = true
+        diag(.playbackEnded, [
+            PlayerDiagnostics.field("item", currentItem?.id),
+            PlayerDiagnostics.field("positionSeconds", player?.currentItem?.currentTime().seconds),
+            PlayerDiagnostics.field("autoPlayNext", playbackSettings.autoPlayNextEpisode)
+        ])
 
         progressReportTask?.cancel()
 
@@ -600,6 +755,7 @@ final class PlayerViewModel: ObservableObject {
 
     func playNextEpisode() async {
         guard let next = nextEpisode else { return }
+        diag(.nextEpisode, [PlayerDiagnostics.field("item", next.id)])
         nextEpisode = nil
         playbackEnded = false
         await loadMedia(item: next)
@@ -612,10 +768,22 @@ final class PlayerViewModel: ObservableObject {
         let currentPosition = player?.currentItem?.currentTime()
         let positionTicks = currentPosition.map { Int64($0.seconds * 10_000_000) } ?? 0
 
+        playbackAttempt += 1
+        diag(.qualityChange, [
+            PlayerDiagnostics.field("from", selectedQuality.rawValue),
+            PlayerDiagnostics.field("to", quality.rawValue),
+            PlayerDiagnostics.field("item", item.id),
+            PlayerDiagnostics.field("positionSeconds", currentPosition?.seconds)
+        ])
+
         // Update quality setting
         selectedQuality = quality
 
         // Stop current playback
+        diag(.teardown, [
+            PlayerDiagnostics.field("reason", PlayerDiagnostics.TeardownReason.qualityChange.rawValue),
+            PlayerDiagnostics.field("item", item.id)
+        ])
         player?.pause()
         progressReportTask?.cancel()
         subtitleLoadTask?.cancel()
@@ -638,13 +806,7 @@ final class PlayerViewModel: ObservableObject {
 
         // Kill the old transcode session before requesting a new one, so the
         // server isn't left encoding a stream nobody is watching.
-        if let playSessionId, currentMediaSource?.transcodingUrl != nil {
-            do {
-                try await client.stopActiveEncoding(playSessionId: playSessionId)
-            } catch {
-                logger.error("stopActiveEncoding failed: \(error.localizedDescription, privacy: .public)")
-            }
-        }
+        await stopActiveEncodingIfNeeded(reason: .qualityChange)
 
         do {
             // An explicit non-Auto pick forces a transcode so the selection
@@ -661,9 +823,15 @@ final class PlayerViewModel: ObservableObject {
             // ready. Without this the stream restarts at 0:00 and the 5s
             // progress report then overwrites the server's resume point with 0.
             if positionTicks > 0 {
+                // Armed only — same reasoning as the resume path in loadMedia:
+                // awaiting a pre-ready seek blocked startup, and issuing it here
+                // as well as from the status observer meant two seeks (two
+                // server-side transcode restarts) for one position change.
                 pendingResumeTicks = positionTicks
-                let seekTime = CMTime(value: positionTicks / 10000, timescale: 1000)
-                await player?.seek(to: seekTime)
+                diag(.seek, [
+                    PlayerDiagnostics.field("phase", "quality-change-armed"),
+                    PlayerDiagnostics.field("targetSeconds", Double(positionTicks) / 10_000_000)
+                ])
             }
 
             // Re-apply the session's subtitle selection on the rebuilt
@@ -690,23 +858,38 @@ final class PlayerViewModel: ObservableObject {
             await fetchSegments(itemId: item.id)
             startProgressReporting()
             setupSegmentTracking()
-            player?.play()
+            logAndPlay(positionTicks: positionTicks)
         } catch {
+            diagFailure(.loadFailed, [
+                PlayerDiagnostics.field("phase", "quality-change"),
+                PlayerDiagnostics.field("item", item.id)
+            ] + PlayerDiagnostics.fields(for: error))
             self.error = error
             self.errorMessage = error.localizedDescription
             isLoading = false
         }
     }
 
-    /// Applies the saved resume position once the item can actually seek. A
-    /// pre-ready seek is silently dropped for HLS/transcode (no seekable range
-    /// yet) — direct play lands immediately, but transcode needs this retry.
-    /// Runs once, and skips if the immediate seek already landed near target.
+    /// Applies the saved resume position once the item can actually seek.
+    ///
+    /// This is now the ONLY place a resume position is applied. It runs from
+    /// the `.readyToPlay` transition, which is the first moment the item has a
+    /// seekable range at all — a seek issued before that is either dropped
+    /// (HLS/transcode) or deferred, and in both cases it duplicated this one.
+    /// `pendingResumeTicks` is cleared before seeking so a repeated
+    /// `.readyToPlay` cannot issue a second seek.
     private func applyPendingResumeSeekIfNeeded() {
         guard pendingResumeTicks > 0, let player else { return }
         let target = CMTime(value: pendingResumeTicks / 10000, timescale: 1000)
         pendingResumeTicks = 0
-        if abs(player.currentTime().seconds - target.seconds) > 3 {
+        let drift = abs(player.currentTime().seconds - target.seconds)
+        diag(.seek, [
+            PlayerDiagnostics.field("phase", "post-ready-resume"),
+            PlayerDiagnostics.field("targetSeconds", target.seconds),
+            PlayerDiagnostics.field("driftSeconds", drift),
+            PlayerDiagnostics.field("applied", drift > 3)
+        ])
+        if drift > 3 {
             player.seek(to: target)
         }
     }
@@ -718,9 +901,17 @@ final class PlayerViewModel: ObservableObject {
     /// failure is a visible "couldn't find an episode" instead of a silent
     /// server 500 mid-startup.
     func resolvePlayableItem(_ item: BaseItemDto) async throws -> BaseItemDto {
-        guard let type = item.type, !type.isPlayableMediaType else { return item }
+        guard let type = item.type, !type.isPlayableMediaType else {
+            diag(.loadResolved, [
+                PlayerDiagnostics.field("resolved", false),
+                PlayerDiagnostics.field("item", item.id),
+                PlayerDiagnostics.field("type", item.type?.rawValue)
+            ])
+            return item
+        }
 
         if type == .series, let next = try? await client.getNextUp(seriesId: item.id, limit: 1).first {
+            logResolution(from: item, to: next, via: "next-up")
             return next
         }
 
@@ -734,6 +925,7 @@ final class PlayerViewModel: ObservableObject {
                 limit: 1,
                 isPlayed: false
             ).items.first {
+                logResolution(from: item, to: unwatched, via: "first-unwatched")
                 return unwatched
             }
             if let first = try? await client.getItems(
@@ -742,12 +934,30 @@ final class PlayerViewModel: ObservableObject {
                 sortBy: "ParentIndexNumber,IndexNumber",
                 limit: 1
             ).items.first {
+                logResolution(from: item, to: first, via: "first-episode")
                 return first
             }
         }
 
         logger.error("Could not resolve \(type.rawValue, privacy: .public) \(item.id, privacy: .public) to a playable episode")
+        diagFailure(.loadResolved, [
+            PlayerDiagnostics.field("resolved", false),
+            PlayerDiagnostics.field("item", item.id),
+            PlayerDiagnostics.field("type", type.rawValue),
+            PlayerDiagnostics.field("outcome", "no-playable-episode")
+        ])
         throw PlayerError.noPlayableEpisode(item.name)
+    }
+
+    private func logResolution(from container: BaseItemDto, to episode: BaseItemDto, via: String) {
+        diag(.loadResolved, [
+            PlayerDiagnostics.field("resolved", true),
+            PlayerDiagnostics.field("fromType", container.type?.rawValue),
+            PlayerDiagnostics.field("fromItem", container.id),
+            PlayerDiagnostics.field("toItem", episode.id),
+            PlayerDiagnostics.field("toType", episode.type?.rawValue),
+            PlayerDiagnostics.field("via", via)
+        ])
     }
 
     /// Shared player setup: resolves stream URL, creates AVPlayer with observers.
@@ -759,6 +969,31 @@ final class PlayerViewModel: ObservableObject {
             sessionOverride: maxBitrate ?? selectedQuality.maxBitrate,
             settingsMaxBitrate: playbackSettings.maxBitrate
         )
+
+        // The cap in force, and whether it came from a real measurement or a
+        // default (the #341/#342 Auto-cap work). An unexplained transcode is
+        // almost always this value, and it was previously only visible in the
+        // JellyfinClient log, disconnected from the play attempt it belonged to.
+        let bandwidth = await client.bandwidthStatus
+        diag(.playbackInfoRequest, [
+            PlayerDiagnostics.field("item", item.id),
+            PlayerDiagnostics.field("itemType", item.type?.rawValue),
+            PlayerDiagnostics.field("requestedBitrate", effectiveBitrate),
+            PlayerDiagnostics.field("effectiveCap", effectiveBitrate ?? bandwidth.cap),
+            PlayerDiagnostics.field("capSource", effectiveBitrate != nil ? "explicit" : (bandwidth.isMeasured ? "measured" : "default")),
+            PlayerDiagnostics.field("measuredBitrate", bandwidth.measuredBitrate),
+            PlayerDiagnostics.field("localServer", bandwidth.isLocalServer),
+            PlayerDiagnostics.field("maxWidth", maxWidth),
+            PlayerDiagnostics.field("forceTranscode", forceTranscode),
+            PlayerDiagnostics.field("forceDirectPlay", playbackSettings.forceDirectPlay),
+            // The two request flags that decide whether the server may
+            // stream-COPY the video into HLS or must re-encode it, and whether
+            // it may cut segments mid-GOP. Seeking behaves differently in each
+            // combination, and none of it was visible from the client before.
+            PlayerDiagnostics.field("allowVideoStreamCopy", !forceTranscode),
+            PlayerDiagnostics.field("breakOnNonKeyFrames", JellyfinClient.transcodingProfileBreaksOnNonKeyFrames)
+        ])
+
         let playbackInfo = try await client.getPlaybackInfo(
             itemId: item.id,
             itemType: item.type,
@@ -769,8 +1004,30 @@ final class PlayerViewModel: ObservableObject {
         )
 
         guard let mediaSource = playbackInfo.mediaSources?.first else {
+            diagFailure(.playbackInfoResponse, [
+                PlayerDiagnostics.field("item", item.id),
+                PlayerDiagnostics.field("outcome", "no-media-source"),
+                PlayerDiagnostics.field("sourceCount", playbackInfo.mediaSources?.count ?? 0)
+            ])
             throw PlayerError.noMediaSource
         }
+
+        diag(.playbackInfoResponse, [
+            PlayerDiagnostics.field("item", item.id),
+            PlayerDiagnostics.field("mediaSource", mediaSource.id),
+            PlayerDiagnostics.field("playSession", playbackInfo.playSessionId),
+            PlayerDiagnostics.field("container", mediaSource.container),
+            PlayerDiagnostics.field("supportsDirectPlay", mediaSource.supportsDirectPlay),
+            PlayerDiagnostics.field("supportsDirectStream", mediaSource.supportsDirectStream),
+            PlayerDiagnostics.field("supportsTranscoding", mediaSource.supportsTranscoding),
+            PlayerDiagnostics.field("hasTranscodingUrl", mediaSource.transcodingUrl?.isEmpty == false),
+            PlayerDiagnostics.field("hasDirectStreamUrl", mediaSource.directStreamUrl?.isEmpty == false),
+            PlayerDiagnostics.field("videoCodec", mediaSource.videoCodec),
+            PlayerDiagnostics.field("audioCodec", mediaSource.audioCodec),
+            PlayerDiagnostics.field("sourceBitrate", mediaSource.bitrate),
+            PlayerDiagnostics.field("resolution", mediaSource.videoResolution),
+            PlayerDiagnostics.field("transcodeReasons", mediaSource.transcodeReasons?.joined(separator: ",") ?? "none")
+        ])
 
         playSessionId = playbackInfo.playSessionId
         currentMediaSource = mediaSource
@@ -778,11 +1035,15 @@ final class PlayerViewModel: ObservableObject {
         streamInfo = nil   // stale for the new session; refreshed when the overlay opens
 
         let resolvedURL: URL?
+        let streamKind: PlayerDiagnostics.StreamKind
         if let transcodingPath = mediaSource.transcodingUrl, !transcodingPath.isEmpty {
+            streamKind = .transcodeHLS
             resolvedURL = await client.buildURL(path: transcodingPath)
         } else if let directPath = mediaSource.directStreamUrl, !directPath.isEmpty {
+            streamKind = .directStream
             resolvedURL = await client.buildURL(path: directPath)
         } else if mediaSource.supportsDirectPlay != false {
+            streamKind = .directPlayStatic
             resolvedURL = await client.getPlaybackURL(itemId: item.id, mediaSourceId: mediaSource.id, container: mediaSource.container)
         } else {
             // The server offered no transcode/remux URL AND says the source
@@ -793,16 +1054,48 @@ final class PlayerViewModel: ObservableObject {
             // it can't render: audio over a black screen instead of an error.
             // Fail loudly instead.
             logger.error("Media source \(mediaSource.id, privacy: .public) is not playable: no stream URLs and SupportsDirectPlay=false")
+            diagFailure(.streamSelected, [
+                PlayerDiagnostics.field("mediaSource", mediaSource.id),
+                PlayerDiagnostics.field("outcome", "source-not-playable")
+            ])
             throw PlayerError.sourceNotPlayable
         }
 
         guard let resolvedURL else {
+            diagFailure(.streamSelected, [
+                PlayerDiagnostics.field("kind", streamKind.rawValue),
+                PlayerDiagnostics.field("outcome", "no-stream-url")
+            ])
             throw PlayerError.noStreamURL
         }
 
-        attemptedURL = resolvedURL.absoluteString
+        // Which URL AVPlayer is actually being pointed at. `describe(url:)`
+        // keeps the path and drops the query — the query is where api_key lives.
+        // `avplayerPlayableContainer` is a pure observation (nothing branches on
+        // it): AVPlayer has no Matroska demuxer, so a direct-stream URL ending
+        // in .mkv is a stream it cannot render, and that should be visible here
+        // rather than inferred from a black screen.
+        let container = resolvedURL.pathExtension.lowercased()
+        diag(.streamSelected, [
+            PlayerDiagnostics.field("kind", streamKind.rawValue),
+            PlayerDiagnostics.field("mediaSource", mediaSource.id),
+            PlayerDiagnostics.field("playSession", playSessionId),
+            PlayerDiagnostics.field(
+                "avplayerPlayableContainer",
+                container.isEmpty || container == "m3u8" || DeviceMediaCompatibility.directPlayContainers.contains(container)
+            ),
+            PlayerDiagnostics.describe(url: resolvedURL)
+        ])
 
+        // NOTE: the full URL deliberately goes no further than AVURLAsset. It
+        // used to be retained in a published `attemptedURL` property that
+        // nothing ever read — a credential (`api_key`) parked in view-model
+        // state, one `Text(...)` away from being on screen.
         let asset = AVURLAsset(url: resolvedURL)
+        diag(.assetCreated, [
+            PlayerDiagnostics.field("kind", streamKind.rawValue),
+            PlayerDiagnostics.field("chapters", item.chapters?.count ?? 0)
+        ])
         let playerItem = AVPlayerItem(asset: asset, automaticallyLoadedAssetKeys: ["playable", "duration"])
 
         if let chapters = item.chapters, !chapters.isEmpty,
@@ -825,33 +1118,67 @@ final class PlayerViewModel: ObservableObject {
         tracksVersion &+= 1
         errorObserver = playerItem.observe(\.status) { [weak self] observed, _ in
             Task { @MainActor in
+                guard let self else { return }
+                // EVERY transition, not just the interesting ones: an item that
+                // never leaves .unknown is a different failure from one that
+                // reaches .failed, and the two are indistinguishable to a viewer
+                // (both are a black screen).
+                self.diag(.itemStatus, [
+                    PlayerDiagnostics.field("status", PlayerDiagnostics.name(itemStatus: observed.status))
+                ] + (observed.status == .failed ? PlayerDiagnostics.fields(for: observed.error) : []))
+
                 if observed.status == .failed {
-                    self?.errorMessage = observed.error?.localizedDescription ?? "Unknown playback error"
-                    self?.error = observed.error
+                    self.diagFailure(.itemStatus, [
+                        PlayerDiagnostics.field("status", "failed")
+                    ] + PlayerDiagnostics.fields(for: observed.error))
+                    self.errorMessage = observed.error?.localizedDescription ?? "Unknown playback error"
+                    self.error = observed.error
                 } else if observed.status == .readyToPlay {
-                    self?.applyPendingResumeSeekIfNeeded()
+                    self.logTrackAvailability(for: observed)
+                    self.applyPendingResumeSeekIfNeeded()
                 }
             }
         }
+
+        observeItemLogs(for: playerItem)
 
         player = AVPlayer(playerItem: playerItem)
         player?.appliesMediaSelectionCriteriaAutomatically = false
         player?.volume = 1.0
         player?.isMuted = false
+        diag(.playerCreated, [
+            PlayerDiagnostics.field("tracksVersion", tracksVersion)
+        ])
 
         statusObserver = player?.observe(\.status) { [weak self] observed, _ in
             Task { @MainActor in
+                guard let self else { return }
+                self.diag(.playerStatus, [
+                    PlayerDiagnostics.field("status", PlayerDiagnostics.name(playerStatus: observed.status))
+                ])
                 if observed.status == .failed {
-                    self?.errorMessage = observed.error?.localizedDescription ?? "Player failed"
-                    self?.error = observed.error
+                    self.diagFailure(.playerStatus, [
+                        PlayerDiagnostics.field("status", "failed")
+                    ] + PlayerDiagnostics.fields(for: observed.error))
+                    self.errorMessage = observed.error?.localizedDescription ?? "Player failed"
+                    self.error = observed.error
                 }
             }
         }
 
-        rateObserver = player?.observe(\.timeControlStatus) { [weak self] _, _ in
+        rateObserver = player?.observe(\.timeControlStatus) { [weak self] observed, _ in
             Task { @MainActor in
-                self?.refreshNowPlayingProgress()
-                await self?.reportProgress()
+                guard let self else { return }
+                // "waiting" for a long stretch after play() IS the stall the
+                // viewer describes as a freeze; the reason says whether it is
+                // buffering or waiting on a minimum stall-free duration.
+                self.diag(.timeControl, [
+                    PlayerDiagnostics.field("status", PlayerDiagnostics.name(timeControlStatus: observed.timeControlStatus)),
+                    PlayerDiagnostics.field("reason", observed.reasonForWaitingToPlay?.rawValue),
+                    PlayerDiagnostics.field("positionSeconds", observed.currentTime().seconds)
+                ])
+                self.refreshNowPlayingProgress()
+                await self.reportProgress()
             }
         }
 
@@ -866,6 +1193,143 @@ final class PlayerViewModel: ObservableObject {
         }
     }
 
+    /// Subscribes to the AVPlayerItem notifications that explain stalls,
+    /// audio-only playback and seek failures.
+    ///
+    /// None of this reaches `AVPlayerItem.status`: an item can stall forever,
+    /// drop every video frame, or fail an individual segment fetch while its
+    /// status stays `.readyToPlay`. Until now the app observed only `status`,
+    /// which is why a failed play could only be described as "it just sat
+    /// there" and had to be reconstructed from the server's ffmpeg log.
+    private func observeItemLogs(for playerItem: AVPlayerItem) {
+        removeItemLogObservers()
+        let center = NotificationCenter.default
+
+        itemErrorLogObserver = center.addObserver(
+            forName: .AVPlayerItemNewErrorLogEntry,
+            object: playerItem,
+            queue: .main
+        ) { [weak self] note in
+            guard let item = note.object as? AVPlayerItem,
+                  let event = item.errorLog()?.events.last else { return }
+            Task { @MainActor in
+                self?.diagFailure(.errorLog, PlayerDiagnostics.summarize(errorEvent: event))
+            }
+        }
+
+        itemAccessLogObserver = center.addObserver(
+            forName: .AVPlayerItemNewAccessLogEntry,
+            object: playerItem,
+            queue: .main
+        ) { [weak self] note in
+            guard let item = note.object as? AVPlayerItem,
+                  let event = item.accessLog()?.events.last else { return }
+            Task { @MainActor in
+                guard let self else { return }
+                // Access-log entries arrive on every rendition switch and
+                // periodically during playback, so the raw sample is .debug.
+                self.diagDetail(.accessLog, PlayerDiagnostics.summarize(accessEvent: event))
+                // A stall is the exception: promote it, because "numberOfStalls
+                // climbing" is the difference between "the link can't carry
+                // this" and "the stream itself is broken".
+                if event.numberOfStalls > self.lastReportedStallCount {
+                    self.lastReportedStallCount = event.numberOfStalls
+                    self.diag(.accessLog, [
+                        PlayerDiagnostics.field("stallDetected", true)
+                    ] + PlayerDiagnostics.summarize(accessEvent: event))
+                }
+            }
+        }
+
+        // Seeks made through the tvOS transport bar never pass through this
+        // view model — AVPlayerViewController drives AVPlayer directly. This
+        // notification is the only way to see them, and seeking is the
+        // reproducer for the 4K stream-copy failure.
+        stallObservers.append(center.addObserver(
+            forName: AVPlayerItem.timeJumpedNotification,
+            object: playerItem,
+            queue: .main
+        ) { [weak self] note in
+            guard let item = note.object as? AVPlayerItem else { return }
+            Task { @MainActor in
+                self?.logSeekLanding(on: item, cause: "time-jumped")
+            }
+        })
+
+        stallObservers.append(center.addObserver(
+            forName: .AVPlayerItemPlaybackStalled,
+            object: playerItem,
+            queue: .main
+        ) { [weak self] note in
+            guard let item = note.object as? AVPlayerItem else { return }
+            Task { @MainActor in
+                self?.logSeekLanding(on: item, cause: "playback-stalled")
+            }
+        })
+
+        stallObservers.append(center.addObserver(
+            forName: .AVPlayerItemFailedToPlayToEndTime,
+            object: playerItem,
+            queue: .main
+        ) { [weak self] note in
+            let error = note.userInfo?[AVPlayerItemFailedToPlayToEndTimeErrorKey] as? Error
+            Task { @MainActor in
+                self?.diagFailure(.itemStatus, [
+                    PlayerDiagnostics.field("event", "failed-to-play-to-end")
+                ] + PlayerDiagnostics.fields(for: error))
+            }
+        })
+    }
+
+    private func removeItemLogObservers() {
+        let center = NotificationCenter.default
+        if let itemErrorLogObserver {
+            center.removeObserver(itemErrorLogObserver)
+            self.itemErrorLogObserver = nil
+        }
+        if let itemAccessLogObserver {
+            center.removeObserver(itemAccessLogObserver)
+            self.itemAccessLogObserver = nil
+        }
+        for observer in stallObservers {
+            center.removeObserver(observer)
+        }
+        stallObservers.removeAll()
+        lastReportedStallCount = 0
+    }
+
+    /// Where a seek (or stall) actually landed, relative to what the stream can
+    /// serve.
+    ///
+    /// `seekable` is the range Jellyfin's playlist claims; `loaded` is what
+    /// AVPlayer actually holds. A position inside `seekable` but outside
+    /// `loaded`, with playback not advancing, is a seek into a segment the
+    /// server has not produced — the question the server log cannot answer.
+    private func logSeekLanding(on item: AVPlayerItem, cause: String) {
+        let position = item.currentTime().seconds
+        let seekable = item.seekableTimeRanges.first?.timeRangeValue
+        let loaded = item.loadedTimeRanges.first?.timeRangeValue
+        diag(.seek, [
+            PlayerDiagnostics.field("cause", cause),
+            PlayerDiagnostics.field("positionSeconds", position),
+            PlayerDiagnostics.field("seekableStart", seekable?.start.seconds),
+            PlayerDiagnostics.field("seekableEnd", seekable.map { ($0.start + $0.duration).seconds }),
+            PlayerDiagnostics.field("loadedStart", loaded?.start.seconds),
+            PlayerDiagnostics.field("loadedEnd", loaded.map { ($0.start + $0.duration).seconds }),
+            PlayerDiagnostics.field("likelyToKeepUp", item.isPlaybackLikelyToKeepUp),
+            PlayerDiagnostics.field("bufferEmpty", item.isPlaybackBufferEmpty)
+        ] + PlayerDiagnostics.trackSummary(for: item).fields)
+    }
+
+    /// How many video and audio tracks AVPlayer ended up with, and how many it
+    /// enabled. Zero enabled video tracks alongside enabled audio IS the
+    /// "audio plays, picture is frozen" report, stated rather than inferred.
+    private func logTrackAvailability(for item: AVPlayerItem) {
+        diag(.tracks, PlayerDiagnostics.trackSummary(for: item).fields + [
+            PlayerDiagnostics.field("durationSeconds", item.duration.seconds)
+        ])
+    }
+
     /// Invalidates the KVO observations tied to the current player/item.
     /// Must run before the player is dropped or replaced so no observation
     /// outlives the object it watches.
@@ -876,9 +1340,17 @@ final class PlayerViewModel: ObservableObject {
         errorObserver = nil
         rateObserver?.invalidate()
         rateObserver = nil
+        removeItemLogObservers()
     }
 
-    func stop() async {
+    func stop(reason: PlayerDiagnostics.TeardownReason = .unspecified) async {
+        diag(.teardown, [
+            PlayerDiagnostics.field("reason", reason.rawValue),
+            PlayerDiagnostics.field("item", currentItem?.id),
+            PlayerDiagnostics.field("playSession", playSessionId),
+            PlayerDiagnostics.field("positionSeconds", player?.currentItem?.currentTime().seconds),
+            PlayerDiagnostics.field("hadPlayer", player != nil)
+        ])
         progressReportTask?.cancel()
         subtitleLoadTask?.cancel()
         cleanupSegmentTracking()
@@ -917,13 +1389,7 @@ final class PlayerViewModel: ObservableObject {
         }
 
         // Kill the session's server-side transcode, if one was active.
-        if !isOfflinePlayback, let playSessionId, currentMediaSource?.transcodingUrl != nil {
-            do {
-                try await client.stopActiveEncoding(playSessionId: playSessionId)
-            } catch {
-                logger.error("stopActiveEncoding failed: \(error.localizedDescription, privacy: .public)")
-            }
-        }
+        await stopActiveEncodingIfNeeded(reason: reason)
         playSessionId = nil
 
         player?.pause()
@@ -1291,6 +1757,11 @@ final class PlayerViewModel: ObservableObject {
         }
 
         let targetTime = CMTime(seconds: segment.endSeconds, preferredTimescale: CMTimeScale(NSEC_PER_SEC))
+        diag(.seek, [
+            PlayerDiagnostics.field("phase", "skip-segment"),
+            PlayerDiagnostics.field("segmentType", segment.type.rawValue),
+            PlayerDiagnostics.field("targetSeconds", segment.endSeconds)
+        ])
         player.seek(to: targetTime)
     }
 
@@ -1455,11 +1926,27 @@ final class PlayerViewModel: ObservableObject {
     }
 
     deinit {
+        PlayerDiagnostics.event(.deinitialized, [
+            PlayerDiagnostics.field("vm", sessionTag),
+            PlayerDiagnostics.field("reason", PlayerDiagnostics.TeardownReason.deallocated.rawValue)
+        ])
         progressReportTask?.cancel()
         subtitleLoadTask?.cancel()
         cleanupRemoteCommands()
         if let endObserver {
             NotificationCenter.default.removeObserver(endObserver)
+        }
+        // The diagnostics observers are block-based, so they outlive this
+        // object unless they are removed explicitly — same contract as
+        // endObserver above.
+        if let itemErrorLogObserver {
+            NotificationCenter.default.removeObserver(itemErrorLogObserver)
+        }
+        if let itemAccessLogObserver {
+            NotificationCenter.default.removeObserver(itemAccessLogObserver)
+        }
+        for observer in stallObservers {
+            NotificationCenter.default.removeObserver(observer)
         }
     }
 }


### PR DESCRIPTION
Fixes #348. **Do not merge yet** — see "What is still unverified".

Two deliverables: structured player diagnostics (the priority), and an investigation of the restart loop using what the instrumentation exposed.

---

## The production evidence, line by line

Captured live from the Jellyfin server while the Apple TV (tvOS 1.2.0) failed to play. For each line, what the new logging would have told us on the device:

| Server line | What it meant | What the device log now says |
|---|---|---|
| `18:59:36 ffmpeg ... -ss 00:50:27.524 -noaccurate_seek` | a transcode starting *at the resume point* — so a seek had already reached the server | `SASHIMI-PLAYER seek phase=post-ready-resume targetSeconds=3027.52 applied=true` — one line, with the target, and `startTimeTicksSentToServer=false` proving the offset came from a client seek and not from the PlaybackInfo request |
| `18:59:37 TranscodingJob: Stopping ffmpeg process with q command` | the client abandoned that transcode. Two client actions produce this: `DELETE /Videos/ActiveEncodings`, or a seek that lands outside the transcode window | `encoding.stop reason=<new-item\|quality-change\|user-stop\|view-disappeared> playSession=…` if it was a DELETE. If no `encoding.stop` line appears, it was a seek — and `seek cause=time-jumped positionSeconds=… seekableEnd=… loadedEnd=…` says where it landed relative to what the stream could actually serve |
| `18:59:38 ffmpeg ... -f matroska` | a *different* stream shape from the first (`m3u8` → `matroska`), i.e. a second negotiation, not a retry of the first | `pbinfo.request` / `pbinfo.response` / `stream.selected kind=<transcode-hls\|direct-stream\|direct-play-static> ext=mkv avplayerPlayableContainer=false`. Two `pbinfo.request` lines with different `attempt` values under one `vm` tag = one view model loading twice; two different `vm` tags = SwiftUI rebuilt the player. Those need different fixes and the server cannot tell them apart |
| `18:59:38 / 18:59:41 FFmpeg exited with code 0` | clean exits — the server never errored | `item.status`, `avlog.error`, `timecontrol status=waiting reason=…` say what AVPlayer was doing while the server was idle |
| session then vanished from `/Sessions` | last teardown | `teardown reason=… item=… playSession=…` plus `deinit vm=…` |
| earlier: mid-episode stall ~43 min, `"A task was canceled"` on `GET /videos/{id}` | client dropped the connection, no server error first | `avlog.access stallDetected=true numberOfStalls=N observedBitrate=… indicatedBitrate=…` and `tracks video=1 audio=2 videoEnabled=0 audioOnly=true` — the direct answer to "was it audio-only, or was the link too slow" |

---

## Deliverable 1 — the diagnostics

New `Shared/Services/PlayerDiagnostics.swift`. Subsystem `com.mondominator.sashimi`, category `player`, every line prefixed `SASHIMI-PLAYER`.

```
log stream --predicate 'subsystem == "com.mondominator.sashimi" AND category == "player"' --style compact
log show --last 30m --predicate 'subsystem == "com.mondominator.sashimi" AND category == "player"'
```

**Level policy.** Lifecycle events are `.notice` (os_log *default* level) — captured in Release with nothing enabled, and persisted so `log show` finds them after the fact. Failures are `.error`. Only the high-volume AVPlayerItem access-log sampling is `.debug`, which needs `log stream --level debug`. Verified on a booted simulator: default and error lines appear in `log show`; debug lines do not.

**What is covered**

- **loadMedia entry** — item id, type, `startFromBeginning`, offline?, whether a player already existed, previous item id.
- **Series/Season resolution** — `load.resolved resolved=true fromType=Series fromItem=… toItem=… via=next-up|first-unwatched|first-episode`, and a failure line when nothing resolves.
- **PlaybackInfo request** — requested bitrate, the effective cap, `capSource=explicit|measured|default`, the measured bitrate, local-vs-remote server, max width, `forceTranscode`, `forceDirectPlay`, `allowVideoStreamCopy`, `breakOnNonKeyFrames`. Reuses `JellyfinClient.bandwidthStatus` from the #341/#342 work, so the cap is now attached to the play attempt it belonged to instead of floating in a separate log category.
- **PlaybackInfo response** — media source id, play session id, container, `SupportsDirectPlay/DirectStream/Transcoding`, which URLs came back, codecs, source bitrate, resolution, and **transcode reasons** (`MediaSourceInfo.transcodeReasons` is newly decoded — it was being thrown away).
- **Stream selection** — which of the three URL branches was taken, plus `avplayerPlayableContainer`, a pure observation flagging a URL whose container AVPlayer has no demuxer for (`.mkv`).
- **AVPlayer setup** — asset creation, player creation, and *every* `AVPlayerItem.status` and `AVPlayer.status` transition including `.unknown` (an item that never leaves `.unknown` is a different bug from one that reaches `.failed`, and both look like a black screen). `.failed` logs the NSError domain/code plus any underlying domain/code.
- **AVPlayerItem error and access logs** — `errorStatusCode`, `errorDomain`, `errorComment`; `indicatedBitrate`, `observedBitrate`, `switchBitrate`, `numberOfStalls`, `numberOfDroppedVideoFrames`, `durationWatched`, `startupTime`, `playbackType`. A rising stall count is promoted from `.debug` to `.notice` so it survives into `log show`.
- **Seeks** — every one, including the ones this app never sees: `AVPlayerItem.timeJumpedNotification` catches transport-bar scrubs driven by `AVPlayerViewController`, which is the reproducer for the seek failure. Each logs position, the seekable range, the loaded range, `likelyToKeepUp`, `bufferEmpty` and the track summary — so "did the client seek beyond what the server had produced" is answerable.
- **Track availability once ready** — video/audio track counts, how many are *enabled*, presentation size, and an explicit `audioOnly=true`. Uses `AVPlayerItem.tracks`, not `asset.tracks`, because HLS exposes none on the asset.
- **Teardown** — every path names its reason (`user-stop`, `view-disappeared`, `new-item`, `quality-change`, `playback-ended`, `deallocated`). All three `stopActiveEncoding` call sites funnel through one helper that logs the reason and the play session before the DELETE.
- **View lifecycle** — `view.task` / `view.disappear` / `view.dismiss` with a per-presentation tag, and a per-instance `vm` tag plus an `attempt` counter on every view-model line.

**PII.** No stream URL is ever logged. `describe(url:)` keeps the path and the extension and reduces the query to a count — the query is dropped wholesale rather than filtered, because an allowlist leaks the day Jellyfin adds a parameter. System-supplied text goes through `scrub()`, which strips anything URL-shaped and any `api_key` / `token` / `password` parameter. 23 tests cover this. This also removes `attemptedURL`, a published property holding the full URL (api_key included) that nothing read.

---

## Deliverable 2 — the investigation

### Fixed: the resume position was applied twice, and the first one blocked startup

`loadMedia` did this on the resume path:

```swift
pendingResumeTicks = startTicks
await player?.seek(to: startTime)   // "best-effort; the status observer re-applies it"
```

Both halves are wrong.

1. **It awaited a seek completion inside startup.** Everything below it — `reportPlaybackStart`, `startProgressReporting`, `setupSegmentTracking`, `playbackStartDate`, and `play()` itself — was blocked behind a completion handler AVFoundation only promises to deliver when the seek finishes *or is superseded*, and which may not arrive at all if the item is replaced first. This exists only on the resume path, which matches the reported boundary exactly: **from the beginning works, resume does not.**

2. **It armed `pendingResumeTicks` as well**, so `applyPendingResumeSeekIfNeeded` seeked to the same position again on `.readyToPlay`. Its 3-second drift guard could not suppress the duplicate, because `player.currentTime()` is still 0 while the first seek is in flight. On a Jellyfin HLS session every client seek makes the server kill the running ffmpeg and restart it at the new offset — so two seeks a second apart produce precisely the captured `start → q command → start → q command` pattern.

The resume position is now applied exactly once, from `.readyToPlay`. `changeQuality` had the identical shape and got the identical treatment. The iOS offline path, which used to seek the player directly after `loadMedia` returned, now goes through `overrideResumePosition(ticks:)` so it cannot be undone by the ready-time seek.

### Not fixed, because it cannot be established from this repo's code: seeking in a stream-copied HLS stream

The user's triangle isolates it cleanly:

- 4K Auto (`IsVideoDirect=true`, video stream-copied, HEVC in fMP4 HLS) + no seek → **works**
- same + any seek (resume or fast-forward) → **breaks** (video freezes, audio continues)
- 1080p tier (`forceTranscode` → `AllowVideoStreamCopy=false` → real h264 re-encode) + seek → **works**

The double-seek fix above cannot be the cause of this, because fast-forward mid-playback reproduces it with a single seek, and because it does not reproduce on a re-encode.

**The leading hypothesis, and the client's part in it.** `JellyfinClient.videoDeviceProfile` sends `"BreakOnNonKeyFrames": true` in the HLS TranscodingProfile. That flag tells the server it may cut segments on non-key frames. With `-c:v copy` the server cannot *insert* key frames, so a segment can begin mid-GOP; a seek that lands on such a segment gives the decoder nothing to start from — video frozen, audio fine. Playing linearly from segment 0 never hits it because every preceding segment was decoded in order. A real re-encode gets forced key frames at segment boundaries, which is exactly the case that works.

That story fits every observation, but the part that would prove it is ffmpeg's behaviour on the server, not anything in this repo. So this PR does not change the flag. It does two things instead:

1. Logs it (`breakOnNonKeyFrames=…`, `allowVideoStreamCopy=…` on every `pbinfo.request`), and logs where seeks land relative to `seekableTimeRanges` / `loadedTimeRanges`, so one capture settles it.
2. Names it: `JellyfinClient.transcodingProfileBreaksOnNonKeyFrames`, with a comment explaining why it is a behavioural lever. Git history shows it was inherited wholesale from a copied jellyfin-web profile (it was on the old `getHLSStreamURL` deleted in #179) and was never added to fix anything here — so flipping it does not undo a known fix.

**The one-line experiment**, for whoever has hardware in front of them:

```diff
-    nonisolated static let transcodingProfileBreaksOnNonKeyFrames = true
+    nonisolated static let transcodingProfileBreaksOnNonKeyFrames = false
```

Play a 4K stream-copied item on Auto, seek, and check `SASHIMI-PLAYER tracks … videoEnabled=` after the seek. If this is the mechanism, `videoEnabled` goes from `0` to `1`. If it is not, the same log line says so and costs nothing.

### Ruled out

- **SwiftUI view churn.** `PlayerView` is presented from three sites (`MediaDetailView` `fullScreenCover(isPresented:)`, `HomeView` `fullScreenCover(item:)`, the deep-link cover in `SashimiApp`). `.task` has no `id:`, so it fires once per identity insert, and `@StateObject` survives body re-evaluation. Re-evaluating the cover's content does not re-run `loadMedia`. Not conclusive on its own, which is why the `vm`/`view`/`attempt` tags exist — if it ever does happen, one capture proves it.
- **A subtitle re-match triggering a second negotiation.** There is no such path in this codebase: subtitle selection goes to `SubtitleManager`, never back to `getPlaybackInfo`.
- **Retry-on-failure.** There is none; a failure sets `errorMessage` and stops.

### Noted, not changed

- `MediaDetailView.loadContent()` ends with `loadMediaInfo()`, a full `PlaybackInfo` POST for the same item, at the end of a long async chain. The comment at that call site already admits it "raced the real episode PlaybackInfo whenever the user pressed Play quickly"; #346 only gated it for series. It creates a second server play session, and it does not start ffmpeg, so it is not this bug — but it is noise in every capture and worth removing on its own.
- The `directStreamUrl` branch in `setupPlayer` hands AVPlayer whatever container the server names, with no check. For an mkv source that is a stream AVPlayer cannot demux. Logged (`avplayerPlayableContainer=false`) rather than gated, because failing the branch closed would change playback behaviour with no way to verify it here.

---

## Verification

- SwiftLint strict: **0 violations in 66 files**.
- `xcodebuild -scheme Sashimi -destination 'platform=tvOS Simulator,name=sashimi-verify'` → **BUILD SUCCEEDED**
- `xcodebuild -scheme SashimiMobile -destination 'platform=iOS Simulator,name=iPhone 17'` → **BUILD SUCCEEDED**
- `xcodebuild test` (tvOS) → **194 tests, 0 failures** (23 new).
- The log pipeline was exercised end to end on a booted simulator, not assumed: `log show` returns `SASHIMI-PLAYER load.begin item=abc url=<url-redacted>` — the redaction works against the real os_log path, and default/error lines appear while `.debug` lines do not.

## What is still unverified

- **Nothing here has run on an Apple TV or against a real Jellyfin server.** All builds and tests are simulator/unit only.
- **The resume fix is not proven to fix the user's failure.** It is proven to remove a duplicate seek and an await that blocked startup. Whether that alone restores resume on 4K Auto needs hardware — and given that fast-forward reproduces the same failure with a single seek, it probably does not, on its own.
- **The new tests do not prove the fix.** They cover `PlayerDiagnostics` (redaction, field rendering, status naming, track summary, the greppable vocabulary) and the new `transcodeReasons` decoding. The seek change is inside `loadMedia`, which reaches the network and AVFoundation with no seam to inject; there is no test in this repo that would fail on the old code for it. Said plainly rather than dressed up.
- **`BreakOnNonKeyFrames` is a hypothesis, not a diagnosis.** It is not changed here.
- The AVPlayerItem access/error-log observers, the time-jump observer and the track summary have never fired against a real stream — only the emit path is exercised by tests.
- No measurement of the logging's overhead during playback. The volume is bounded (lifecycle events are one-shot; the per-entry access log is `.debug`), but that is reasoning, not a measurement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XzUNvRCXML3DJe98KBCGkN
