### PR TITLE
fix: MKV seek via forced re-encode + hero UX (badge, dots, description)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -64,3 +64,4 @@ Thumbs.db
 *.mobileprovision
 *.provisionprofile
 .aider*
+Vendor/

--- a/Sashimi/Views/Home/HomeView.swift
+++ b/Sashimi/Views/Home/HomeView.swift
@@ -430,7 +430,7 @@ struct HeroSection: View {
                             Text(overview)
                                 .font(.system(size: 22))
                                 .foregroundStyle(.white.opacity(0.75))
-                                .lineLimit(2)
+                                .lineLimit(3)
                                 .frame(maxWidth: 800, alignment: .leading)
                                 .padding(.top, 4)
                         }
@@ -456,6 +456,7 @@ struct HeroSection: View {
                                     .animation(.easeInOut(duration: 0.3), value: safeIndex)
                                 }
                             }
+                            .frame(maxWidth: .infinity, alignment: .center)
                             .padding(.top, 16)
                         }
 

--- a/SashimiMobile/Views/Components/MobileContinueWatchingCard.swift
+++ b/SashimiMobile/Views/Components/MobileContinueWatchingCard.swift
@@ -154,7 +154,7 @@ struct MobileContinueWatchingCard: View {
             .clipShape(RoundedRectangle(cornerRadius: MobileCornerRadius.large))
             .overlay(alignment: .topLeading) {
                 if isYouTube {
-                    YouTubeBadge(fontSize: 11, horizontalPadding: 6, verticalPadding: 3)
+                    YouTubeBadge(glyphSize: 20)
                         .padding(8)
                 }
             }

--- a/Shared/Services/JellyfinClient.swift
+++ b/Shared/Services/JellyfinClient.swift
@@ -1017,11 +1017,18 @@ actor JellyfinClient {
             "EnableDirectPlay": !forceTranscode,
             "EnableDirectStream": !effectiveForceDirectPlay && !forceTranscode,
             "EnableTranscoding": !effectiveForceDirectPlay,
-            // The real reason picking a tier did nothing: with video stream copy
-            // allowed, the server satisfied a "transcode" by remuxing the
-            // original video untouched (IsVideoDirect=true) whenever the source
-            // already fit under the bitrate cap. An explicit pick must re-encode.
-            "AllowVideoStreamCopy": !forceTranscode,
+            // Never allow video stream-copy. AVPlayer can't demux MKV, so an MKV
+            // goes through HLS; when the server stream-COPIES the video into that
+            // HLS (IsVideoDirect=true), its playlist grid and the restarted
+            // ffmpeg's segment grid diverge after any seek, freezing the picture
+            // (jellyfin#16070, #4188). Forcing a genuine re-encode makes ffmpeg
+            // manufacture keyframes on the advertised grid, so seeking works. The
+            // cost is real — the server re-encodes (CPU) and Dolby Vision dynamic
+            // metadata is lost (HDR10 base at best) on MKV titles — but seek is
+            // otherwise broken. MP4/M4V/MOV direct-play and never reach this path,
+            // so they are unaffected. (Also makes explicit quality tiers real
+            // re-encodes rather than no-op remuxes.)
+            "AllowVideoStreamCopy": false,
             "AllowAudioStreamCopy": true,
             "AutoOpenLiveStream": true
         ]

--- a/Shared/ViewModels/PlayerViewModel.swift
+++ b/Shared/ViewModels/PlayerViewModel.swift
@@ -986,12 +986,10 @@ final class PlayerViewModel: ObservableObject {
             PlayerDiagnostics.field("maxWidth", maxWidth),
             PlayerDiagnostics.field("forceTranscode", forceTranscode),
             PlayerDiagnostics.field("forceDirectPlay", playbackSettings.forceDirectPlay),
-            // Whether the server may stream-COPY the video into HLS or must
-            // re-encode it. This is the flag that decides whether seeking works:
-            // on a copy, Jellyfin's playlist grid and its restarted ffmpeg's
-            // segment grid diverge after any seek (jellyfin#16070, #4188), so
-            // the decoder is handed segments the playlist mislabels.
-            PlayerDiagnostics.field("allowVideoStreamCopy", !forceTranscode)
+            // Video stream-copy is now always disabled (see getPlaybackInfo):
+            // a stream-copied MKV's HLS grid diverges on seek and freezes, so we
+            // force a re-encode to make seeking work (jellyfin#16070, #4188).
+            PlayerDiagnostics.field("allowVideoStreamCopy", false)
         ])
 
         // Phase 1 of the VLC work: the profile can be VLC-shaped for

--- a/Shared/Views/YouTubeBadge.swift
+++ b/Shared/Views/YouTubeBadge.swift
@@ -1,33 +1,37 @@
 import SwiftUI
 
