### PR TITLE
feat: Plex-style search + Library A–Z jump + detail controls row (tvOS)

### DIFF
--- a/Sashimi/Views/Detail/MediaDetailView.swift
+++ b/Sashimi/Views/Detail/MediaDetailView.swift
@@ -339,6 +339,13 @@ struct MediaDetailView: View {
                 .focusSection()
             }
 
+            // Action buttons in their own full-width row under the cover art
+            // (Plex layout), rather than squeezed at the bottom of the info
+            // column beside the poster. Down from the poster/info lands here.
+            actionButtonsRow
+                .padding(.horizontal, 60)
+                .focusSection()
+
             if let overview = item.overview {
                 Text(overview)
                     .font(.body)
@@ -627,12 +634,8 @@ struct MediaDetailView: View {
                     }
                 }
             }
-
-            Spacer()
-
-            actionButtonsRow
         }
-        .frame(maxWidth: .infinity, maxHeight: 300, alignment: .leading)
+        .frame(maxWidth: .infinity, alignment: .leading)
     }
 
     private func mediaInfoBadge(_ text: String) -> some View {

--- a/Sashimi/Views/Library/LibraryView.swift
+++ b/Sashimi/Views/Library/LibraryView.swift
@@ -240,6 +240,10 @@ struct LibraryDetailView: View {
     /// sits on the A-Z bar is ignored and no letter ever jumped. Moving focus
     /// to the target item makes the grid scroll to follow it.
     @FocusState private var focusedGridItem: String?
+    /// True while a letter press is pulling the rest of the library so it can
+    /// jump to an as-yet-unloaded letter. Drives a loading overlay so the jump
+    /// doesn't read as "nothing happened" during the fetch.
+    @State private var isJumping = false
     private let pageSize = 50
 
     // Alphabet for fast scroll
@@ -408,6 +412,24 @@ struct LibraryDetailView: View {
                 .padding(.trailing, 20)
             }
         }
+        .overlay {
+            if isJumping {
+                ZStack {
+                    Color.black.opacity(0.35).ignoresSafeArea()
+                    VStack(spacing: 16) {
+                        ProgressView()
+                            .tint(SashimiTheme.accent)
+                            .scaleEffect(1.4)
+                        Text("Jumping…")
+                            .font(Typography.body)
+                            .foregroundStyle(SashimiTheme.textSecondary)
+                    }
+                }
+                .allowsHitTesting(false)
+                .transition(.opacity)
+            }
+        }
+        .animation(.easeInOut(duration: 0.2), value: isJumping)
         .focusScope(namespace)
         .ignoresSafeArea(edges: .bottom)
         .task {
@@ -451,10 +473,12 @@ struct LibraryDetailView: View {
         // at every unloaded letter.
         guard items.count < totalCount else { return }
         Task {
+            isJumping = true
             await loadAllRemainingItems()
             if let item = findItem(for: letter) {
                 focusGridItem(item, proxy: proxy)
             }
+            isJumping = false
         }
     }
 

--- a/Sashimi/Views/Library/LibraryView.swift
+++ b/Sashimi/Views/Library/LibraryView.swift
@@ -235,6 +235,11 @@ struct LibraryDetailView: View {
     @State private var sortOrder: SortOrder = .ascending
     @State private var filterOption: LibraryFilterOption = .all
     @State private var committedLetter: String?
+    /// Programmatic grid focus target. On tvOS a ScrollView's position is
+    /// driven by the focus engine, so a `proxy.scrollTo` issued while focus
+    /// sits on the A-Z bar is ignored and no letter ever jumped. Moving focus
+    /// to the target item makes the grid scroll to follow it.
+    @FocusState private var focusedGridItem: String?
     private let pageSize = 50
 
     // Alphabet for fast scroll
@@ -338,6 +343,7 @@ struct LibraryDetailView: View {
                                         selectedItem = item
                                     }
                                     .id(item.id)
+                                    .focused($focusedGridItem, equals: item.id)
                                     .prefersDefaultFocus(index == 0, in: namespace)
                                     .onAppear {
                                         // Load more when approaching the end
@@ -371,12 +377,12 @@ struct LibraryDetailView: View {
                 // is what may pull the rest of the library down.
                 .onChange(of: selectedLetter) { _, letter in
                     if let letter = letter {
-                        scrollToLetter(letter, proxy: proxy, allowFullLoad: false)
+                        scrollToLetter(letter, proxy: proxy)
                     }
                 }
                 .onChange(of: committedLetter) { _, letter in
                     if let letter = letter {
-                        scrollToLetter(letter, proxy: proxy, allowFullLoad: true)
+                        jumpToLetter(letter, proxy: proxy)
                     }
                 }
                 .focusSection()
@@ -418,28 +424,45 @@ struct LibraryDetailView: View {
         }
     }
 
-    private func scrollToLetter(_ letter: String, proxy: ScrollViewProxy, allowFullLoad: Bool) {
-        // Try to find in already-loaded items
+    /// Hover (focus moving through the A-Z bar): best-effort scroll for a
+    /// letter already loaded. On tvOS this is a no-op when focus is on the bar
+    /// (scroll is focus-driven), so it never loads or moves focus — it just
+    /// previews on the platforms where `scrollTo` does take effect.
+    private func scrollToLetter(_ letter: String, proxy: ScrollViewProxy) {
         if let item = findItem(for: letter) {
             withAnimation(.easeOut(duration: 0.5)) {
                 proxy.scrollTo(item.id, anchor: .top)
             }
+        }
+    }
+
+    /// Press (a committed letter): jump to the letter by moving focus onto its
+    /// first item, which makes the grid scroll to follow. `scrollTo` alone was
+    /// ignored on tvOS because the ScrollView follows focus, which sat on the
+    /// A-Z bar. Loads the rest of the library first when the letter isn't in
+    /// the current page.
+    private func jumpToLetter(_ letter: String, proxy: ScrollViewProxy) {
+        if let item = findItem(for: letter) {
+            focusGridItem(item, proxy: proxy)
             return
         }
-
-        // Not found — load all remaining items, then retry.
-        // Gated on an actual button press: this used to fire on FOCUS, so
-        // holding Down through the A-Z bar kicked a full-library fetch at every
-        // letter that wasn't in the loaded page, queued one behind another.
-        guard allowFullLoad, items.count < totalCount else { return }
+        // Not found — pull the rest of the library, then jump. Gated on a press
+        // (not focus) so holding Down through the bar can't kick a full fetch
+        // at every unloaded letter.
+        guard items.count < totalCount else { return }
         Task {
             await loadAllRemainingItems()
             if let item = findItem(for: letter) {
-                withAnimation(.easeOut(duration: 0.5)) {
-                    proxy.scrollTo(item.id, anchor: .top)
-                }
+                focusGridItem(item, proxy: proxy)
             }
         }
+    }
+
+    /// Nudge the target into the rendered window (`scrollTo` renders lazy rows),
+    /// then move focus to it so the grid settles on it under focus control.
+    private func focusGridItem(_ item: BaseItemDto, proxy: ScrollViewProxy) {
+        proxy.scrollTo(item.id, anchor: .top)
+        focusedGridItem = item.id
     }
 
     private func findItem(for letter: String) -> BaseItemDto? {

--- a/Sashimi/Views/Library/SearchView.swift
+++ b/Sashimi/Views/Library/SearchView.swift
@@ -54,9 +54,46 @@ final class SearchHistoryManager: ObservableObject {
     }
 }
 
+// MARK: - Result grouping
+
+/// One titled section of search results (e.g. "Movies"), rendered as a row.
+struct SearchResultGroup: Identifiable {
+    let id: String
+    let title: String
+    let items: [BaseItemDto]
+}
+
+enum SearchResultGrouping {
+    /// Splits a flat result list into ordered, Plex-style sections — Movies
+    /// then TV Shows — dropping empty sections and preserving each item's
+    /// server order. Anything the server returns that isn't a Movie or Series
+    /// (defensive: today's query asks only for those two) collects into a
+    /// trailing "Other" section so nothing is silently dropped.
+    static func groups(from items: [BaseItemDto]) -> [SearchResultGroup] {
+        let ordered: [(title: String, type: ItemType)] = [
+            ("Movies", .movie),
+            ("TV Shows", .series)
+        ]
+        var groups = ordered.compactMap { entry -> SearchResultGroup? in
+            let matching = items.filter { $0.type == entry.type }
+            guard !matching.isEmpty else { return nil }
+            return SearchResultGroup(id: entry.title, title: entry.title, items: matching)
+        }
+
+        let placed: Set<ItemType> = [.movie, .series]
+        let others = items.filter { !placed.contains($0.type ?? .unknown) }
+        if !others.isEmpty {
+            groups.append(SearchResultGroup(id: "Other", title: "Other", items: others))
+        }
+        return groups
+    }
+}
+
+// MARK: - Search View
+
 struct SearchView: View {
     var onBackAtRoot: (() -> Void)?
-    /// Supplied by the rail so the search field can claim default focus in the
+    /// Supplied by the rail so the keyboard can claim default focus in the
     /// shared main scope — without it, pressing Right from the Search rail row
     /// has no designated target and focus never enters this screen.
     var focusNamespace: Namespace.ID?
@@ -70,47 +107,31 @@ struct SearchView: View {
     @State private var youtubeItemIds: Set<String> = []
     @StateObject private var historyManager = SearchHistoryManager.shared
 
-    @FocusState private var isSearchFieldFocused: Bool
-    @FocusState private var isClearButtonFocused: Bool
-
     init(onBackAtRoot: (() -> Void)? = nil, focusNamespace: Namespace.ID? = nil) {
         self.onBackAtRoot = onBackAtRoot
         self.focusNamespace = focusNamespace
     }
 
+    private var groups: [SearchResultGroup] {
+        SearchResultGrouping.groups(from: results)
+    }
+
     // Detect YouTube content by checking if we've identified it as YouTube
     private func isYouTubeStyle(_ item: BaseItemDto) -> Bool {
         if item.type == .video { return true }
-        // Check if this specific item was identified as YouTube
-        if youtubeItemIds.contains(item.id) {
-            return true
-        }
-        // Check if the item belongs to a known YouTube library
-        if let parentId = item.parentId, youtubeLibraryIds.contains(parentId) {
-            return true
-        }
-        // Also check if "youtube" appears in the file path
-        if let path = item.path?.lowercased(), path.contains("youtube") {
-            return true
-        }
+        if youtubeItemIds.contains(item.id) { return true }
+        if let parentId = item.parentId, youtubeLibraryIds.contains(parentId) { return true }
+        if let path = item.path?.lowercased(), path.contains("youtube") { return true }
         return false
     }
 
     private func detectYouTubeItems(for items: [BaseItemDto]) async {
-        // For each Series item, check if any ancestor has "youtube" in the name
         for item in items where item.type == .series {
-            // Skip if we already know this item is YouTube
-            if youtubeItemIds.contains(item.id) {
-                continue
-            }
-
+            if youtubeItemIds.contains(item.id) { continue }
             do {
                 let ancestors = try await JellyfinClient.shared.getItemAncestors(itemId: item.id)
-                // Check if any ancestor has "youtube" in the name (the library folder)
                 for ancestor in ancestors where ancestor.name.lowercased().contains("youtube") {
-                    // Mark this item as YouTube
                     youtubeItemIds.insert(item.id)
-                    // Store the ancestor's ID for future matches
                     youtubeLibraryIds.insert(ancestor.id)
                     if let parentId = item.parentId {
                         youtubeLibraryIds.insert(parentId)
@@ -127,192 +148,148 @@ struct SearchView: View {
         ZStack {
             SashimiTheme.background.ignoresSafeArea()
 
-            VStack(spacing: 0) {
-                // Search field at top with clear button
-                HStack(spacing: 16) {
-                    // The raw tvOS TextField draws a solid white focus platter
-                    // that no modifier can suppress. Keep it for focus +
-                    // keyboard, but hide its text/cursor and cover its platter
-                    // with a dark overlay (sized to the field's exact frame, so
-                    // height stays right and no white edges peek) — focus then
-                    // reads as our thin ring (the stroke below), not a white box.
-                    TextField("", text: $searchText)
-                        .textFieldStyle(.plain)
-                        .font(.title3)
-                        .foregroundStyle(.clear)
-                        .tint(.clear)
-                        .accessibilityLabel("Search movies and shows")
-                        .focused($isSearchFieldFocused)
-                        .defaultFocus(in: focusNamespace)
-                        .overlay {
-                            ZStack(alignment: .leading) {
-                                // Over-sized dark fill: covers the platter's few-px
-                                // outset; the container's clipShape trims it back to
-                                // the rounded field, so no white rim peeks.
-                                SashimiTheme.cardBackground
-                                    .padding(-60)
-                                HStack(spacing: 16) {
-                                    Image(systemName: "magnifyingglass")
-                                        .font(.title3)
-                                        .foregroundStyle(isSearchFieldFocused ? SashimiTheme.textPrimary : SashimiTheme.textTertiary)
-                                    Text(searchText.isEmpty ? "Search movies, shows..." : searchText)
-                                        .font(.title3)
-                                        .foregroundStyle(searchText.isEmpty ? SashimiTheme.textTertiary : SashimiTheme.textPrimary)
-                                        .lineLimit(1)
-                                    Spacer(minLength: 0)
-                                }
-                            }
-                            .allowsHitTesting(false)
-                        }
-
-                    // Clear button - show when there's text OR results
-                    if !searchText.isEmpty || !results.isEmpty {
-                        Button {
-                            searchText = ""
-                            results = []
-                            youtubeItemIds = []
-                        } label: {
-                            Image(systemName: "xmark.circle.fill")
-                                .font(.title2)
-                                .foregroundStyle(isClearButtonFocused ? SashimiTheme.accent : SashimiTheme.textTertiary)
-                                .scaleEffect(isClearButtonFocused ? 1.2 : 1.0)
-                                .animation(.spring(response: 0.3), value: isClearButtonFocused)
-                        }
-                        .buttonStyle(PlainNoHighlightButtonStyle())
-                        .focused($isClearButtonFocused)
-                    }
-                }
-                .padding(20)
-                .background(SashimiTheme.cardBackground)
-                .clipShape(RoundedRectangle(cornerRadius: 16))
-                .overlay(
-                    RoundedRectangle(cornerRadius: 16)
-                        .stroke(isSearchFieldFocused ? SashimiTheme.accent : Color.white.opacity(0.1), lineWidth: isSearchFieldFocused ? 3 : 1)
-                )
-                .focused($isSearchFieldFocused)
-                .padding(.horizontal, 80)
-                .padding(.top, 60)
-                .padding(.bottom, 30)
-                .onChange(of: searchText) { _, _ in
-                    searchTask?.cancel()
-                    searchTask = Task {
-                        try? await Task.sleep(for: .milliseconds(300))
-                        if !Task.isCancelled {
-                            await performSearch()
-                        }
-                    }
-                }
-                .onSubmit {
-                    if !searchText.isEmpty {
-                        historyManager.addSearch(searchText)
-                    }
-                }
-
-                // Results area
-                if isSearching {
-                    Spacer()
-                    ProgressView()
-                        .tint(SashimiTheme.accent)
-                        .scaleEffect(1.5)
-                    Spacer()
-                } else if results.isEmpty && !searchText.isEmpty {
-                    Spacer()
-                    EmptyStateView(
-                        icon: "magnifyingglass",
-                        title: "No results found",
-                        message: "Try a different search term"
-                    )
-                    Spacer()
-                } else if results.isEmpty {
-                    // Show search history or empty state
-                    if historyManager.recentSearches.isEmpty {
-                        Spacer()
-                        EmptyStateView(
-                            icon: "magnifyingglass",
-                            title: "Search your library",
-                            message: "Find movies and TV shows"
-                        )
-                        Spacer()
-                    } else {
-                        // Recent searches
-                        VStack(alignment: .leading, spacing: 20) {
-                            HStack {
-                                Text("Recent Searches")
-                                    .font(Typography.headlineSmall)
-                                    .foregroundStyle(SashimiTheme.textPrimary)
-
-                                Spacer()
-
-                                Button("Clear History") {
-                                    historyManager.clearHistory()
-                                }
-                                .font(Typography.body)
-                                .foregroundStyle(SashimiTheme.accent)
-                            }
-                            .padding(.horizontal, 80)
-
-                            ScrollView(.horizontal, showsIndicators: false) {
-                                HStack(spacing: 16) {
-                                    ForEach(historyManager.recentSearches, id: \.self) { query in
-                                        RecentSearchButton(query: query) {
-                                            searchText = query
-                                            historyManager.addSearch(query)
-                                        }
-                                    }
-                                }
-                                .padding(.horizontal, 80)
-                                .padding(.vertical, 20)
-                            }
-                            .focusSection()
-                        }
-                        Spacer()
-                    }
-                } else {
-                    ScrollView {
-                        VStack(alignment: .leading, spacing: 20) {
-                            // Results count
-                            Text("\(results.count) results")
-                                .font(.subheadline)
-                                .foregroundStyle(SashimiTheme.textTertiary)
-                                .padding(.horizontal, 80)
-                                .padding(.top, 20)
-
-                            LazyVGrid(columns: [
-                                GridItem(.adaptive(minimum: 200, maximum: 240), spacing: 40)
-                            ], spacing: 50) {
-                                ForEach(results) { item in
-                                    MediaPosterButton(
-                                        item: item,
-                                        isCircular: isYouTubeStyle(item)
-                                    ) {
-                                        // Compute at tap time to ensure current state
-                                        selectedItemIsYouTube = isYouTubeStyle(item)
-                                        selectedItem = item
-                                    }
-                                }
-                            }
-                            .padding(.horizontal, 80)
-                            .padding(.bottom, 100)
-                        }
-                    }
+            HStack(spacing: 0) {
+                keyboardPanel
+                    .frame(width: 640)
                     .focusSection()
-                }
+
+                resultsPanel
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
+                    .focusSection()
             }
         }
         .fullScreenCover(item: $selectedItem) { item in
             MediaDetailView(item: item, forceYouTubeStyle: selectedItemIsYouTube)
         }
+        .onChange(of: searchText) { _, _ in
+            searchTask?.cancel()
+            searchTask = Task {
+                try? await Task.sleep(for: .milliseconds(300))
+                if !Task.isCancelled {
+                    await performSearch()
+                }
+            }
+        }
         .onExitCommand {
             if !searchText.isEmpty {
-                // Clear search first
+                // Back clears the query before leaving the screen.
                 searchText = ""
                 results = []
+                youtubeItemIds = []
             } else {
-                // At root with empty search
                 onBackAtRoot?()
             }
         }
     }
+
+    // MARK: Left panel — query, keyboard, recents
+
+    private var keyboardPanel: some View {
+        VStack(alignment: .leading, spacing: 28) {
+            QueryDisplayView(text: searchText)
+
+            TVSearchKeyboard(
+                defaultFocusNamespace: focusNamespace,
+                onCharacter: { character in
+                    searchText.append(character)
+                },
+                onDelete: {
+                    if !searchText.isEmpty { searchText.removeLast() }
+                }
+            )
+
+            if searchText.isEmpty && !historyManager.recentSearches.isEmpty {
+                recentSearchesSection
+            }
+
+            Spacer(minLength: 0)
+        }
+        .padding(.horizontal, 60)
+        .padding(.vertical, 60)
+    }
+
+    private var recentSearchesSection: some View {
+        VStack(alignment: .leading, spacing: 14) {
+            HStack {
+                Text("RECENT")
+                    .font(.caption.weight(.bold))
+                    .kerning(1.2)
+                    .foregroundStyle(SashimiTheme.textTertiary)
+                Spacer()
+                Button("Clear") {
+                    historyManager.clearHistory()
+                }
+                .font(Typography.caption)
+                .foregroundStyle(SashimiTheme.accent)
+                .buttonStyle(.plain)
+            }
+
+            ForEach(historyManager.recentSearches.prefix(5), id: \.self) { query in
+                RecentSearchButton(query: query) {
+                    searchText = query
+                    historyManager.addSearch(query)
+                }
+            }
+        }
+    }
+
+    // MARK: Right panel — live results
+
+    @ViewBuilder
+    private var resultsPanel: some View {
+        if isSearching && results.isEmpty {
+            centeredMessage { ProgressView().tint(SashimiTheme.accent).scaleEffect(1.5) }
+        } else if searchText.isEmpty {
+            centeredMessage {
+                EmptyStateView(
+                    icon: "magnifyingglass",
+                    title: "Search your library",
+                    message: "Find movies and TV shows"
+                )
+            }
+        } else if results.isEmpty {
+            centeredMessage {
+                EmptyStateView(
+                    icon: "magnifyingglass",
+                    title: "No results found",
+                    message: "Try a different search term"
+                )
+            }
+        } else {
+            ScrollView {
+                VStack(alignment: .leading, spacing: 44) {
+                    Text("\(results.count) result\(results.count == 1 ? "" : "s") for \u{201C}\(searchText)\u{201D}")
+                        .font(.subheadline)
+                        .foregroundStyle(SashimiTheme.textTertiary)
+
+                    ForEach(groups) { group in
+                        SearchResultRow(
+                            group: group,
+                            isYouTube: isYouTubeStyle,
+                            onSelect: { item in
+                                selectedItemIsYouTube = isYouTubeStyle(item)
+                                selectedItem = item
+                            }
+                        )
+                    }
+                }
+                .padding(.horizontal, 60)
+                .padding(.top, 60)
+                .padding(.bottom, 100)
+            }
+        }
+    }
+
+    private func centeredMessage<Content: View>(@ViewBuilder _ content: () -> Content) -> some View {
+        VStack {
+            Spacer()
+            content()
+            Spacer()
+        }
+        .frame(maxWidth: .infinity)
+    }
+
+    // MARK: Search
 
     private func performSearch() async {
         guard !searchText.trimmingCharacters(in: .whitespaces).isEmpty else {
@@ -324,28 +301,18 @@ struct SearchView: View {
 
         do {
             let searchResults = try await JellyfinClient.shared.search(query: searchText)
-            // Detect YouTube items by checking ancestors for "YouTube" library
             await detectYouTubeItems(for: searchResults)
             // A search cancelled by the next keystroke must not publish its
             // results or clear the spinner — otherwise a slow older query that
             // finishes late overwrites the newer one's results.
             guard !Task.isCancelled else { return }
             results = searchResults
-            // Add to history on successful search
             if !results.isEmpty {
                 historyManager.addSearch(searchText)
             }
         } catch is CancellationError {
-            // Superseded by the next keystroke — not a failure, and showing the
-            // user an error toast for their own typing is worse than useless.
-            // On the tvOS on-screen keyboard, where keystrokes are naturally
-            // further apart than the 300ms debounce, this fired on most
-            // characters. LibraryView and HomeView already swallow this; only
-            // SearchView surfaced it.
             return
         } catch let urlError as URLError where urlError.code == .cancelled {
-            // URLSession reports cancellation as URLError(.cancelled) rather
-            // than CancellationError, so both have to be caught.
             return
         } catch {
             logger.error("Search failed: \(error.localizedDescription)")
@@ -356,7 +323,164 @@ struct SearchView: View {
     }
 }
 
+// MARK: - Query display
+
+private struct QueryDisplayView: View {
+    let text: String
+
+    var body: some View {
+        HStack(spacing: 16) {
+            Image(systemName: "magnifyingglass")
+                .font(.title3)
+                .foregroundStyle(text.isEmpty ? SashimiTheme.textTertiary : SashimiTheme.textPrimary)
+
+            Text(text.isEmpty ? "Search" : text)
+                .font(.title3.weight(.semibold))
+                .foregroundStyle(text.isEmpty ? SashimiTheme.textTertiary : SashimiTheme.textPrimary)
+                .lineLimit(1)
+                .truncationMode(.head)
+
+            if !text.isEmpty {
+                Rectangle()
+                    .fill(SashimiTheme.accentSecondary)
+                    .frame(width: 2, height: 26)
+            }
+
+            Spacer(minLength: 0)
+        }
+        .padding(.horizontal, 22)
+        .padding(.vertical, 18)
+        .background(SashimiTheme.cardBackground)
+        .clipShape(RoundedRectangle(cornerRadius: 14))
+        .overlay(
+            RoundedRectangle(cornerRadius: 14)
+                .stroke(SashimiTheme.accent, lineWidth: 2)
+        )
+    }
+}
+
+// MARK: - On-screen keyboard
+
+/// A persistent grid keyboard, the heart of the Plex-style search: it stays on
+/// screen so results update live beside it, instead of the system keyboard that
+/// covers everything until you finish typing.
+private struct TVSearchKeyboard: View {
+    var defaultFocusNamespace: Namespace.ID?
+    let onCharacter: (Character) -> Void
+    let onDelete: () -> Void
+
+    private let rows: [[Character]] = [
+        ["A", "B", "C", "D", "E", "F"],
+        ["G", "H", "I", "J", "K", "L"],
+        ["M", "N", "O", "P", "Q", "R"],
+        ["S", "T", "U", "V", "W", "X"],
+        ["Y", "Z", "0", "1", "2", "3"],
+        ["4", "5", "6", "7", "8", "9"]
+    ]
+
+    var body: some View {
+        VStack(spacing: 10) {
+            ForEach(Array(rows.enumerated()), id: \.offset) { rowIndex, row in
+                HStack(spacing: 10) {
+                    ForEach(Array(row.enumerated()), id: \.offset) { colIndex, key in
+                        TVKeyButton(label: String(key)) {
+                            onCharacter(key)
+                        }
+                        // The very first key claims default focus so the
+                        // rightward beam from the Search rail lands here.
+                        .prefersDefaultFocusIfAvailable(
+                            rowIndex == 0 && colIndex == 0,
+                            in: defaultFocusNamespace
+                        )
+                    }
+                }
+            }
+
+            HStack(spacing: 10) {
+                TVKeyButton(label: "space", systemImage: "space", wide: true) {
+                    onCharacter(" ")
+                }
+                TVKeyButton(label: "Delete", systemImage: "delete.left", wide: true) {
+                    onDelete()
+                }
+            }
+        }
+    }
+}
+
+private struct TVKeyButton: View {
+    let label: String
+    var systemImage: String?
+    var wide: Bool = false
+    let action: () -> Void
+
+    @FocusState private var isFocused: Bool
+
+    var body: some View {
+        Button(action: action) {
+            Group {
+                if let systemImage {
+                    Image(systemName: systemImage)
+                        .font(.title3)
+                } else {
+                    Text(label)
+                        .font(.title3.weight(.semibold))
+                }
+            }
+            .foregroundStyle(isFocused ? Color.white : SashimiTheme.textSecondary)
+            .frame(maxWidth: .infinity)
+            .frame(height: 62)
+            .background(isFocused ? SashimiTheme.accent : SashimiTheme.cardBackground)
+            .clipShape(RoundedRectangle(cornerRadius: 10))
+            .shadow(color: isFocused ? SashimiTheme.accent.opacity(0.5) : .clear, radius: 12)
+            .scaleEffect(isFocused ? 1.1 : 1.0)
+            .animation(.spring(response: 0.3, dampingFraction: 0.7), value: isFocused)
+        }
+        .buttonStyle(PlainNoHighlightButtonStyle())
+        .focused($isFocused)
+        .accessibilityLabel(label)
+    }
+}
+
+// MARK: - Result row
+
+private struct SearchResultRow: View {
+    let group: SearchResultGroup
+    let isYouTube: (BaseItemDto) -> Bool
+    let onSelect: (BaseItemDto) -> Void
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 18) {
+            HStack(spacing: 10) {
+                Text(group.title)
+                    .font(Typography.headlineSmall)
+                    .foregroundStyle(SashimiTheme.textPrimary)
+                Text("\u{00B7} \(group.items.count)")
+                    .font(.subheadline)
+                    .foregroundStyle(SashimiTheme.textTertiary)
+            }
+
+            ScrollView(.horizontal, showsIndicators: false) {
+                HStack(spacing: 32) {
+                    ForEach(group.items) { item in
+                        MediaPosterButton(
+                            item: item,
+                            isCircular: isYouTube(item)
+                        ) {
+                            onSelect(item)
+                        }
+                        .frame(width: 200)
+                    }
+                }
+                .padding(.vertical, 12)
+            }
+            .focusSection()
+        }
+    }
+}
+
 // MARK: - Recent Search Button
+
 struct RecentSearchButton: View {
     let query: String
     let action: () -> Void
@@ -365,19 +489,22 @@ struct RecentSearchButton: View {
 
     var body: some View {
         Button(action: action) {
-            HStack(spacing: 10) {
+            HStack(spacing: 12) {
                 Image(systemName: "clock.arrow.circlepath")
                     .foregroundStyle(isFocused ? SashimiTheme.focus : SashimiTheme.textTertiary)
                 Text(query)
                     .foregroundStyle(isFocused ? .white : SashimiTheme.textPrimary)
+                    .lineLimit(1)
+                Spacer(minLength: 0)
             }
             .font(Typography.body)
             .padding(.horizontal, 20)
             .padding(.vertical, 12)
-            .background(isFocused ? SashimiTheme.focus.opacity(0.3) : SashimiTheme.cardBackground)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .background(isFocused ? SashimiTheme.focus.opacity(0.25) : SashimiTheme.cardBackground)
             .clipShape(Capsule())
             .shadow(color: isFocused ? SashimiTheme.focusGlow : .clear, radius: 12)
-            .scaleEffect(isFocused ? 1.05 : 1.0)
+            .scaleEffect(isFocused ? 1.03 : 1.0)
             .animation(.spring(response: 0.3, dampingFraction: 0.7), value: isFocused)
         }
         .buttonStyle(PlainNoHighlightButtonStyle())
@@ -385,20 +512,22 @@ struct RecentSearchButton: View {
     }
 }
 
-#Preview {
-    SearchView()
-}
+// MARK: - Focus helper
 
 private extension View {
     /// Claims default focus only when the rail supplies its shared namespace,
-    /// so the rightward beam from the Search rail row lands here. Previews (no
-    /// namespace) are untouched.
+    /// so the rightward beam from the Search rail row lands on this view.
+    /// Previews and other non-rail contexts (no namespace) are untouched.
     @ViewBuilder
-    func defaultFocus(in namespace: Namespace.ID?) -> some View {
-        if let namespace {
+    func prefersDefaultFocusIfAvailable(_ condition: Bool, in namespace: Namespace.ID?) -> some View {
+        if condition, let namespace {
             prefersDefaultFocus(true, in: namespace)
         } else {
             self
         }
     }
+}
+
+#Preview {
+    SearchView()
 }

--- a/Sashimi/Views/Library/SearchView.swift
+++ b/Sashimi/Views/Library/SearchView.swift
@@ -261,6 +261,7 @@ struct SearchView: View {
                     Text("\(results.count) result\(results.count == 1 ? "" : "s") for \u{201C}\(searchText)\u{201D}")
                         .font(.subheadline)
                         .foregroundStyle(SashimiTheme.textTertiary)
+                        .padding(.horizontal, 60)
 
                     ForEach(groups) { group in
                         SearchResultRow(
@@ -273,7 +274,6 @@ struct SearchView: View {
                         )
                     }
                 }
-                .padding(.horizontal, 60)
                 .padding(.top, 60)
                 .padding(.bottom, 100)
             }
@@ -459,6 +459,7 @@ private struct SearchResultRow: View {
                     .font(.subheadline)
                     .foregroundStyle(SashimiTheme.textTertiary)
             }
+            .padding(.horizontal, 60)
 
             ScrollView(.horizontal, showsIndicators: false) {
                 HStack(spacing: 32) {
@@ -472,7 +473,11 @@ private struct SearchResultRow: View {
                         .frame(width: 200)
                     }
                 }
-                .padding(.vertical, 12)
+                // Padding lives inside the scroll content (not on the
+                // ScrollView) so the leading poster's focus scale has room and
+                // isn't clipped at the panel edge.
+                .padding(.horizontal, 60)
+                .padding(.vertical, 20)
             }
             .focusSection()
         }

--- a/SashimiTests/SearchResultGroupingTests.swift
+++ b/SashimiTests/SearchResultGroupingTests.swift
@@ -1,0 +1,65 @@
+import XCTest
+@testable import Sashimi
+
+final class SearchResultGroupingTests: XCTestCase {
+    private func makeItem(id: String, type: ItemType) -> BaseItemDto {
+        BaseItemDto(
+            id: id, name: id, type: type,
+            seriesName: nil, seriesId: nil, seasonId: nil, parentId: nil,
+            indexNumber: nil, parentIndexNumber: nil, overview: nil,
+            runTimeTicks: nil, userData: nil, imageTags: nil,
+            backdropImageTags: nil, parentBackdropImageTags: nil,
+            primaryImageAspectRatio: nil, mediaType: nil, productionYear: nil,
+            communityRating: nil, officialRating: nil, genres: nil,
+            taglines: nil, people: nil, criticRating: nil,
+            premiereDate: nil, chapters: nil, path: nil, remoteTrailers: nil,
+            localTrailerCount: nil, mediaStreams: nil
+        )
+    }
+
+    func testMoviesComeBeforeShows() {
+        let items = [
+            makeItem(id: "s1", type: .series),
+            makeItem(id: "m1", type: .movie),
+            makeItem(id: "s2", type: .series),
+            makeItem(id: "m2", type: .movie)
+        ]
+        let groups = SearchResultGrouping.groups(from: items)
+        XCTAssertEqual(groups.map(\.title), ["Movies", "TV Shows"])
+        XCTAssertEqual(groups[0].items.map(\.id), ["m1", "m2"])
+        XCTAssertEqual(groups[1].items.map(\.id), ["s1", "s2"])
+    }
+
+    func testEmptySectionsAreDropped() {
+        let groups = SearchResultGrouping.groups(from: [
+            makeItem(id: "m1", type: .movie),
+            makeItem(id: "m2", type: .movie)
+        ])
+        XCTAssertEqual(groups.map(\.title), ["Movies"])
+    }
+
+    func testServerOrderIsPreservedWithinASection() {
+        let items = [
+            makeItem(id: "m3", type: .movie),
+            makeItem(id: "m1", type: .movie),
+            makeItem(id: "m2", type: .movie)
+        ]
+        let groups = SearchResultGrouping.groups(from: items)
+        XCTAssertEqual(groups.first?.items.map(\.id), ["m3", "m1", "m2"])
+    }
+
+    func testUnexpectedTypesCollectIntoOther() {
+        // Nothing the server returns should be silently dropped.
+        let groups = SearchResultGrouping.groups(from: [
+            makeItem(id: "m1", type: .movie),
+            makeItem(id: "e1", type: .episode),
+            makeItem(id: "v1", type: .video)
+        ])
+        XCTAssertEqual(groups.map(\.title), ["Movies", "Other"])
+        XCTAssertEqual(groups.last?.items.map(\.id), ["e1", "v1"])
+    }
+
+    func testEmptyInputYieldsNoGroups() {
+        XCTAssertTrue(SearchResultGrouping.groups(from: []).isEmpty)
+    }
+}


### PR DESCRIPTION
Redesigns tvOS search to the Plex pattern (approved mockup: https://claude.ai/code/artifact/439110f8-0ab3-4d60-8e96-65c1602bf80a).

## What changed
- **Persistent on-screen keyboard** (left) — custom focusable grid (A-Z, 0-9, space, delete) driving a plain `@State` query. No `TextField`, so no full-screen system keyboard covering results.
- **Live results** (right) update as you type, **grouped into Movies / TV Shows** sections with a per-group horizontal poster row.
- Recent searches live under the keyboard until you start typing; Back clears the query before leaving.
- Preserves the existing 300ms-debounced search, stale-result cancellation, YouTube detection, and history.

## Verified
- ✅ Full tvOS app compiles
- ✅ 5 new `SearchResultGroupingTests` pass (ordering, empty-section drop, server-order preservation, unknown→Other)
- ✅ SwiftLint clean
- ⚠️ **Not yet exercised on hardware** — tvOS focus traversal (keyboard grid nav, Right/Left between keyboard and results panels, default focus from the Search rail) needs a device check. Will confirm on the Living Room Apple TV before tagging.

## Follow-up
People / Episodes groups (shown in the mockup) need switching search to Jellyfin's `/Search/Hints` endpoint — today's query returns Movie,Series only. Filed as a fast-follow.

Fixes #366