### PR TITLE
fix: constrained link targets smooth 1080p instead of stuttery 4K re-encode

### DIFF
--- a/SashimiTests/PlaybackSelectionTests.swift
+++ b/SashimiTests/PlaybackSelectionTests.swift
@@ -118,6 +118,37 @@ final class PlaybackSelectionTests: XCTestCase {
         XCTAssertEqual(PlaybackSelection.autoMaxWidth(forBitrateCap: 3_000_000), 854)
     }
 
+    // MARK: - constrainedAutoOverride
+
+    func testConstrainedLinkTargets1080p() {
+        // The bedroom Wi-Fi case: ~61 Mbps cap under a 68.8 Mbps 4K remux. A
+        // full-4K re-encode there stalls/OOMs, so drop to a light 1080p at a
+        // link-safe bitrate.
+        let override = PlaybackSelection.constrainedAutoOverride(cap: 61_000_000, sourceBitrate: 68_818_483)
+        XCTAssertEqual(override?.maxWidth, 1920)
+        XCTAssertEqual(override?.maxBitrate, 20_000_000)
+    }
+
+    func testCopyableSourceIsNotConstrained() {
+        // Wired/fast client: cap clears the source, so leave Auto untouched and
+        // let it stream-copy native 4K.
+        XCTAssertNil(PlaybackSelection.constrainedAutoOverride(cap: 120_000_000, sourceBitrate: 68_818_483))
+        XCTAssertNil(PlaybackSelection.constrainedAutoOverride(cap: 68_818_483, sourceBitrate: 68_818_483))
+    }
+
+    func testUnknownSourceBitrateIsNotConstrained() {
+        XCTAssertNil(PlaybackSelection.constrainedAutoOverride(cap: 20_000_000, sourceBitrate: nil))
+        XCTAssertNil(PlaybackSelection.constrainedAutoOverride(cap: 20_000_000, sourceBitrate: 0))
+    }
+
+    func testConstrainedBitrateNeverExceedsTheCap() {
+        // A very constrained link: the 1080p target must not exceed what the
+        // link can carry.
+        let override = PlaybackSelection.constrainedAutoOverride(cap: 12_000_000, sourceBitrate: 40_000_000)
+        XCTAssertEqual(override?.maxBitrate, 12_000_000)
+        XCTAssertEqual(override?.maxWidth, 1920)
+    }
+
     // MARK: - isLocalServer
 
     func testPrivateAddressesAreLocal() {

--- a/Shared/Services/PlaybackSelection.swift
+++ b/Shared/Services/PlaybackSelection.swift
@@ -69,6 +69,20 @@ enum PlaybackSelection {
         }
     }
 
+    /// On the "Auto" path, decides whether the link forces a transcode of this
+    /// source and, if so, what to request. When the cap is below the source
+    /// bitrate the server must transcode — and a full-4K re-encode there is the
+    /// worst option (heavy enough to OOM-kill the server, and it rides the link
+    /// ceiling so it stutters: a ~72 Mbps Wi-Fi link cannot hold a 68.8 Mbps 4K
+    /// remux). So target a light, smooth 1080p the link comfortably carries.
+    /// Returns nil when the link can copy the source (cap >= source) or the
+    /// source bitrate is unknown — in which case Auto is left untouched and a
+    /// wired/fast client still stream-copies native 4K.
+    static func constrainedAutoOverride(cap: Int, sourceBitrate: Int?) -> (maxWidth: Int, maxBitrate: Int)? {
+        guard let sourceBitrate, sourceBitrate > 0, cap < sourceBitrate else { return nil }
+        return (maxWidth: 1920, maxBitrate: min(cap, 20_000_000))
+    }
+
     /// Whether the server is reached over the local network. This is what
     /// separates "the probe failed" from "the link is slow" without a
     /// measurement: a LAN path is fast until proven otherwise.