-/// YouTube identifier chip for cover art (top-left corner) — the red
-/// `play.rectangle.fill` glyph the home hero already uses, in a compact pill so
-/// a YouTube video in a landscape card (Continue Watching) reads as YouTube the
-/// same way the hero does. Channel cards render as circular art and don't need
-/// it. Sizing is parameterized so the 10-ft tvOS card can render larger than the
-/// compact iOS card while keeping identical styling.
+/// YouTube identifier for cover art (top-left corner) — the red
+/// `play.rectangle.fill` glyph, matching the home hero. On cards it's the glyph
+/// alone (no wordmark), like the Roku badge, so a YouTube video in a landscape
+/// card (Continue Watching) reads as YouTube without a bulky label. Channel
+/// cards render as circular art and don't need it. `showWordmark` is opt-in for
+/// contexts that want the full "YouTube" pill.
 struct YouTubeBadge: View {
-    var fontSize: CGFloat = 15
-    var showWordmark: Bool = true
-    var horizontalPadding: CGFloat = 8
-    var verticalPadding: CGFloat = 4
+    var glyphSize: CGFloat = 26
+    var showWordmark: Bool = false
 
     /// YouTube brand red, matching the home hero badge.
     private static let youTubeRed = Color(red: 230 / 255, green: 33 / 255, blue: 23 / 255)
 
     var body: some View {
-        HStack(spacing: 5) {
-            Image(systemName: "play.rectangle.fill")
-            if showWordmark {
+        if showWordmark {
+            HStack(spacing: 5) {
+                Image(systemName: "play.rectangle.fill")
                 Text("YouTube")
             }
+            .font(.system(size: glyphSize * 0.6, weight: .semibold))
+            .foregroundStyle(YouTubeBadge.youTubeRed)
+            .padding(.horizontal, 8).padding(.vertical, 4)
+            .background(Color.black.opacity(0.6))
+            .clipShape(Capsule())
+            .shadow(color: .black.opacity(0.35), radius: 2, y: 1)
+        } else {
+            // Glyph only. A drop shadow keeps it legible over bright thumbnails
+            // without a pill; play.rectangle.fill already reads as the YouTube mark.
+            Image(systemName: "play.rectangle.fill")
+                .font(.system(size: glyphSize))
+                .foregroundStyle(YouTubeBadge.youTubeRed)
+                .shadow(color: .black.opacity(0.6), radius: 3, y: 1)
         }
-        .font(.system(size: fontSize, weight: .semibold))
-        .foregroundStyle(YouTubeBadge.youTubeRed)
-        .padding(.horizontal, horizontalPadding)
-        .padding(.vertical, verticalPadding)
-        .background(Color.black.opacity(0.6))
-        .clipShape(Capsule())
-        .shadow(color: .black.opacity(0.35), radius: 2, y: 1)
     }
 }

--- a/project.yml
+++ b/project.yml
@@ -66,7 +66,7 @@ targets:
     settings:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.mondominator.sashimi
-        MARKETING_VERSION: 1.2.2
+        MARKETING_VERSION: 1.2.3
         CURRENT_PROJECT_VERSION: 2
         SWIFT_VERSION: 5.9
         SDKROOT: appletvos
@@ -144,7 +144,7 @@ targets:
         # Shared bundle ID with the tvOS app for Universal Purchase (one "Sashimi"
         # app spanning Apple TV + iPhone + iPad). Distinguished by platform.
         PRODUCT_BUNDLE_IDENTIFIER: com.mondominator.sashimi
-        MARKETING_VERSION: 1.2.2
+        MARKETING_VERSION: 1.2.3
         CURRENT_PROJECT_VERSION: 1
         SWIFT_VERSION: 5.9
         SDKROOT: iphoneos
@@ -186,7 +186,7 @@ targets:
     settings:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.mondominator.sashimi.topshelf
-        MARKETING_VERSION: 1.2.2
+        MARKETING_VERSION: 1.2.3
         CURRENT_PROJECT_VERSION: 2
         SWIFT_VERSION: 5.9
         SDKROOT: appletvos


### PR DESCRIPTION
MKV seek: after the VLCKit Phase 2 hardware test showed VLC direct-play is
worse for this DV library (software-decoded HEVC → choppy + ~80s seeks +
DV→HDR10), fix seek on the AVPlayer path instead of switching engines.
Disable video stream-copy: a stream-copied MKV's HLS playlist grid and the
restarted ffmpeg's segment grid diverge on seek and freeze the picture
(jellyfin#16070, #4188); forcing a real re-encode makes ffmpeg manufacture
keyframes on the advertised grid, so seeking works. Cost: server re-encode
(QSV) + Dolby Vision dynamic metadata lost on MKV titles; MP4/M4V/MOV
direct-play and are unaffected. Device-verified.

Hero/badge UX (Roku parity, all user-approved on device):
- YouTubeBadge reworked to a red logo glyph by default (no "YouTube"
  wordmark); tvOS + iOS Continue Watching cards use it.
- Home hero page dots centered (were hard-left).
- Home hero description raised to 3 lines (was cut short at 2).

Bumps MARKETING_VERSION 1.2.2 -> 1.2.3. tvOS + iOS build, 210 tests pass,
SwiftLint strict clean.

Fixes #358

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01XzUNvRCXML3DJe98KBCGkN
