### PR TITLE
fix: keep 4K on a constrained link (Roku-style), cap bitrate to ~24 Mbps

### DIFF
--- a/SashimiTests/PlaybackSelectionTests.swift
+++ b/SashimiTests/PlaybackSelectionTests.swift
@@ -120,13 +120,28 @@ final class PlaybackSelectionTests: XCTestCase {
 
     // MARK: - constrainedAutoOverride
 
-    func testConstrainedLinkTargets1080p() {
-        // The bedroom Wi-Fi case: ~61 Mbps cap under a 68.8 Mbps 4K remux. A
-        // full-4K re-encode there stalls/OOMs, so drop to a light 1080p at a
-        // link-safe bitrate.
+    func testConstrainedLinkKeeps4KAtSmoothBitrate() {
+        // The bedroom Wi-Fi case: cap ~61 Mbps under a 68.8 Mbps 4K remux. Keep
+        // 4K (like Roku) but cap the transcode to a light, smooth bitrate — a
+        // 66 Mbps 4K re-encode OOMs/stutters.
         let override = PlaybackSelection.constrainedAutoOverride(cap: 61_000_000, sourceBitrate: 68_818_483)
+        XCTAssertEqual(override?.maxWidth, 3840)
+        XCTAssertEqual(override?.maxBitrate, PlaybackSelection.smooth4KBitrate)
+    }
+
+    func testConstrainedBitrateNeverExceedsTheCap() {
+        // A mid link still under the source keeps 4K but is capped to the link.
+        let override = PlaybackSelection.constrainedAutoOverride(cap: 18_000_000, sourceBitrate: 40_000_000)
+        XCTAssertEqual(override?.maxWidth, 3840)
+        XCTAssertEqual(override?.maxBitrate, 18_000_000)
+    }
+
+    func testSlowLinkDropsTo1080p() {
+        // Below the 4K floor a 4K encode would be blocky, so spend the bits on
+        // 1080p instead.
+        let override = PlaybackSelection.constrainedAutoOverride(cap: 9_000_000, sourceBitrate: 40_000_000)
         XCTAssertEqual(override?.maxWidth, 1920)
-        XCTAssertEqual(override?.maxBitrate, 20_000_000)
+        XCTAssertEqual(override?.maxBitrate, 8_000_000)
     }
 
     func testCopyableSourceIsNotConstrained() {
@@ -139,14 +154,6 @@ final class PlaybackSelectionTests: XCTestCase {
     func testUnknownSourceBitrateIsNotConstrained() {
         XCTAssertNil(PlaybackSelection.constrainedAutoOverride(cap: 20_000_000, sourceBitrate: nil))
         XCTAssertNil(PlaybackSelection.constrainedAutoOverride(cap: 20_000_000, sourceBitrate: 0))
-    }
-
-    func testConstrainedBitrateNeverExceedsTheCap() {
-        // A very constrained link: the 1080p target must not exceed what the
-        // link can carry.
-        let override = PlaybackSelection.constrainedAutoOverride(cap: 12_000_000, sourceBitrate: 40_000_000)
-        XCTAssertEqual(override?.maxBitrate, 12_000_000)
-        XCTAssertEqual(override?.maxWidth, 1920)
     }
 
     // MARK: - isLocalServer

--- a/Shared/Services/PlaybackSelection.swift
+++ b/Shared/Services/PlaybackSelection.swift
@@ -69,18 +69,34 @@ enum PlaybackSelection {
         }
     }
 
+    /// A light, smooth 4K transcode bitrate. A full-source or link-ceiling 4K
+    /// re-encode (e.g. 66 Mbps) is the worst option — heavy enough to OOM-kill
+    /// the QSV encoder, and it rides the link so it stutters. ~24 Mbps is
+    /// streaming-service 4K quality, encodes cheaply, and any decent link
+    /// carries it (this is what the Roku client ends up doing and it plays
+    /// smoothly).
+    static let smooth4KBitrate = 24_000_000
+
+    /// Below this the picture is better spent on 1080p than a blocky 4K encode.
+    static let keep4KMinimumBitrate = 12_000_000
+
     /// On the "Auto" path, decides whether the link forces a transcode of this
     /// source and, if so, what to request. When the cap is below the source
-    /// bitrate the server must transcode — and a full-4K re-encode there is the
-    /// worst option (heavy enough to OOM-kill the server, and it rides the link
-    /// ceiling so it stutters: a ~72 Mbps Wi-Fi link cannot hold a 68.8 Mbps 4K
-    /// remux). So target a light, smooth 1080p the link comfortably carries.
+    /// bitrate the server must transcode. Rather than a heavy 4K re-encode near
+    /// the link/source bitrate (which OOMs/stutters), keep 4K but cap it to a
+    /// light, smooth bitrate — matching what the Roku client does. Only drop to
+    /// 1080p on a genuinely slow link, where a 4K encode would be blocky.
     /// Returns nil when the link can copy the source (cap >= source) or the
-    /// source bitrate is unknown — in which case Auto is left untouched and a
-    /// wired/fast client still stream-copies native 4K.
+    /// source bitrate is unknown — Auto is left untouched and a wired/fast
+    /// client still stream-copies native 4K.
     static func constrainedAutoOverride(cap: Int, sourceBitrate: Int?) -> (maxWidth: Int, maxBitrate: Int)? {
         guard let sourceBitrate, sourceBitrate > 0, cap < sourceBitrate else { return nil }
-        return (maxWidth: 1920, maxBitrate: min(cap, 20_000_000))
+        if cap >= keep4KMinimumBitrate {
+            // Keep 4K (3840 keeps UHD; the source is already <= this so it is
+            // not downscaled), just cap the transcode bitrate.
+            return (maxWidth: 3840, maxBitrate: min(cap, smooth4KBitrate))
+        }
+        return (maxWidth: 1920, maxBitrate: min(cap, 8_000_000))
     }
 
     /// Whether the server is reached over the local network. This is what

--- a/project.yml
+++ b/project.yml
@@ -66,7 +66,7 @@ targets:
     settings:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.mondominator.sashimi
-        MARKETING_VERSION: 1.2.6
+        MARKETING_VERSION: 1.2.7
         CURRENT_PROJECT_VERSION: 2
         SWIFT_VERSION: 5.9
         SDKROOT: appletvos
@@ -144,7 +144,7 @@ targets:
         # Shared bundle ID with the tvOS app for Universal Purchase (one "Sashimi"
         # app spanning Apple TV + iPhone + iPad). Distinguished by platform.
         PRODUCT_BUNDLE_IDENTIFIER: com.mondominator.sashimi
-        MARKETING_VERSION: 1.2.6
+        MARKETING_VERSION: 1.2.7
         CURRENT_PROJECT_VERSION: 1
         SWIFT_VERSION: 5.9
         SDKROOT: iphoneos
@@ -186,7 +186,7 @@ targets:
     settings:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.mondominator.sashimi.topshelf
-        MARKETING_VERSION: 1.2.6
+        MARKETING_VERSION: 1.2.7
         CURRENT_PROJECT_VERSION: 2
         SWIFT_VERSION: 5.9
         SDKROOT: appletvos


### PR DESCRIPTION
Refines v1.2.6. The stall/OOM on a constrained link was the **bitrate** (a ~66 Mbps 4K re-encode is heavy enough to OOM the QSV encoder and rides the link), not 4K resolution — the **Roku client keeps 4K and caps ~24 Mbps** and it plays smoothly (confirmed on device). So instead of dropping to 1080p, keep 4K (`maxWidth 3840`) and cap the transcode to `min(cap, 24 Mbps)`; only fall to 1080p below a 12 Mbps floor where a 4K encode would be blocky. Copyable sources (fast/wired clients) still stream-copy native 4K untouched. Pure logic in `PlaybackSelection.constrainedAutoOverride`, unit-tested.