### PR TITLE
feat: show release year before runtime on movie detail

### DIFF
--- a/Sashimi/Views/Detail/MediaDetailView.swift
+++ b/Sashimi/Views/Detail/MediaDetailView.swift
@@ -739,9 +739,14 @@ struct MediaDetailView: View {
             if seasonCount > 0 {
                 parts.append(seasonCount == 1 ? "1 Season" : "\(seasonCount) Seasons")
             }
-        } else if let runtime = DateFormatting.formatRuntime(item.runTimeTicks) {
-            // Only show runtime for non-series content
-            parts.append(runtime)
+        } else {
+            // Movie: release year, then runtime.
+            if let year = item.productionYear {
+                parts.append(String(year))
+            }
+            if let runtime = DateFormatting.formatRuntime(item.runTimeTicks) {
+                parts.append(runtime)
+            }
         }
 
         return parts.joined(separator: " • ")

--- a/SashimiMobile/Views/Detail/MobileDetailView.swift
+++ b/SashimiMobile/Views/Detail/MobileDetailView.swift
@@ -457,7 +457,11 @@ struct MobileDetailView: View {
 
             // Metadata row
             HStack(spacing: MobileSpacing.sm) {
-                if let premiereDateStr = item.premiereDate {
+                // Movies lead with the release year (right before the runtime);
+                // episodes keep their full air date.
+                if isMovie, let year = item.productionYear {
+                    Text(String(year))
+                } else if let premiereDateStr = item.premiereDate {
                     Text(formatPremiereDate(premiereDateStr))
                 }
 

--- a/SashimiMobile/Views/Phone/PhoneDetailView.swift
+++ b/SashimiMobile/Views/Phone/PhoneDetailView.swift
@@ -537,7 +537,11 @@ struct PhoneDetailView: View {
 
     private var metadataParts: [String] {
         var parts: [String] = []
-        if let dateText = premiereDateLongText {
+        // Movies lead with the release year (right before the runtime);
+        // episodes/others keep their full air date.
+        if isMovie, let year = item.productionYear {
+            parts.append(String(year))
+        } else if let dateText = premiereDateLongText {
             parts.append(dateText)
         } else if let year = item.productionYear {
             parts.append(String(year))

--- a/project.yml
+++ b/project.yml
@@ -66,7 +66,7 @@ targets:
     settings:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.mondominator.sashimi
-        MARKETING_VERSION: 1.2.12
+        MARKETING_VERSION: 1.2.13
         CURRENT_PROJECT_VERSION: 2
         SWIFT_VERSION: 5.9
         SDKROOT: appletvos
@@ -144,7 +144,7 @@ targets:
         # Shared bundle ID with the tvOS app for Universal Purchase (one "Sashimi"
         # app spanning Apple TV + iPhone + iPad). Distinguished by platform.
         PRODUCT_BUNDLE_IDENTIFIER: com.mondominator.sashimi
-        MARKETING_VERSION: 1.2.12
+        MARKETING_VERSION: 1.2.13
         CURRENT_PROJECT_VERSION: 1
         SWIFT_VERSION: 5.9
         SDKROOT: iphoneos
@@ -186,7 +186,7 @@ targets:
     settings:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.mondominator.sashimi.topshelf
-        MARKETING_VERSION: 1.2.12
+        MARKETING_VERSION: 1.2.13
         CURRENT_PROJECT_VERSION: 2
         SWIFT_VERSION: 5.9
         SDKROOT: appletvos


### PR DESCRIPTION
Movie detail metadata now leads with the release **year** right before the runtime, on all Apple targets. tvOS previously showed runtime only; iOS showed a full release date — both now show `2023 • 3h 0m` for movies. Episodes keep their full air date (type-gated on `.movie`). Compiles; SwiftLint clean.