### PR TITLE
fix: tvOS forces 4K re-encode to HEVC, not undecodable H.264 (Oppenheimer crash)

### DIFF
--- a/SashimiTests/PlaybackEngineProfileTests.swift
+++ b/SashimiTests/PlaybackEngineProfileTests.swift
@@ -71,6 +71,24 @@ final class PlaybackEngineProfileTests: XCTestCase {
         XCTAssertTrue(embedded.contains { ($0["Format"] as? String) == "pgssub" }, "image subs must be Embed to avoid burn-in transcode")
     }
 
+    // MARK: - Forced re-encode must target a codec the Apple TV can decode at 4K
+
+    /// `AllowVideoStreamCopy` is false (getPlaybackInfo), so an MKV always
+    /// re-encodes. The Apple TV cannot decode 4K H.264 — it caps H.264 at 1080p;
+    /// 4K needs HEVC — so the transcoding profile must offer HEVC FIRST. With
+    /// H.264 first, the server emits undecodable 4K H.264: black picture, then a
+    /// transcode restart storm and crash (the v1.2.3 Oppenheimer regression).
+    /// HEVC first makes the forced re-encode produce 4K HEVC, which decodes
+    /// natively (requires the server's AllowHevcEncoding to be enabled).
+    func testAVFoundationTranscodeProfilePrefersHEVC() async {
+        let client = JellyfinClient.shared
+        let profile = await client.videoDeviceProfile(engine: .avFoundation, streamingBitrate: 120_000_000, maxWidth: nil)
+        let transcoding = (profile["TranscodingProfiles"] as? [[String: Any]]) ?? []
+        XCTAssertFalse(transcoding.isEmpty)
+        XCTAssertEqual(transcoding.first?["VideoCodec"] as? String, "hevc,h264",
+            "Forced re-encode must prefer HEVC; H.264-first yields undecodable 4K H.264 on Apple TV")
+    }
+
     // MARK: - Width condition applies to both engines
 
     func testWidthConditionPresentWhenMaxWidthGiven() async {

--- a/Shared/Services/JellyfinClient.swift
+++ b/Shared/Services/JellyfinClient.swift
@@ -861,10 +861,18 @@ actor JellyfinClient {
                     // DV supplemental codec) that AVPlayer actually renders.
                     "Container": "mp4",
                     "Type": "Video",
-                    // tvOS plays HEVC and EAC3 in HLS natively — declaring
-                    // them lets mkv remuxes stream-copy both tracks instead
-                    // of re-encoding video / downmixing EAC3 5.1 to AAC.
-                    "VideoCodec": "h264,hevc",
+                    // HEVC is listed FIRST, and that order matters: because
+                    // getPlaybackInfo sends AllowVideoStreamCopy=false, an mkv
+                    // always RE-ENCODES rather than stream-copying. The Apple TV
+                    // cannot decode 4K H.264 (it caps H.264 at 1080p; 4K needs
+                    // HEVC), so an h264-first list made the server emit
+                    // undecodable 4K H.264 — black picture, transcode restart
+                    // storm, crash (the v1.2.3 Oppenheimer regression). HEVC
+                    // first makes the forced re-encode produce 4K HEVC, which
+                    // decodes natively and seeks. This requires the server's
+                    // AllowHevcEncoding to be ON; with it off the server falls
+                    // back to H.264 and 4K sources break again.
+                    "VideoCodec": "hevc,h264",
                     "AudioCodec": "aac,ac3,eac3",
                     "Protocol": "hls",
                     "Context": "Streaming",
@@ -1023,11 +1031,14 @@ actor JellyfinClient {
             // ffmpeg's segment grid diverge after any seek, freezing the picture
             // (jellyfin#16070, #4188). Forcing a genuine re-encode makes ffmpeg
             // manufacture keyframes on the advertised grid, so seeking works. The
-            // cost is real — the server re-encodes (CPU) and Dolby Vision dynamic
-            // metadata is lost (HDR10 base at best) on MKV titles — but seek is
-            // otherwise broken. MP4/M4V/MOV direct-play and never reach this path,
-            // so they are unaffected. (Also makes explicit quality tiers real
-            // re-encodes rather than no-op remuxes.)
+            // cost is real — the server re-encodes (CPU) and HDR/Dolby Vision is
+            // lost (tonemapped to SDR) on MKV titles — but seek is otherwise
+            // broken. The re-encode MUST target HEVC (the device profile lists
+            // hevc first) so 4K stays decodable on the Apple TV, which requires
+            // the server's AllowHevcEncoding to be ON; an h264 re-encode of a 4K
+            // source is undecodable there. MP4/M4V/MOV direct-play and never
+            // reach this path, so they are unaffected. (Also makes explicit
+            // quality tiers real re-encodes rather than no-op remuxes.)
             "AllowVideoStreamCopy": false,
             "AllowAudioStreamCopy": true,
             "AutoOpenLiveStream": true

--- a/project.yml
+++ b/project.yml
@@ -66,7 +66,7 @@ targets:
     settings:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.mondominator.sashimi
-        MARKETING_VERSION: 1.2.3
+        MARKETING_VERSION: 1.2.4
         CURRENT_PROJECT_VERSION: 2
         SWIFT_VERSION: 5.9
         SDKROOT: appletvos
@@ -144,7 +144,7 @@ targets:
         # Shared bundle ID with the tvOS app for Universal Purchase (one "Sashimi"
         # app spanning Apple TV + iPhone + iPad). Distinguished by platform.
         PRODUCT_BUNDLE_IDENTIFIER: com.mondominator.sashimi
-        MARKETING_VERSION: 1.2.3
+        MARKETING_VERSION: 1.2.4
         CURRENT_PROJECT_VERSION: 1
         SWIFT_VERSION: 5.9
         SDKROOT: iphoneos
@@ -186,7 +186,7 @@ targets:
     settings:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.mondominator.sashimi.topshelf
-        MARKETING_VERSION: 1.2.3
+        MARKETING_VERSION: 1.2.4
         CURRENT_PROJECT_VERSION: 2
         SWIFT_VERSION: 5.9
         SDKROOT: appletvos


### PR DESCRIPTION
## Hotfix: 4K HEVC titles (e.g. Oppenheimer) crash on Apple TV under v1.2.3

### Symptom
On v1.2.3-beta1, Oppenheimer (a 4K HDR10 HEVC MKV remux) crashes, loses the resume position, then errors on retry.

### Root cause (verified against the live Jellyfin)
v1.2.3 (#359) shipped Option 2 — `AllowVideoStreamCopy: false` — which forces every MKV to **re-encode** instead of stream-copying. But the tvOS `TranscodingProfiles` listed `VideoCodec: "h264,hevc"` (h264 first), so the server re-encoded the 4K source to **4K H.264**. The Apple TV **cannot decode 4K H.264** (it caps H.264 at 1080p; 4K requires HEVC), so AVPlayer got an undecodable stream → cancelled segments → the server spawned a fresh transcode each time (**30 ffmpeg processes in ~5 min**, confirmed in the server logs) → crash, no stable progress saved → lost place.

The server also had `AllowHevcEncoding: false`, so it *couldn't* emit HEVC even if asked.

### Fix
- **App:** list HEVC first — `VideoCodec: "hevc,h264"` — so the forced re-encode targets HEVC. Verified on the live server: the ffmpeg process now spawns `hevc_qsv` at native 4K (was `h264_qsv`). Plays + seeks; HDR is tonemapped to SDR on MKV re-encodes, as already accepted for the seek fix.
- **Server (already applied):** enabled `AllowHevcEncoding` on the popcorn Jellyfin (with backup) so it can emit HEVC. The app comment documents this dependency.

### Tests
Added `testAVFoundationTranscodeProfilePrefersHEVC` guarding the HEVC-first order. Passes locally; full suite/build via CI.

### Not device-verified yet
The server-side transcode is confirmed HEVC-at-4K, but on-device playback of Oppenheimer on the Apple TV will be verified once this build reaches TestFlight (v1.2.4-beta1).
