### PR TITLE
Stop segmenting HLS on non-key frames so seeking works on stream-copied video

### DIFF
--- a/Shared/Services/JellyfinClient.swift
+++ b/Shared/Services/JellyfinClient.swift
@@ -810,17 +810,21 @@ actor JellyfinClient {
     }
 
     /// Whether the HLS TranscodingProfile lets the server cut segments on
-    /// non-key frames.
+    /// non-key frames. **False, deliberately.**
     ///
-    /// Named rather than inlined below because it is a real behavioural lever
-    /// and the player's diagnostics record it with every negotiation: when the
-    /// server STREAM-COPIES the video (`IsVideoDirect`) it cannot insert key
-    /// frames, so with this enabled a segment can begin mid-GOP — which is the
-    /// leading hypothesis for seeking failing on stream-copied 4K while a real
-    /// re-encode (an explicit quality tier) seeks fine. Changing it is a
-    /// server-behaviour experiment, so it is deliberately left as-is here and
-    /// only made observable.
-    nonisolated static let transcodingProfileBreaksOnNonKeyFrames = true
+    /// With `-c:v copy` the server cannot insert key frames,
+    /// so segmenting on non-key frames yields segments that begin mid-GOP: a
+    /// seek hands the decoder a segment it cannot start from, and video freezes
+    /// while audio continues. Confirmed in production 2026-08-03 — seeking broke
+    /// on 4K stream-copied HEVC, worked on a re-encoded 1080p tier, and worked at
+    /// position zero with no seek. Each failed seek made the client tear down and
+    /// re-request, the ffmpeg start/kill storm captured server-side.
+    ///
+    /// This was never chosen for this app: it arrived in a file-move commit
+    /// (126ffaa, iPad extraction) copied from jellyfin-web, so turning it off
+    /// undoes nothing that was added to fix a problem here. The player's
+    /// diagnostics record it with every negotiation.
+    nonisolated static let transcodingProfileBreaksOnNonKeyFrames = false
 
     /// The device profile sent with every PlaybackInfo request: what this
     /// client can play natively, and the ceilings the server must respect.


### PR DESCRIPTION
Seeking froze the video (audio continuing) whenever the server stream-copied the video track into fMP4 HLS — which Auto quality picks for most 4K HEVC in this library.

## Evidence (live production server, 2026-08-03)

| Case | Seek |
|---|---|
| 4K, video stream-copied (`IsVideoDirect=true`, fMP4 HLS) | **freezes** |
| 4K stream-copied, no seeking at all | plays fine start to finish |
| 1080p tier (`forceTranscode` → real h264 re-encode) | **works** |

Server log during a failed seek — one seek, five transcodes:
```
19:26:12 ffmpeg starts  → Stopping ffmpeg process with q command
19:26:13 ffmpeg starts  → Stopping ffmpeg process with q command
19:26:16 ffmpeg starts  → Stopping ffmpeg process with q command
19:26:19 ffmpeg starts  → FFmpeg exited with code 0
```
The earlier failed attempt carried `-ss 00:50:27.524`, the resume point.

## Mechanism

With `-c:v copy` ffmpeg cannot insert key frames. `BreakOnNonKeyFrames` then lets segments cut mid-GOP, so a seek lands the decoder on a segment with no I-frame to start from: video freezes, audio (re-encoded or copied independently) keeps going. The client treats the stall as a failure, tears down and re-requests, and the loop repeats. A real re-encode gets forced key frames at segment boundaries, which is why the 1080p tier seeks cleanly.

## Why this is safe to change

`BreakOnNonKeyFrames` was never chosen for this app. `git log -S` puts its introduction in **126ffaa**, a file-move commit ("Add iPad app target and extract shared code"), copied from a jellyfin-web profile. No commit added it to fix a playback problem here, so removing it cannot regress one.

## Verification

SwiftLint strict clean; tvOS BUILD SUCCEEDED on `sashimi-verify`; 195 tests pass.

**Not verified:** no Apple TV run against a real server. This is a server-behaviour lever — the proof is whether seeking works on a stream-copied 4K item after this ships, and PR #349's `SASHIMI-PLAYER` diagnostics now log the flag with every negotiation plus where each seek lands relative to the seekable range, so the next attempt is observable either way.