### PR TITLE
feat: YouTube badge on Continue Watching cards (tvOS + iOS)

### DIFF
--- a/Sashimi/Views/Home/ContinueWatchingRow.swift
+++ b/Sashimi/Views/Home/ContinueWatchingRow.swift
@@ -122,6 +122,12 @@ struct ContinueWatchingCard: View {
                         )
                     )
                     .clipShape(RoundedRectangle(cornerRadius: 16))
+                    .overlay(alignment: .topLeading) {
+                        if isYouTube {
+                            YouTubeBadge()
+                                .padding(10)
+                        }
+                    }
 
                     VStack(alignment: .leading, spacing: 10) {
                         HStack(spacing: 10) {

--- a/SashimiMobile/Views/Components/MobileContinueWatchingCard.swift
+++ b/SashimiMobile/Views/Components/MobileContinueWatchingCard.swift
@@ -152,6 +152,12 @@ struct MobileContinueWatchingCard: View {
             }
             .frame(width: width, height: height)
             .clipShape(RoundedRectangle(cornerRadius: MobileCornerRadius.large))
+            .overlay(alignment: .topLeading) {
+                if isYouTube {
+                    YouTubeBadge(fontSize: 11, horizontalPadding: 6, verticalPadding: 3)
+                        .padding(8)
+                }
+            }
 
             // Title and episode info
             VStack(alignment: .leading, spacing: 3) {

--- a/Shared/Views/YouTubeBadge.swift
+++ b/Shared/Views/YouTubeBadge.swift
@@ -1,0 +1,33 @@
+import SwiftUI
+
+/// YouTube identifier chip for cover art (top-left corner) — the red
+/// `play.rectangle.fill` glyph the home hero already uses, in a compact pill so
+/// a YouTube video in a landscape card (Continue Watching) reads as YouTube the
+/// same way the hero does. Channel cards render as circular art and don't need
+/// it. Sizing is parameterized so the 10-ft tvOS card can render larger than the
+/// compact iOS card while keeping identical styling.
+struct YouTubeBadge: View {
+    var fontSize: CGFloat = 15
+    var showWordmark: Bool = true
+    var horizontalPadding: CGFloat = 8
+    var verticalPadding: CGFloat = 4
+
+    /// YouTube brand red, matching the home hero badge.
+    private static let youTubeRed = Color(red: 230 / 255, green: 33 / 255, blue: 23 / 255)
+
+    var body: some View {
+        HStack(spacing: 5) {
+            Image(systemName: "play.rectangle.fill")
+            if showWordmark {
+                Text("YouTube")
+            }
+        }
+        .font(.system(size: fontSize, weight: .semibold))
+        .foregroundStyle(YouTubeBadge.youTubeRed)
+        .padding(.horizontal, horizontalPadding)
+        .padding(.vertical, verticalPadding)
+        .background(Color.black.opacity(0.6))
+        .clipShape(Capsule())
+        .shadow(color: .black.opacity(0.35), radius: 2, y: 1)
+    }
+}


### PR DESCRIPTION
Parity with Roku v1.2.5, which badges YouTube videos in Continue Watching.
On Apple the red "YouTube" badge was hero-only; a YouTube video in a CW
landscape card (channels render circular and don't need it) had no marker,
so a resumed YouTube video read like any other episode.

New shared Shared/Views/YouTubeBadge.swift — the hero's play.rectangle.fill
red glyph in a compact pill — overlaid top-leading on the CW card image when
isYouTube (tvOS ContinueWatchingCard, iOS MobileContinueWatchingCard).
Detection is unchanged: both already resolve the item's owning library via
the ancestors endpoint and check the library name, so a suffix-less Pinchflat
channel is badged correctly.

tvOS + iOS build; SwiftLint strict clean. Not exercised on hardware (needs a
real server + YouTube library); the badge is a pure overlay gated on the
existing isYouTube flag.

Fixes #355

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01XzUNvRCXML3DJe98KBCGkN
