### PR TITLE
feat: error/stall recovery fallback + bandwidth-probe freshness

### DIFF
--- a/Shared/Services/JellyfinClient.swift
+++ b/Shared/Services/JellyfinClient.swift
@@ -510,10 +510,29 @@ actor JellyfinClient {
         bandwidthProbeTask?.cancel()
         bandwidthProbeTask = nil
         measuredBitrate = nil
+        bandwidthMeasuredAt = nil
     }
 
     /// Measured downstream bandwidth (bits/sec) from the last BitrateTest.
     private var measuredBitrate: Int?
+
+    /// When the current measurement landed. Drives staleness re-probing: the
+    /// link can change under a long-lived session (roaming across mesh nodes,
+    /// congestion), so a measurement older than `bandwidthMaxAge` triggers a
+    /// background re-probe at the next Auto playback (jellyfin-web caches its
+    /// bitrate test for the same 1 hour). The stale value still serves the
+    /// current request — a re-probe never blocks playback.
+    private var bandwidthMeasuredAt: Date?
+    private static let bandwidthMaxAge: TimeInterval = 3600
+
+    /// Kicks a background re-probe when the measurement is stale. Called on
+    /// the Auto path at playback time; deliberately non-blocking.
+    private func refreshBandwidthIfStale() {
+        guard let bandwidthMeasuredAt,
+              Date().timeIntervalSince(bandwidthMeasuredAt) > Self.bandwidthMaxAge else { return }
+        logger.info("Bandwidth measurement stale (>1h); re-probing in background")
+        startBandwidthMeasurement()
+    }
 
     /// Retry schedule for the bandwidth probe: one immediate attempt, then
     /// these delays. A single failure (a router reboot, a Wi-Fi handoff, a
@@ -601,6 +620,7 @@ actor JellyfinClient {
         let probe = SustainedBandwidthProbe(authDelegate: certificateDelegate)
         guard let bitsPerSecond = await probe.run(request: req), bitsPerSecond > 0 else { return false }
         measuredBitrate = bitsPerSecond
+        bandwidthMeasuredAt = Date()
         logger.info("Bandwidth probe (sustained) measured \(bitsPerSecond) bps")
         return true
     }
@@ -923,8 +943,6 @@ actor JellyfinClient {
         return response.items.first
     }
 
-    /// Whether the HLS TranscodingProfile lets the server cut segments on
-
     /// The device profile sent with every PlaybackInfo request: what the
     /// *engine this playback will use* can play natively, and the ceilings
     /// the server must respect. Internal (not private) so the profile shape
