### PR TITLE
fix: never copy heavy 4K over Wi-Fi; add interface-aware ceiling

### DIFF
--- a/SashimiTests/PlaybackSelectionTests.swift
+++ b/SashimiTests/PlaybackSelectionTests.swift
@@ -124,14 +124,15 @@ final class PlaybackSelectionTests: XCTestCase {
         // The bedroom Wi-Fi case: cap ~61 Mbps under a 68.8 Mbps 4K remux. Keep
         // 4K (like Roku) but cap the transcode to a light, smooth bitrate — a
         // 66 Mbps 4K re-encode OOMs/stutters.
-        let override = PlaybackSelection.constrainedAutoOverride(cap: 61_000_000, sourceBitrate: 68_818_483)
+        let override = PlaybackSelection.constrainedAutoOverride(cap: 61_000_000, sourceBitrate: 68_818_483, isWired: false)
         XCTAssertEqual(override?.maxWidth, 3840)
         XCTAssertEqual(override?.maxBitrate, PlaybackSelection.smooth4KBitrate)
     }
 
     func testConstrainedBitrateNeverExceedsTheCap() {
-        // A mid link still under the source keeps 4K but is capped to the link.
-        let override = PlaybackSelection.constrainedAutoOverride(cap: 18_000_000, sourceBitrate: 40_000_000)
+        // A mid Wi-Fi link under both the source and the smooth-4K ceiling keeps
+        // 4K but is capped to the link.
+        let override = PlaybackSelection.constrainedAutoOverride(cap: 18_000_000, sourceBitrate: 40_000_000, isWired: false)
         XCTAssertEqual(override?.maxWidth, 3840)
         XCTAssertEqual(override?.maxBitrate, 18_000_000)
     }
