### PR TITLE
Remove BreakOnNonKeyFrames — the server has ignored it since 2019

### DIFF
--- a/Shared/Services/JellyfinClient.swift
+++ b/Shared/Services/JellyfinClient.swift
@@ -810,21 +810,6 @@ actor JellyfinClient {
     }
 
     /// Whether the HLS TranscodingProfile lets the server cut segments on
-    /// non-key frames. **False, deliberately.**
-    ///
-    /// With `-c:v copy` the server cannot insert key frames,
-    /// so segmenting on non-key frames yields segments that begin mid-GOP: a
-    /// seek hands the decoder a segment it cannot start from, and video freezes
-    /// while audio continues. Confirmed in production 2026-08-03 — seeking broke
-    /// on 4K stream-copied HEVC, worked on a re-encoded 1080p tier, and worked at
-    /// position zero with no seek. Each failed seek made the client tear down and
-    /// re-request, the ffmpeg start/kill storm captured server-side.
-    ///
-    /// This was never chosen for this app: it arrived in a file-move commit
-    /// (126ffaa, iPad extraction) copied from jellyfin-web, so turning it off
-    /// undoes nothing that was added to fix a problem here. The player's
-    /// diagnostics record it with every negotiation.
-    nonisolated static let transcodingProfileBreaksOnNonKeyFrames = false
 
     /// The device profile sent with every PlaybackInfo request: what this
     /// client can play natively, and the ceilings the server must respect.
@@ -856,7 +841,6 @@ actor JellyfinClient {
                     "Context": "Streaming",
                     "MaxAudioChannels": "6",
                     "MinSegments": "2",
-                    "BreakOnNonKeyFrames": Self.transcodingProfileBreaksOnNonKeyFrames
                 ]
             ],
             "ContainerProfiles": [],

--- a/Shared/ViewModels/PlayerViewModel.swift
+++ b/Shared/ViewModels/PlayerViewModel.swift
@@ -986,12 +986,12 @@ final class PlayerViewModel: ObservableObject {
             PlayerDiagnostics.field("maxWidth", maxWidth),
             PlayerDiagnostics.field("forceTranscode", forceTranscode),
             PlayerDiagnostics.field("forceDirectPlay", playbackSettings.forceDirectPlay),
-            // The two request flags that decide whether the server may
-            // stream-COPY the video into HLS or must re-encode it, and whether
-            // it may cut segments mid-GOP. Seeking behaves differently in each
-            // combination, and none of it was visible from the client before.
-            PlayerDiagnostics.field("allowVideoStreamCopy", !forceTranscode),
-            PlayerDiagnostics.field("breakOnNonKeyFrames", JellyfinClient.transcodingProfileBreaksOnNonKeyFrames)
+            // Whether the server may stream-COPY the video into HLS or must
+            // re-encode it. This is the flag that decides whether seeking works:
+            // on a copy, Jellyfin's playlist grid and its restarted ffmpeg's
+            // segment grid diverge after any seek (jellyfin#16070, #4188), so
+            // the decoder is handed segments the playlist mislabels.
+            PlayerDiagnostics.field("allowVideoStreamCopy", !forceTranscode)
         ])
 
         let playbackInfo = try await client.getPlaybackInfo(


### PR DESCRIPTION
Reverts a change I made last night that claimed to fix seeking on stream-copied video. **It fixes nothing.**

Jellyfin forces the flag false at the top of `GetCommandLineArguments`, on every version we target (verified in v10.8.13, v10.9.11, v10.10.7, v10.11.0):

```csharp
if (state.BaseRequest.BreakOnNonKeyFrames)
{
    // FIXME: this is actually a workaround, as ideally it really should be the client which decides
    //        whether non-keyframe breakpoints are supported; but current implementation always uses
    //        "ffmpeg input seeking" which is liable to produce a missing part of video stream before
    //        first keyframe is encountered, which may lead to awkward cases like a few starting HLS
    //        segments having no video whatsoever, which breaks hls.js
    _logger.LogInformation("Current HLS implementation doesn't support non-keyframe breaks but one is requested, ignoring that request");
    state.BaseRequest.BreakOnNonKeyFrames = false;
}
```

Both downstream consumers sit below that reset, so the flag has been **fully inert for HLS since PR #1659 (2019)**. PR #15926 removes the option entirely in 12.0 with the note that clients should stop sending it.

## The actual mechanism

For a stream-copy, `DynamicHlsPlaylistGenerator` builds the playlist from the source file's own keyframes as an **absolute grid from t=0**. On a seek, `GetDynamicSegment` kills ffmpeg and restarts it at the new position — and the restarted process numbers segments from **its own** start. The two grids coincide only at zero.

That is why linear playback is flawless and every seek fails, and why forcing a re-encode works: ffmpeg then emits `-force_key_frames` on exactly the equal-length grid the playlist advertises.

Upstream: [jellyfin#16070](https://github.com/jellyfin/jellyfin/issues/16070) (open), [jellyfin#4188](https://github.com/jellyfin/jellyfin/issues/4188) (reconfirmed on 10.11: *"If I force full transcoding, the video unfreezes"*).

## Changes
- Delete the constant, its doc block, and the `BreakOnNonKeyFrames` profile key
- Delete the diagnostics field that recorded it, and point the neighbouring comment at the real mechanism

No behavioural change — the server was already ignoring it. This removes a comment that would have misdirected the next investigation.