@@ -1083,7 +1101,8 @@ actor JellyfinClient {
         maxBitrate: Int? = nil,
         maxWidth: Int? = nil,
         forceDirectPlay: Bool = false,
-        forceTranscode: Bool = false
+        forceTranscode: Bool = false,
+        allowVideoStreamCopy: Bool = true
     ) async throws -> PlaybackInfoResponse {
         // Defensive guard: PlaybackInfo for a container type (Series, Season,
         // BoxSet, folder) is a guaranteed server 500 — Jellyfin throws
@@ -1099,7 +1118,9 @@ actor JellyfinClient {
 
         // Auto (no explicit cap) uses the measured connection bandwidth so we
         // don't request more than the link can carry (the cause of remote
-        // stalls); explicit picks are honored as-is.
+        // stalls); explicit picks are honored as-is. A stale measurement kicks
+        // a background re-probe but still serves this request.
+        if maxBitrate == nil { refreshBandwidthIfStale() }
         let streamingBitrate = maxBitrate ?? autoBitrateCap()
 
         // A bitrate cap with no width condition makes the server re-encode at
@@ -1149,10 +1170,13 @@ actor JellyfinClient {
             // seek). That was unworkable: forcing a real-time re-encode of an
             // 88 GB 4K HDR remux OOM-killed ffmpeg (exit 137) into a restart
             // storm, so 4K titles could not play at all (CoreMediaError -12889).
-            // The seek-freeze is a much narrower problem and is handled on the
-            // CLIENT by re-anchoring the session on seek (a fresh stream from the
-            // seek position), NOT by transcoding the whole file.
-            "AllowVideoStreamCopy": true,
+            // The seek-freeze is handled the way the official clients handle
+            // broken playback: an error/stall RECOVERY fallback (see
+            // PlayerViewModel.attemptPlaybackRecovery) rebuilds the session at
+            // the current position forcing a transcode, escalating to
+            // allowVideoStreamCopy=false on a second failure — recovery only,
+            // never as the default path.
+            "AllowVideoStreamCopy": allowVideoStreamCopy,
             "AllowAudioStreamCopy": true,
             "AutoOpenLiveStream": true
         ]

--- a/Shared/Services/NetworkConnectionMonitor.swift
+++ b/Shared/Services/NetworkConnectionMonitor.swift
@@ -24,6 +24,8 @@ final class NetworkConnectionMonitor: @unchecked Sendable {
     private let lock = NSLock()
     private var wired = false
     private var started = false
+    /// Distinguishes the initial path update from a real interface change.
+    private var hasReceivedPath = false
 
     /// Whether the current path runs over wired Ethernet. False for Wi-Fi,
     /// cellular, or before the first path update.
@@ -49,8 +51,17 @@ final class NetworkConnectionMonitor: @unchecked Sendable {
             let isWired = path.status == .satisfied && path.usesInterfaceType(.wiredEthernet)
             guard let self else { return }
             self.lock.lock()
+            let changed = self.hasReceivedPath && self.wired != isWired
+            self.hasReceivedPath = true
             self.wired = isWired
             self.lock.unlock()
+            // A wired<->wireless transition invalidates the bandwidth
+            // measurement (it was taken on the other link), so re-probe.
+            // Only on a real transition — the initial path update is covered
+            // by the login-time probe.
+            if changed {
+                Task { await JellyfinClient.shared.startBandwidthMeasurement() }
+            }
         }
         monitor.start(queue: queue)
     }

--- a/Shared/Services/PlayerDiagnostics.swift
+++ b/Shared/Services/PlayerDiagnostics.swift
@@ -125,6 +125,9 @@ enum PlayerDiagnostics {
         case newItem = "new-item"
         /// The quality menu rebuilt the player against a new media source.
         case qualityChange = "quality-change"
+        /// The error/stall recovery fallback rebuilt the player at the
+        /// current position (official-client onPlaybackError pattern).
+        case recovery = "recovery"
         /// Playback reached the end of the item.
         case playbackEnded = "playback-ended"
         /// The view model was deallocated.

--- a/Shared/ViewModels/PlayerViewModel.swift
+++ b/Shared/ViewModels/PlayerViewModel.swift
@@ -144,6 +144,26 @@ final class PlayerViewModel: ObservableObject {
     private var playbackStartDate: Date?
     private var isOfflinePlayback = false
 
+    // MARK: Recovery (official-client error fallback)
+
+    /// How many recovery rebuilds this item has burned. Two attempts max —
+    /// first forces a transcode (fresh session at the current position, video
+    /// copy still allowed), the second additionally disallows video stream
+    /// copy (a genuine re-encode, the last resort). Mirrors jellyfin-web's
+    /// onPlaybackError escalation. Reset per item in loadMedia.
+    private var recoveryAttempts = 0
+    /// Re-entrancy guard: a failed item can fire status + error-log + stall
+    /// notifications for the same underlying failure in one runloop.
+    private var isRecovering = false
+    /// Pending stall watchdog — armed on a stall notification, cancelled when
+    /// playback recovers on its own or the player is torn down.
+    private var stallWatchdogTask: Task<Void, Never>?
+
+    /// Whether the error/stall fallback can still fire for this item.
+    private var canAttemptRecovery: Bool {
+        !isRecovering && !isOfflinePlayback && recoveryAttempts < 2 && currentItem != nil
+    }
+
     /// Subtitles that came down with a download. Injected by the iOS player,
     /// because the download store lives in the app target and this view model
     /// is shared. Empty for online playback.
@@ -367,6 +387,11 @@ final class PlayerViewModel: ObservableObject {
         offlineSubtitles: [OfflineSubtitle] = []
     ) async {
         playbackAttempt += 1
+        // Fresh item, fresh recovery budget; a watchdog armed for the old
+        // player must not fire into the new one.
+        recoveryAttempts = 0
+        stallWatchdogTask?.cancel()
+        stallWatchdogTask = nil
         diag(.loadBegin, [
             PlayerDiagnostics.field("item", item.id),
             PlayerDiagnostics.field("type", item.type?.rawValue),
@@ -870,6 +895,121 @@ final class PlayerViewModel: ObservableObject {
         }
     }
 
+    /// Official-client error fallback (jellyfin-web's `onPlaybackError`):
+    /// when the stream fails or stalls unrecoverably, rebuild playback at the
+    /// current position forcing a transcode — a fresh session whose segments
+    /// are produced from where the viewer actually is. The first attempt
+    /// keeps video stream-copy allowed (a fresh remux session clears the
+    /// jellyfin#16070 seek-freeze, whose broken state is per-session); the
+    /// second disallows it (genuine re-encode — the last resort, and the
+    /// escalation jellyfin-web uses). Two attempts per item, then the error
+    /// surfaces normally.
+    private func attemptPlaybackRecovery(reason: String) async {
+        guard !isRecovering,
+              !isOfflinePlayback,
+              recoveryAttempts < 2,
+              let item = currentItem else { return }
+        isRecovering = true
+        defer { isRecovering = false }
+        recoveryAttempts += 1
+        let attempt = recoveryAttempts
+        stallWatchdogTask?.cancel()
+        stallWatchdogTask = nil
+
+        // Prefer the live position; a dead/unstarted player falls back to the
+        // last known resume point rather than restarting from zero.
+        let liveSeconds = player?.currentTime().seconds ?? 0
+        let positionTicks = (liveSeconds.isFinite && liveSeconds > 1)
+            ? Int64(liveSeconds * 10_000_000)
+            : resumePositionTicks
+
+        playbackAttempt += 1
+        diag(.loadBegin, [
+            PlayerDiagnostics.field("phase", "recovery"),
+            PlayerDiagnostics.field("recoveryAttempt", attempt),
+            PlayerDiagnostics.field("trigger", reason),
+            PlayerDiagnostics.field("allowVideoStreamCopy", attempt < 2),
+            PlayerDiagnostics.field("positionSeconds", Double(positionTicks) / 10_000_000)
+        ])
+
+        // Clear the surfaced failure — the rebuild is the response to it.
+        error = nil
+        errorMessage = nil
+
+        // Teardown mirrors changeQuality.
+        diag(.teardown, [
+            PlayerDiagnostics.field("reason", PlayerDiagnostics.TeardownReason.recovery.rawValue),
+            PlayerDiagnostics.field("item", item.id)
+        ])
+        player?.pause()
+        progressReportTask?.cancel()
+        subtitleLoadTask?.cancel()
+        cleanupSegmentTracking()
+        subtitleManager.clear()
+        selectedSubtitleTrackId = "off"
+        if let endObserver {
+            NotificationCenter.default.removeObserver(endObserver)
+            self.endObserver = nil
+        }
+        invalidatePlayerObservers()
+        player = nil
+        isLoading = true
+        await stopActiveEncodingIfNeeded(reason: .recovery)
+
+        do {
+            try await setupPlayer(
+                for: item,
+                maxBitrate: selectedQuality.maxBitrate,
+                maxWidth: selectedQuality.maxWidth,
+                forceTranscode: true,
+                allowVideoStreamCopy: attempt < 2
+            )
+            isLoading = false
+            updateNowPlayingInfo(item: item)
+            if positionTicks > 0 {
+                pendingResumeTicks = positionTicks
+            }
+            if !applySessionSubtitlePreference() {
+                applyPreferredSubtitles()
+            }
+            if await !applySessionAudioPreference() {
+                await applyPreferredAudioLanguage()
+            }
+            await fetchSegments(itemId: item.id)
+            startProgressReporting()
+            setupSegmentTracking()
+            logAndPlay(positionTicks: positionTicks)
+        } catch {
+            diagFailure(.loadFailed, [
+                PlayerDiagnostics.field("phase", "recovery"),
+                PlayerDiagnostics.field("recoveryAttempt", attempt),
+                PlayerDiagnostics.field("item", item.id)
+            ] + PlayerDiagnostics.fields(for: error))
+            self.error = error
+            self.errorMessage = error.localizedDescription
+            isLoading = false
+        }
+    }
+
+    /// Arms (or re-arms) the stall watchdog: if the player still isn't making
+    /// progress `stallGraceSeconds` after a stall notification, treat it as
+    /// the unrecoverable freeze and run recovery. Ordinary buffering resumes
+    /// on its own well inside the grace window and cancels nothing — the
+    /// watchdog just finds the position advanced and stands down.
+    private func armStallWatchdog() {
+        stallWatchdogTask?.cancel()
+        let stalledAt = player?.currentTime().seconds ?? 0
+        stallWatchdogTask = Task { [weak self] in
+            try? await Task.sleep(for: .seconds(8))
+            guard !Task.isCancelled, let self else { return }
+            guard let player = self.player,
+                  player.timeControlStatus != .playing else { return }
+            let now = player.currentTime().seconds
+            guard now.isFinite, abs(now - stalledAt) < 0.5 else { return }
+            await self.attemptPlaybackRecovery(reason: "stall-watchdog")
+        }
+    }
+
     /// Applies the saved resume position once the item can actually seek.
     ///
     /// This is now the ONLY place a resume position is applied. It runs from
@@ -961,7 +1101,10 @@ final class PlayerViewModel: ObservableObject {
     }
 
     /// Shared player setup: resolves stream URL, creates AVPlayer with observers.
-    private func setupPlayer(for item: BaseItemDto, maxBitrate: Int? = nil, maxWidth: Int? = nil, forceTranscode: Bool = false) async throws {
+    /// `allowVideoStreamCopy` is only ever false on the second recovery
+    /// attempt (see attemptPlaybackRecovery) — the normal path always permits
+    /// the server to copy the video stream untouched.
+    private func setupPlayer(for item: BaseItemDto, maxBitrate: Int? = nil, maxWidth: Int? = nil, forceTranscode: Bool = false, allowVideoStreamCopy: Bool = true) async throws {
         // Bitrate precedence: explicit override (quality menu change) →
         // session quality selection → global Settings cap. QualityOption.auto
         // has a nil bitrate, so "Auto" defers to Settings, where 0 = no cap.
@@ -986,12 +1129,13 @@ final class PlayerViewModel: ObservableObject {
             PlayerDiagnostics.field("maxWidth", maxWidth),
             PlayerDiagnostics.field("forceTranscode", forceTranscode),
             PlayerDiagnostics.field("forceDirectPlay", playbackSettings.forceDirectPlay),
-            // Video stream-copy is allowed again (see getPlaybackInfo): the
-            // Apple TV decodes the source codec natively, so we remux + copy
-            // rather than re-encode. The stream-copy HLS seek-freeze
-            // (jellyfin#16070, #4188) is handled by re-anchoring on seek, not
-            // by transcoding.
-            PlayerDiagnostics.field("allowVideoStreamCopy", true)
+            // Video stream-copy is normally allowed (see getPlaybackInfo): the
+            // Apple TV decodes the source codec natively, so the server remuxes
+            // + copies rather than re-encodes. False only on the second
+            // recovery attempt — the stream-copy HLS seek-freeze
+            // (jellyfin#16070, #4188) is handled by the error/stall recovery
+            // fallback (attemptPlaybackRecovery), the official-client pattern.
+            PlayerDiagnostics.field("allowVideoStreamCopy", allowVideoStreamCopy)
         ])
 
         // Phase 1 of the VLC work: the profile can be VLC-shaped for
@@ -1005,7 +1149,8 @@ final class PlayerViewModel: ObservableObject {
             maxBitrate: effectiveBitrate,
             maxWidth: maxWidth,
             forceDirectPlay: playbackSettings.forceDirectPlay,
-            forceTranscode: forceTranscode
+            forceTranscode: forceTranscode,
+            allowVideoStreamCopy: allowVideoStreamCopy
         )
 
         // Source-aware retry (Auto path only). The source bitrate is only known
@@ -1035,7 +1180,8 @@ final class PlayerViewModel: ObservableObject {
                 maxBitrate: override.maxBitrate,
                 maxWidth: override.maxWidth,
                 forceDirectPlay: playbackSettings.forceDirectPlay,
-                forceTranscode: forceTranscode
+                forceTranscode: forceTranscode,
+                allowVideoStreamCopy: allowVideoStreamCopy
             )
         }
 
@@ -1167,8 +1313,15 @@ final class PlayerViewModel: ObservableObject {
                     self.diagFailure(.itemStatus, [
                         PlayerDiagnostics.field("status", "failed")
                     ] + PlayerDiagnostics.fields(for: observed.error))
-                    self.errorMessage = observed.error?.localizedDescription ?? "Unknown playback error"
-                    self.error = observed.error
+                    // Recovery first (official-client pattern): rebuild at the
+                    // current position forcing a transcode. The error only
+                    // surfaces once recovery is exhausted.
+                    if self.canAttemptRecovery {
+                        await self.attemptPlaybackRecovery(reason: "item-failed")
+                    } else {
+                        self.errorMessage = observed.error?.localizedDescription ?? "Unknown playback error"
+                        self.error = observed.error
+                    }
                 } else if observed.status == .readyToPlay {
                     self.logTrackAvailability(for: observed)
                     self.applyPendingResumeSeekIfNeeded()
@@ -1300,6 +1453,9 @@ final class PlayerViewModel: ObservableObject {
             guard let item = note.object as? AVPlayerItem else { return }
             Task { @MainActor in
                 self?.logSeekLanding(on: item, cause: "playback-stalled")
+                // A stall that never recovers is the seek-freeze; give normal
+                // buffering a grace window, then rebuild at position.
+                self?.armStallWatchdog()
             }
         })
 
@@ -1310,9 +1466,13 @@ final class PlayerViewModel: ObservableObject {
         ) { [weak self] note in
             let error = note.userInfo?[AVPlayerItemFailedToPlayToEndTimeErrorKey] as? Error
             Task { @MainActor in
-                self?.diagFailure(.itemStatus, [
+                guard let self else { return }
+                self.diagFailure(.itemStatus, [
                     PlayerDiagnostics.field("event", "failed-to-play-to-end")
                 ] + PlayerDiagnostics.fields(for: error))
+                if self.canAttemptRecovery {
+                    await self.attemptPlaybackRecovery(reason: "failed-to-play-to-end")
+                }
             }
         })
     }
@@ -1377,6 +1537,10 @@ final class PlayerViewModel: ObservableObject {
         rateObserver?.invalidate()
         rateObserver = nil
         removeItemLogObservers()
+        // A watchdog armed for this player must not fire into whatever
+        // replaces it. (Recovery re-arms its own if the new stream stalls.)
+        stallWatchdogTask?.cancel()
+        stallWatchdogTask = nil
     }
 
     func stop(reason: PlayerDiagnostics.TeardownReason = .unspecified) async {

--- a/project.yml
+++ b/project.yml
@@ -66,7 +66,7 @@ targets:
     settings:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.mondominator.sashimi
-        MARKETING_VERSION: 1.2.10
+        MARKETING_VERSION: 1.2.11
         CURRENT_PROJECT_VERSION: 2
         SWIFT_VERSION: 5.9
         SDKROOT: appletvos
@@ -144,7 +144,7 @@ targets:
         # Shared bundle ID with the tvOS app for Universal Purchase (one "Sashimi"
         # app spanning Apple TV + iPhone + iPad). Distinguished by platform.
         PRODUCT_BUNDLE_IDENTIFIER: com.mondominator.sashimi
-        MARKETING_VERSION: 1.2.10
+        MARKETING_VERSION: 1.2.11
         CURRENT_PROJECT_VERSION: 1
         SWIFT_VERSION: 5.9
         SDKROOT: iphoneos
@@ -186,7 +186,7 @@ targets:
     settings:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.mondominator.sashimi.topshelf
-        MARKETING_VERSION: 1.2.10
+        MARKETING_VERSION: 1.2.11
         CURRENT_PROJECT_VERSION: 2
         SWIFT_VERSION: 5.9
         SDKROOT: appletvos


### PR DESCRIPTION
Implements the approved convergence plan from the player architecture review (`plans/sashimi/2026-08-06-player-architecture-review.md`): adopt the official clients' recovery pattern instead of the never-built re-anchor.

## What changed
1. **Error/stall recovery fallback** (jellyfin-web `onPlaybackError`): on item failure, failed-to-play-to-end, or a stall that doesn't recover within 8s → rebuild playback at the current position forcing a transcode. Attempt 1 keeps video stream-copy allowed (fresh session clears the per-session jellyfin#16070 freeze); attempt 2 disallows copy (genuine re-encode, last resort). Two attempts per item, storm-guarded, offline exempt.
2. **Probe freshness**: measurement timestamped; Auto playback kicks a background re-probe when >1h stale; a wired↔wireless path change re-probes immediately. Never blocks playback.
3. **Truth cleanup**: comments claiming a re-anchor-on-seek mechanism exists now describe reality; dangling BreakOnNonKeyFrames fragment removed.

## Verified
- ✅ Full suite: **227 tests pass**; SwiftLint clean; tvOS+iOS compile
- ⚠️ Recovery paths are inherently hard to trigger on demand — verified by code-path review + diagnostics; will validate opportunistically on hardware (any future freeze should now self-heal within ~8s instead of sitting there)

Fixes #370