--- a/Shared/ViewModels/PlayerViewModel.swift
+++ b/Shared/ViewModels/PlayerViewModel.swift
@@ -998,7 +998,7 @@ final class PlayerViewModel: ObservableObject {
         // observation, but the player below is still AVPlayer either way.
         let engine: PlaybackEngineKind = playbackSettings.debugVLCDeviceProfile ? .vlc : .avFoundation
 
-        let playbackInfo = try await client.getPlaybackInfo(
+        var playbackInfo = try await client.getPlaybackInfo(
             itemId: item.id,
             itemType: item.type,
             engine: engine,
@@ -1007,6 +1007,35 @@ final class PlayerViewModel: ObservableObject {
             forceDirectPlay: playbackSettings.forceDirectPlay,
             forceTranscode: forceTranscode
         )
+
+        // Source-aware retry (Auto path only). The source bitrate is only known
+        // from the response, so it takes a second pass: if the link cannot carry
+        // this source the server returns a transcode, and left alone that is a
+        // heavy, stutter/OOM-prone full-4K re-encode riding the link ceiling
+        // (a ~72 Mbps Wi-Fi link vs a 68.8 Mbps 4K remux). Re-request a light
+        // 1080p the link comfortably holds. A copyable source never reaches here
+        // (no transcodingUrl, or cap >= source), so a wired/fast client keeps
+        // native 4K; explicit quality picks and forceTranscode are untouched.
+        if effectiveBitrate == nil, maxWidth == nil, !forceTranscode,
+           let source = playbackInfo.mediaSources?.first,
+           source.transcodingUrl?.isEmpty == false,
+           let override = PlaybackSelection.constrainedAutoOverride(cap: bandwidth.cap, sourceBitrate: source.bitrate) {
+            diag(.playbackInfoRequest, [
+                PlayerDiagnostics.field("phase", "constrained-retry-1080p"),
+                PlayerDiagnostics.field("sourceBitrate", source.bitrate),
+                PlayerDiagnostics.field("cap", bandwidth.cap),
+                PlayerDiagnostics.field("retryBitrate", override.maxBitrate)
+            ])
+            playbackInfo = try await client.getPlaybackInfo(
+                itemId: item.id,
+                itemType: item.type,
+                engine: engine,
+                maxBitrate: override.maxBitrate,
+                maxWidth: override.maxWidth,
+                forceDirectPlay: playbackSettings.forceDirectPlay,
+                forceTranscode: forceTranscode
+            )
+        }
 
         guard let mediaSource = playbackInfo.mediaSources?.first else {
             diagFailure(.playbackInfoResponse, [

--- a/project.yml
+++ b/project.yml
@@ -66,7 +66,7 @@ targets:
     settings:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.mondominator.sashimi
-        MARKETING_VERSION: 1.2.5
+        MARKETING_VERSION: 1.2.6
         CURRENT_PROJECT_VERSION: 2
         SWIFT_VERSION: 5.9
         SDKROOT: appletvos
@@ -144,7 +144,7 @@ targets:
         # Shared bundle ID with the tvOS app for Universal Purchase (one "Sashimi"
         # app spanning Apple TV + iPhone + iPad). Distinguished by platform.
         PRODUCT_BUNDLE_IDENTIFIER: com.mondominator.sashimi
-        MARKETING_VERSION: 1.2.5
+        MARKETING_VERSION: 1.2.6
         CURRENT_PROJECT_VERSION: 1
         SWIFT_VERSION: 5.9
         SDKROOT: iphoneos
@@ -186,7 +186,7 @@ targets:
     settings:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.mondominator.sashimi.topshelf
-        MARKETING_VERSION: 1.2.5
+        MARKETING_VERSION: 1.2.6
         CURRENT_PROJECT_VERSION: 2
         SWIFT_VERSION: 5.9
         SDKROOT: appletvos


### PR DESCRIPTION
## Smooth playback on a Wi-Fi / constrained link

When Auto's bitrate cap is below the source, the server must transcode — and left alone that's a full-4K re-encode that's **heavy** (it has OOM-killed the server) and **rides the link ceiling**, so it stalls. Real case: an Apple TV 4K on Wi-Fi measures ~72 Mbps vs a 68.8 Mbps 4K remux — **1080p plays fine, 4K stalls** (confirmed on device).

**Fix (source-aware, two-pass):** the source bitrate is only known from the PlaybackInfo response, so: first request, and if it came back as a transcode with `cap < source`, re-request a light **1080p at `min(cap, 20 Mbps)`** — the smooth outcome verified by hand on device.

**Safe by construction:** only fires on the **Auto path**, only when the server is **already transcoding** AND **cap < source**. So a copyable source (wired/fast client) is never downscaled and still stream-copies native 4K; explicit quality picks and forceTranscode are untouched. Pure decision extracted to `PlaybackSelection.constrainedAutoOverride` with unit tests.

Note: base Apple TV 4K (Wi-Fi model) has no Ethernet, so this Auto behavior — not wiring — is the real fix for that client.