### PR TITLE
Bump MARKETING_VERSION to 1.2.1 and document the release step

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -302,3 +302,20 @@ cd Sashimi/Resources/Assets.xcassets
 cp -r CatIcon.imagestack MyIcon.imagestack
 # Then replace the icon.png and icon@2x.png files in each layer
 ```
+
+## Releasing: bump MARKETING_VERSION every TestFlight build
+
+`MARKETING_VERSION` is hardcoded in **`project.yml`** in three places (tvOS, iOS,
+and the shared target) — `xcodegen` writes it into the pbxproj, so editing the
+pbxproj directly is pointless. Fastlane only auto-increments the *build* number
+(epoch seconds); nothing touches the marketing version.
+
+**Bump all three before triggering a TestFlight deploy.** Shipping several builds
+under one version makes them indistinguishable in TestFlight and in Jellyfin's
+`ApplicationVersion` — during the 2026-08-03 playback investigation three builds
+all reported `1.2.0`, so neither the user nor the server logs could say which
+code was running while a fix was being tested.
+
+```bash
+sed -i '' 's/MARKETING_VERSION: 1\.2\.0/MARKETING_VERSION: 1.2.1/g' project.yml
+```

--- a/project.yml
+++ b/project.yml
@@ -66,7 +66,7 @@ targets:
     settings:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.mondominator.sashimi
-        MARKETING_VERSION: 1.2.0
+        MARKETING_VERSION: 1.2.1
         CURRENT_PROJECT_VERSION: 2
         SWIFT_VERSION: 5.9
         SDKROOT: appletvos
@@ -144,7 +144,7 @@ targets:
         # Shared bundle ID with the tvOS app for Universal Purchase (one "Sashimi"
         # app spanning Apple TV + iPhone + iPad). Distinguished by platform.
         PRODUCT_BUNDLE_IDENTIFIER: com.mondominator.sashimi
-        MARKETING_VERSION: 1.2.0
+        MARKETING_VERSION: 1.2.1
         CURRENT_PROJECT_VERSION: 1
         SWIFT_VERSION: 5.9
         SDKROOT: iphoneos
@@ -186,7 +186,7 @@ targets:
     settings:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.mondominator.sashimi.topshelf
-        MARKETING_VERSION: 1.2.0
+        MARKETING_VERSION: 1.2.1
         CURRENT_PROJECT_VERSION: 2
         SWIFT_VERSION: 5.9
         SDKROOT: appletvos


### PR DESCRIPTION
Three TestFlight builds went out on 2026-08-03 — logo/UX changes, the series-id PlaybackInfo fix, and the seek fix — and **all three reported version 1.2.0**. Neither TestFlight nor Jellyfin`&#39;`s `ApplicationVersion` field could distinguish them, so while testing whether a playback fix had landed there was no way to confirm which build was installed.

Fastlane auto-increments only the build number (epoch seconds). `MARKETING_VERSION` is hardcoded in `project.yml` in three places and is never touched.

- Bumps all three to **1.2.1**
- Adds a release section to CLAUDE.md so the bump is part of the deploy step rather than something rediscovered