@@ -139,21 +140,37 @@ final class PlaybackSelectionTests: XCTestCase {
     func testSlowLinkDropsTo1080p() {
         // Below the 4K floor a 4K encode would be blocky, so spend the bits on
         // 1080p instead.
-        let override = PlaybackSelection.constrainedAutoOverride(cap: 9_000_000, sourceBitrate: 40_000_000)
+        let override = PlaybackSelection.constrainedAutoOverride(cap: 9_000_000, sourceBitrate: 40_000_000, isWired: false)
         XCTAssertEqual(override?.maxWidth, 1920)
         XCTAssertEqual(override?.maxBitrate, 8_000_000)
     }
 
-    func testCopyableSourceIsNotConstrained() {
-        // Wired/fast client: cap clears the source, so leave Auto untouched and
-        // let it stream-copy native 4K.
-        XCTAssertNil(PlaybackSelection.constrainedAutoOverride(cap: 120_000_000, sourceBitrate: 68_818_483))
-        XCTAssertNil(PlaybackSelection.constrainedAutoOverride(cap: 68_818_483, sourceBitrate: 68_818_483))
+    func testWirelessNeverCopiesHeavy4KEvenWhenProbeReadsHigh() {
+        // The Living Room bug: the burst probe over-reads Wi-Fi's peak (here
+        // 90 Mbps) above the 68.8 Mbps source, so the old rule (cap >= source)
+        // let the server copy it — and Wi-Fi stalled on the VBR peaks. The
+        // wireless ceiling now forces a smooth 24 Mbps 4K transcode instead.
+        let override = PlaybackSelection.constrainedAutoOverride(cap: 90_000_000, sourceBitrate: 68_818_483, isWired: false)
+        XCTAssertEqual(override?.maxWidth, 3840)
+        XCTAssertEqual(override?.maxBitrate, PlaybackSelection.smooth4KBitrate)
+    }
+
+    func testWiredCopiesHeavy4KNatively() {
+        // Ethernet can carry what it measured, so a heavy 4K source above the
+        // smooth ceiling is left untouched and stream-copied native.
+        XCTAssertNil(PlaybackSelection.constrainedAutoOverride(cap: 90_000_000, sourceBitrate: 68_818_483, isWired: true))
+        XCTAssertNil(PlaybackSelection.constrainedAutoOverride(cap: 68_818_483, sourceBitrate: 68_818_483, isWired: true))
+    }
+
+    func testWirelessSafeSourceIsNotConstrained() {
+        // A source already under the smooth-4K ceiling is Wi-Fi-safe: copy it
+        // untouched rather than pointlessly transcoding.
+        XCTAssertNil(PlaybackSelection.constrainedAutoOverride(cap: 30_000_000, sourceBitrate: 20_000_000, isWired: false))
     }
 
     func testUnknownSourceBitrateIsNotConstrained() {
-        XCTAssertNil(PlaybackSelection.constrainedAutoOverride(cap: 20_000_000, sourceBitrate: nil))
-        XCTAssertNil(PlaybackSelection.constrainedAutoOverride(cap: 20_000_000, sourceBitrate: 0))
+        XCTAssertNil(PlaybackSelection.constrainedAutoOverride(cap: 20_000_000, sourceBitrate: nil, isWired: false))
+        XCTAssertNil(PlaybackSelection.constrainedAutoOverride(cap: 20_000_000, sourceBitrate: 0, isWired: true))
     }
 
     // MARK: - isLocalServer

--- a/Shared/Services/JellyfinClient.swift
+++ b/Shared/Services/JellyfinClient.swift
@@ -421,6 +421,9 @@ actor JellyfinClient {
         let measuredBitrate: Int?
         let cap: Int
         let isLocalServer: Bool
+        /// Whether the active link is wired Ethernet. Wireless links get a
+        /// smooth-4K ceiling so a heavy source is never copied over Wi-Fi.
+        let isWired: Bool
 
         var isMeasured: Bool { measuredBitrate != nil }
     }
@@ -429,7 +432,8 @@ actor JellyfinClient {
         BandwidthStatus(
             measuredBitrate: measuredBitrate,
             cap: autoBitrateCap(),
-            isLocalServer: PlaybackSelection.isLocalServer(serverURL)
+            isLocalServer: PlaybackSelection.isLocalServer(serverURL),
+            isWired: NetworkConnectionMonitor.shared.isWired
         )
     }
 
@@ -448,6 +452,9 @@ actor JellyfinClient {
     /// succeeds. Returns immediately; the Auto cap updates when one lands.
     /// Any probe already running is cancelled first.
     func startBandwidthMeasurement() {
+        // Begin (idempotent) interface monitoring alongside the bandwidth probe
+        // so the copy-vs-transcode decision knows wired from wireless.
+        NetworkConnectionMonitor.shared.start()
         bandwidthProbeTask?.cancel()
         bandwidthProbeTask = Task { await self.runBandwidthProbes() }
     }

--- a/Shared/Services/NetworkConnectionMonitor.swift
+++ b/Shared/Services/NetworkConnectionMonitor.swift
@@ -1,0 +1,57 @@
+import Foundation
+import Network
+
+/// Observes the active network interface so playback can tell a wired link
+/// from a wireless one.
+///
+/// This is the axis that actually matters for copy-vs-transcode, and the one
+/// the old local-vs-remote (by IP) split got wrong: a 66 Mbps 4K source that
+/// copies fine over Ethernet stalls over Wi-Fi, whatever the bandwidth probe
+/// measured. An 8 MB burst probe reads Wi-Fi's *peak*, not the sustained rate,
+/// and even a correct average can't cover a VBR source's peaks on Wi-Fi — so
+/// the reliable rule is "don't copy heavy 4K over a wireless link", and that
+/// needs to know the link is wireless.
+///
+/// Defaults to *not wired* until the first path update lands (which happens
+/// within milliseconds of `start()`), so the conservative wireless ceiling
+/// applies during the brief startup window rather than optimistically allowing
+/// a copy.
+final class NetworkConnectionMonitor: @unchecked Sendable {
+    static let shared = NetworkConnectionMonitor()
+
+    private let monitor = NWPathMonitor()
+    private let queue = DispatchQueue(label: "com.mondominator.sashimi.network-monitor")
+    private let lock = NSLock()
+    private var wired = false
+    private var started = false
+
+    /// Whether the current path runs over wired Ethernet. False for Wi-Fi,
+    /// cellular, or before the first path update.
+    var isWired: Bool {
+        lock.lock()
+        defer { lock.unlock() }
+        return wired
+    }
+
+    private init() {}
+
+    /// Begins monitoring. Idempotent — safe to call on every login.
+    func start() {
+        lock.lock()
+        guard !started else {
+            lock.unlock()
+            return
+        }
+        started = true
+        lock.unlock()
+
+        monitor.pathUpdateHandler = { [weak self] path in
+            let isWired = path.status == .satisfied && path.usesInterfaceType(.wiredEthernet)
+            guard let self else { return }
+            self.lock.lock()
+            self.wired = isWired
+            self.lock.unlock()
+        }
+        monitor.start(queue: queue)
+    }
+}

--- a/Shared/Services/PlaybackSelection.swift
+++ b/Shared/Services/PlaybackSelection.swift
@@ -81,22 +81,37 @@ enum PlaybackSelection {
     static let keep4KMinimumBitrate = 12_000_000
 
     /// On the "Auto" path, decides whether the link forces a transcode of this
-    /// source and, if so, what to request. When the cap is below the source
-    /// bitrate the server must transcode. Rather than a heavy 4K re-encode near
-    /// the link/source bitrate (which OOMs/stutters), keep 4K but cap it to a
-    /// light, smooth bitrate — matching what the Roku client does. Only drop to
-    /// 1080p on a genuinely slow link, where a 4K encode would be blocky.
-    /// Returns nil when the link can copy the source (cap >= source) or the
-    /// source bitrate is unknown — Auto is left untouched and a wired/fast
-    /// client still stream-copies native 4K.
-    static func constrainedAutoOverride(cap: Int, sourceBitrate: Int?) -> (maxWidth: Int, maxBitrate: Int)? {
-        guard let sourceBitrate, sourceBitrate > 0, cap < sourceBitrate else { return nil }
-        if cap >= keep4KMinimumBitrate {
+    /// source and, if so, what to request.
+    ///
+    /// A transcode is forced when the usable ceiling is below the source
+    /// bitrate. On a wired link that ceiling is the measured cap: Ethernet can
+    /// carry whatever it measured, so a fast wired client still stream-copies
+    /// native 4K (returns nil when cap >= source).
+    ///
+    /// On a wireless link the ceiling is additionally clamped to the smooth 4K
+    /// bitrate, so a heavy 4K source is *never copied* over Wi-Fi — the Roku's
+    /// behaviour, and the fix for the copy-vs-transcode coin-flip. The 8 MB
+    /// burst probe reads Wi-Fi's peak, not its sustained rate, so it routinely
+    /// reads above a 68.8 Mbps source and the server copies it; Wi-Fi then
+    /// can't hold the VBR peaks and playback stalls. Clamping the ceiling means
+    /// any source above ~24 Mbps transcodes down to a light, smooth stream the
+    /// link comfortably holds, regardless of what the noisy probe measured.
+    ///
+    /// Once a transcode is forced, keep 4K unless the link is genuinely slow
+    /// (below `keep4KMinimumBitrate`), where a 4K encode would be blocky and
+    /// 1080p spends the bits better. Returns nil when the source is unknown or
+    /// the ceiling already covers it (a Wi-Fi-safe source under ~24 Mbps copies
+    /// untouched).
+    static func constrainedAutoOverride(cap: Int, sourceBitrate: Int?, isWired: Bool) -> (maxWidth: Int, maxBitrate: Int)? {
+        guard let sourceBitrate, sourceBitrate > 0 else { return nil }
+        let ceiling = isWired ? cap : min(cap, smooth4KBitrate)
+        guard ceiling < sourceBitrate else { return nil }
+        if ceiling >= keep4KMinimumBitrate {
             // Keep 4K (3840 keeps UHD; the source is already <= this so it is
             // not downscaled), just cap the transcode bitrate.
-            return (maxWidth: 3840, maxBitrate: min(cap, smooth4KBitrate))
+            return (maxWidth: 3840, maxBitrate: min(ceiling, smooth4KBitrate))
         }
-        return (maxWidth: 1920, maxBitrate: min(cap, 8_000_000))
+        return (maxWidth: 1920, maxBitrate: min(ceiling, 8_000_000))
     }
 
     /// Whether the server is reached over the local network. This is what

--- a/Shared/ViewModels/PlayerViewModel.swift
+++ b/Shared/ViewModels/PlayerViewModel.swift
@@ -1019,11 +1019,13 @@ final class PlayerViewModel: ObservableObject {
         if effectiveBitrate == nil, maxWidth == nil, !forceTranscode,
            let source = playbackInfo.mediaSources?.first,
            source.transcodingUrl?.isEmpty == false,
-           let override = PlaybackSelection.constrainedAutoOverride(cap: bandwidth.cap, sourceBitrate: source.bitrate) {
+           let override = PlaybackSelection.constrainedAutoOverride(cap: bandwidth.cap, sourceBitrate: source.bitrate, isWired: bandwidth.isWired) {
             diag(.playbackInfoRequest, [
-                PlayerDiagnostics.field("phase", "constrained-retry-1080p"),
+                PlayerDiagnostics.field("phase", "constrained-retry"),
                 PlayerDiagnostics.field("sourceBitrate", source.bitrate),
                 PlayerDiagnostics.field("cap", bandwidth.cap),
+                PlayerDiagnostics.field("isWired", bandwidth.isWired),
+                PlayerDiagnostics.field("retryWidth", override.maxWidth),
                 PlayerDiagnostics.field("retryBitrate", override.maxBitrate)
             ])
             playbackInfo = try await client.getPlaybackInfo(

--- a/project.yml
+++ b/project.yml
@@ -66,7 +66,7 @@ targets:
     settings:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.mondominator.sashimi
-        MARKETING_VERSION: 1.2.7
+        MARKETING_VERSION: 1.2.8
         CURRENT_PROJECT_VERSION: 2
         SWIFT_VERSION: 5.9
         SDKROOT: appletvos
@@ -144,7 +144,7 @@ targets:
         # Shared bundle ID with the tvOS app for Universal Purchase (one "Sashimi"
         # app spanning Apple TV + iPhone + iPad). Distinguished by platform.
         PRODUCT_BUNDLE_IDENTIFIER: com.mondominator.sashimi
-        MARKETING_VERSION: 1.2.7
+        MARKETING_VERSION: 1.2.8
         CURRENT_PROJECT_VERSION: 1
         SWIFT_VERSION: 5.9
         SDKROOT: iphoneos
@@ -186,7 +186,7 @@ targets:
     settings:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.mondominator.sashimi.topshelf
-        MARKETING_VERSION: 1.2.7
+        MARKETING_VERSION: 1.2.8
         CURRENT_PROJECT_VERSION: 2
         SWIFT_VERSION: 5.9
         SDKROOT: appletvos


### PR DESCRIPTION
## Problem

On a Wi-Fi Apple TV, the Auto bandwidth probe (single 8 MB burst) reads the link's **peak** throughput (~77 Mbps on strong signal), not the sustained rate. When that reads above a 4K source's average bitrate (68.8 Mbps Oppenheimer), the server returns a DirectStream **copy** of the source. Wi-Fi can't hold the VBR peaks of a 66 Mbps stream → stalls/spins ("original 66 Mbps"). Because Wi-Fi throughput fluctuates around the source bitrate, playback flipped between copy (spin) and transcode (play) run-to-run.

`constrainedAutoOverride` only forced a smooth 24 Mbps transcode when `cap < source`, so the copy case (`cap >= source`) slipped through.

## Fix

Detect the active interface with `NWPathMonitor`. On wireless links, clamp the copy-vs-transcode ceiling to the smooth 4K bitrate (24 Mbps) so a heavy 4K source is **always** transcoded down — the Roku's behaviour — regardless of what the noisy burst probe measured. Wired Ethernet clients keep native 4K stream-copy.

## Verified
- ✅ `swift`/Xcode compile (tvOS) — full app builds
- ✅ 42 `PlaybackSelectionTests` pass, incl. new wireless-never-copies / wired-copies-native / wireless-safe-source cases
- ✅ SwiftLint clean
- ⚠️ **Not yet exercised on hardware** — the NWPathMonitor interface read and real Wi-Fi playback need a device check. Will confirm on the Living Room Apple TV before tagging a deploy.

Fixes #364