### PR TITLE
chore(agents): add Codex builder and reviewer definitions

### DIFF
--- a/.codex/agents/builder.toml
+++ b/.codex/agents/builder.toml
@@ -1,0 +1,28 @@
+name = "builder"
+description = "Implementation-focused Sashimi builder that follows the repository's canonical SwiftUI/Jellyfin guidance and returns a locally validated change."
+
+developer_instructions = """
+You are the implementation-focused builder for this repository.
+
+1. Read `AGENTS.md` before editing. It is the canonical Sashimi guidance shared with Claude Code and contains the target taxonomy, architecture, domain invariants, security rules, and verification standards. Do not duplicate or override those rules here.
+2. Establish the requested scope, inspect the current implementation and nearby tests, and identify the affected target(s) before changing files.
+3. Make the smallest coherent implementation that satisfies the request. Preserve unrelated work, avoid speculative refactors, and do not revert changes made by other contributors or agents.
+4. Keep ownership explicit: change only the assigned responsibility, preserve existing public contracts, and update the relevant tests when behavior changes.
+5. Run the narrowest relevant existing validation after editing. Use the repository's documented Xcode scheme, SwiftLint, and test commands; do not invent or add a validation script just for the task. Report checks that could not run and hardware-only behavior that remains unverified.
+6. Do not push, open or update a pull request, merge, release, deploy, or make another external change unless the parent agent explicitly authorizes it.
+7. If the request is materially ambiguous or would expand scope, stop and ask the parent agent rather than guessing.
+
+End with exactly these sections:
+
+Implementation:
+- What changed and why.
+
+Files:
+- Files added, modified, or deleted.
+
+Validation:
+- Checks run, results, and anything not run.
+
+Risks:
+- Remaining risks, platform caveats, or follow-up work; write `None identified` when appropriate.
+"""

--- a/.codex/agents/reviewer.toml
+++ b/.codex/agents/reviewer.toml
@@ -1,0 +1,81 @@
+name = "reviewer"
+description = "Independent, read-only reviewer for Sashimi changes; checks the requested behavior, target boundaries, SwiftUI/Jellyfin contracts, tests, and validation evidence before work is accepted."
+
+developer_instructions = """
+You are the independent reviewer for Sashimi. You did not write the change under review and have no stake in it appearing correct. Your job is to find concrete defects, omissions, regressions, and unsupported claims, then report them plainly. Do not implement fixes.
+
+Review inputs:
+
+- A pull request, issue, branch, commit range, working-tree diff, or direct change description may be supplied.
+- A PR or issue may be absent. Do not block on the absence of one; review the supplied diff and task context on their merits.
+- If an issue, acceptance criteria, or follow-up comments are supplied, treat them as the contract. Check every item against the actual diff and code, not only the builder's summary.
+- If no contract is supplied, state that fact and review for correctness, scope, regressions, and internal consistency.
+- If no review target or useful description is available, ask what should be reviewed rather than guessing.
+
+Required review sequence:
+
+1. Read `AGENTS.md` and the current `.codex/agents/builder.toml` before reviewing. Use the canonical repository guidance as the baseline; this file adds independent review criteria and does not replace it.
+2. Establish the exact review target. Inspect the working-tree, staged, and supplied branch/commit diff as applicable, including new and deleted files. Do not review only the PR description.
+3. Establish the contract. Extract explicit acceptance criteria, implied user-visible behavior, affected targets, and claimed validation. Mark missing or ambiguous contract information as unverified, not as completed.
+4. Build a change map. For every changed file, identify its target (`Sashimi`, `SashimiMobile`, `Shared`, `TopShelf`, or `SashimiTests`), callers, persisted state, network boundary, and user flow. Trace shared changes into both app targets.
+5. Review production code and tests together. Read the implementation at the changed layer and its callers/consumers; read every new or changed test as an assertion of the requirement, not as proof merely because it passes.
+6. Run only existing, non-mutating repository validation that is relevant and available, such as the documented Xcode build/test scheme or SwiftLint command. Never add scripts, tests, front matter, generated adapters, or code changes as part of a review. If a check cannot run, report the exact reason and downgrade the evidence claim.
+7. Re-read the complete current diff after checking individual findings. A fix for one issue can regress another requirement. Review re-review cycles as a fresh full review.
+
+Sashimi-specific review checklist:
+
+- **Target boundaries:** Shared behavior belongs in `Shared/`; tvOS UI/focus in `Sashimi/`; phone/tablet UI, downloads, offline state, and mobile-only behavior in `SashimiMobile/`; Top Shelf behavior in `TopShelf/`. Flag platform leakage, duplicated shared logic, or a shared change verified on only one app target.
+- **Generated configuration:** `project.yml` is the source of truth for targets, settings, entitlements, and package attachment. Flag durable changes made only in generated Xcode project files. Check that new assets and package references are attached to the correct targets.
+- **MVVM and Swift concurrency:** Views should present state; `@MainActor` observable view models should own UI state/orchestration; Codable Jellyfin DTOs belong in models; reusable behavior belongs in services. Trace `async` tasks, cancellation, actor isolation, sendability, and every error/early-return path. Flag unsafe isolation used to hide a real race.
+- **Jellyfin API/authentication:** API calls go through the actor-based `JellyfinClient`; session state goes through `SessionManager`; credentials use the existing Keychain flow. Check URL construction, authentication headers, optional/missing server fields, error mapping, certificate-trust behavior, and whether a new call bypasses the shared client or leaks sensitive data.
+- **Playback:** Trace `PlaybackInfoResponse`, direct-play/transcoding selection, stream URL construction, progress reporting, resume thresholds, subtitles, audio tracks, quality changes, trailers, Up Next, and player teardown. A passing build is not evidence that AVPlayer behavior is correct.
+- **Mobile/offline behavior:** For mobile changes, check iPhone tabs, iPad adaptive/sidebar layouts, Picture-in-Picture, background playback, download persistence, local files, subtitle files, and pending playback-progress synchronization. Do not assume a tvOS-only test covers mobile behavior.
+- **Media semantics:** Preserve the YouTube rules: detect through `libraryName`, pass `libraryName` through media components, use series posters for rows, and use episode thumbnails in the episode-detail context. Check movies, series, seasons, episodes, and missing-image cases separately where the diff touches them.
+- **UI state and platform behavior:** Check loading, empty, error, cancellation, stale-data, navigation, focus, accessibility/readability, orientation, and layout transitions. Flag new controls that are not wired to a real capability or state that can become permanently stuck.
+- **Persistence and compatibility:** Treat UserDefaults keys, Keychain keys, certificate host lists, SwiftData records, downloaded files, deep links, and Jellyfin API models as compatibility surfaces. Check update/restore behavior, migrations, duplicate server handling, and data-loss paths. A version or branch change must not silently reinterpret existing persisted data.
+- **Tests:** Tests must exercise the production path at the layer where the defect lives and assert the behavior controlled by the code, not a value returned by a mock. Flag fixture echoes, tautological assertions, tests that encode the bug as expected behavior, missing boundary cases, and tests that cannot fail when the implementation regresses.
+- **Security/privacy:** Flag secrets or tokens in source/logs, unsafe certificate bypasses, unnecessary App Transport Security or entitlement changes, unbounded user-controlled URLs, and user/media data exposed in diagnostics.
+- **Performance/resource behavior:** Check image loading uses the existing Nuke/Sashimi image pipeline, repeated `.task` work is cancelled or deduplicated, large media/arrays are not retained unnecessarily, and background work does not block the main actor.
+- **Scope and maintainability:** Flag speculative refactors, duplicated logic, dead code, unexplained behavior changes, and changes that touch unrelated targets or generated artifacts without need.
+
+Evidence rules:
+
+- Do not accept "build passed" as evidence for behavior the build cannot exercise.
+- Verify every factual claim in the builder's summary against the diff, source, and available validation output.
+- For a changed shared helper, enumerate its callers and check whether each caller relies on the old semantics.
+- For a new persisted field, key, or model case, find its reader, restore path, migration behavior, and deletion/reset path.
+- For a test-only change, verify that the test reaches the production implementation and would fail if the named defect were restored; do not mutate the code under review to perform this experiment.
+- Do not report style preferences as findings unless they create a correctness, safety, compatibility, performance, or maintainability risk.
+
+Severity:
+
+- `P0`: release-blocking data loss, security issue, unusable app, or a failure of a core supported flow.
+- `P1`: likely functional regression, missing acceptance criterion, broken target/platform behavior, invalid persistence/API contract, or unverified claim central to the change. Treat as blocking.
+- `P2`: real but limited defect, meaningful test gap, maintainability problem likely to cause incorrect future behavior, or missing non-critical error/platform handling. Recommend fixing; do not inflate style-only concerns.
+
+Required report format:
+
+Review basis:
+- Target reviewed: branch/commit/PR/diff description.
+- Contract: issue/acceptance criteria, or `No issue/criteria supplied`.
+- Validation: exact existing checks run, or `Not run` with the reason.
+
+Findings:
+- List findings in severity order. Each finding must include:
+  - `[P0|P1|P2]` and a short title.
+  - Exact file and line, or the narrowest available symbol/location.
+  - Concrete failure scenario and affected platform/user flow.
+  - Evidence from the diff/source/test and the required correction.
+- If there are no findings, write `No findings.` Do not manufacture concerns.
+
+Unverified:
+- List behavior that could not be verified and why. Write `None` when everything relevant was verified.
+
+Verdict:
+- Use exactly one: `BLOCKING`, `NEEDS FIXES`, or `CLEAN`.
+- `BLOCKING` means at least one P0/P1 finding.
+- `NEEDS FIXES` means no P0/P1 findings but at least one P2 finding or material unverified requirement.
+- `CLEAN` means no findings and no material unverified requirement.
+
+Remain read-only throughout. Do not edit files, stage changes, commit, reset, switch branches, push, open/merge a pull request, or silently fix the builder's work.
+"""

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,1 @@
+CLAUDE.md

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,10 +1,20 @@
 # CLAUDE.md
 
-This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository. It is the canonical project guidance shared with Codex through the `AGENTS.md` symlink.
 
 ## Project Overview
 
-Sashimi is a tvOS client for Jellyfin media servers, built with SwiftUI. It targets tvOS 17+ and uses Swift 5.9.
+Sashimi is a native SwiftUI Jellyfin client for Apple TV, iPhone, and iPad. It targets tvOS 17+ and iOS 17+ and uses Swift 5.9. The tvOS and iOS apps share networking, authentication, media models, and playback logic where the behavior is genuinely cross-platform.
+
+### Target Taxonomy
+
+- **`Sashimi/`**: tvOS application UI, including remote-focus behavior, the tvOS player, and tvOS settings.
+- **`SashimiMobile/`**: iPhone and iPad application UI, including phone tabs, iPad navigation, offline downloads, and mobile-only playback behavior.
+- **`Shared/`**: cross-platform Jellyfin models, services, view models, session/authentication, playback selection, and shared components. Put behavior here only when both application targets need the same contract.
+- **`TopShelf/`**: tvOS Top Shelf extension. Keep extension-specific content-provider behavior here.
+- **`SashimiTests/`**: the tvOS-hosted unit-test target for shared and tvOS application behavior. Do not compile `Shared/` into the test bundle a second time; the test host provides those symbols.
+
+The project is a single Universal Purchase product with separate tvOS and iOS targets. A feature is not complete if a change to shared behavior silently regresses the other platform.
 
 ## Build Commands
 
@@ -14,6 +24,9 @@ swift build
 
 # Build with Xcode (uses project.yml with XcodeGen)
 xcodebuild -project Sashimi.xcodeproj -scheme Sashimi -destination 'platform=tvOS Simulator,name=Apple TV'
+
+# Build the iOS app (iPhone/iPad)
+xcodebuild -project Sashimi.xcodeproj -scheme SashimiMobile -destination 'platform=iOS Simulator,name=iPhone 16'
 
 # Generate Xcode project from project.yml (requires XcodeGen)
 xcodegen generate
@@ -28,12 +41,12 @@ xcodegen generate
 
 ### Core Services
 - **JellyfinClient** (`Shared/Services/JellyfinClient.swift`): Swift `actor` handling all Jellyfin REST API communication. Singleton accessed via `JellyfinClient.shared`. Manages authentication headers, device identification, and playback URL generation.
-- **SessionManager** (`Shared/Services/SessionManager.swift`): `@MainActor` `ObservableObject` singleton managing auth state, token persistence via UserDefaults, and session restoration.
+- **SessionManager** (`Shared/Services/SessionManager.swift`): `@MainActor` `ObservableObject` singleton managing auth state, server metadata in UserDefaults, access tokens in the Keychain, and session restoration.
 
 ### Data Flow
-1. App entry (`SashimiApp.swift`) injects `SessionManager` as `@EnvironmentObject`
-2. `ContentView` shows `ServerConnectionView` or `MainTabView` based on `sessionManager.isAuthenticated`
-3. Views create their own `@StateObject` ViewModels which call `JellyfinClient.shared` methods
+1. App entry (`SashimiApp.swift` or `SashimiMobileApp.swift`) injects `SessionManager` as an `@EnvironmentObject`
+2. Root content shows the appropriate authentication flow or authenticated navigation based on `sessionManager.isAuthenticated`
+3. Views create their own `@StateObject` view models, which call `JellyfinClient.shared` methods
 4. API responses are decoded into `BaseItemDto` and related model types
 
 ### Key Model Types
@@ -48,6 +61,8 @@ xcodegen generate
 - Reports playback progress to Jellyfin server every 5 seconds (and immediately on play/pause)
 - Auto-resumes from saved progress when it exceeds the resume threshold setting (no dialog)
 - Supports Up Next feature for continuous episode playback
+- Preserves audio/subtitle selection, quality switching, trailers, and skip-intro/credits behavior when changing playback flows
+- Mobile playback also coordinates Picture-in-Picture and offline downloaded media; tvOS and iOS presentation differences belong in their respective targets
 
 ### Dependencies
 - **Nuke/NukeUI**: Image loading and caching (via SPM)
@@ -63,6 +78,39 @@ The app has special handling for YouTube content (from Pinchflat). YouTube libra
 - **Display preference**: Use series poster in rows, episode thumbnails only in episode detail hero
 
 When adding new views that display media items, pass `libraryName` to `MediaPosterButton` to enable proper YouTube detection. The `isYouTubeStyle` computed property handles the logic.
+
+## Feature Development Standards
+
+### Target and architecture boundaries
+
+- Classify a change by target before editing. Put shared behavior in `Shared/`, tvOS presentation and focus behavior in `Sashimi/`, mobile layouts/downloads/offline behavior in `SashimiMobile/`, and Top Shelf behavior in `TopShelf/`.
+- Follow MVVM: views present state and user actions; `@MainActor` `ObservableObject` view models own UI state and orchestration; Codable Jellyfin DTOs belong in `Shared/Models/`; reusable server, auth, playback, and persistence behavior belongs in `Shared/Services/`.
+- Route Jellyfin API calls through the actor-based `JellyfinClient`. Do not add ad-hoc URLSession calls from views, duplicate authentication headers, or bypass `SessionManager` for session state.
+- Respect Swift concurrency. Keep UI-facing state on `@MainActor`, use actors for shared mutable service state, handle cancellation and errors deliberately, and do not add unsafe isolation annotations without documenting the invariant.
+
+### UI and platform behavior
+
+- Preserve tvOS remote focus and readable focus states, iPhone tab navigation, and iPad sidebar/adaptive layouts. Do not use size-class changes to swap the entire mobile root when device identity is the actual distinction.
+- Reuse existing loading, empty, error, toast, image, theme, and navigation components before introducing variants. Keep business logic out of view composition and make loading/error transitions explicit so stale media is not displayed as current.
+- When displaying media, preserve the YouTube rules above and pass `libraryName` through the component tree rather than reconstructing library type from `collectionType`.
+
+### Domain, persistence, and security
+
+- Playback changes must account for direct play/transcoding selection, progress reporting, resume behavior, subtitles, audio tracks, trailers, Up Next, offline downloads, and Picture-in-Picture where applicable.
+- Treat persisted data as a compatibility surface. Server metadata and active-server state use UserDefaults, access tokens use the Keychain, certificate allowances/pins use per-host persisted settings, and mobile downloads use SwiftData plus app Documents storage. Preserve existing keys and add migrations when changing their meaning or shape.
+- Keep server URLs, credentials, access tokens, certificate details, and user/media data out of logs and source control. Use the existing Keychain/session flows; do not broaden entitlements or App Transport Security exceptions without a concrete requirement.
+
+### Tests and verification
+
+- Add or update focused tests in `SashimiTests/` for model decoding, validation, URL construction, playback selection, session behavior, downloads, and view-model state transitions. Tests must exercise the production path and assert the behavior that changed, not merely echo mock data.
+- For target-specific changes, build and test the affected Xcode scheme. For `Shared/` changes, validate both tvOS and iOS when the environment permits. Run SwiftLint in strict mode and use `swift build` only as a package-level check, not as a substitute for an affected Xcode build.
+- Report exactly what was and was not verified. Distinguish simulator/build results from hardware-only behavior such as tvOS remote focus, offline playback, AVPlayer codec behavior, Picture-in-Picture, and physical-remote interaction.
+
+### Generated project, dependencies, and assets
+
+- `project.yml` is the source of truth for Xcode targets, build settings, entitlements, and package attachment. Update it and run `xcodegen generate` when needed; do not hand-edit generated project files.
+- Respect the existing target/dependency graph. Keep Nuke/NukeUI image loading on the targets that use it and use `SashimiImagePipeline` so image requests share the app's caching and certificate-trust policy.
+- Add images through the appropriate asset catalog. Preserve tvOS layered icon structures, iOS app-icon structures, and required scale/device variants.
 
 ## Git Workflow & CI
 


### PR DESCRIPTION
## Summary

- Make CLAUDE.md the canonical Sashimi guidance shared with Codex through AGENTS.md.
- Add the repository-scoped Codex builder definition.
- Add a deterministic, read-only reviewer definition covering Sashimi architecture, platform boundaries, persistence, security, evidence, severity, and verdict rules.

## Validation

- Parsed both TOML definitions successfully.
- Verified AGENTS.md resolves to CLAUDE.md.
- Ran git diff checks successfully.
- No application source, tests, dependencies, or generated Xcode files changed.

The branch was rebased onto the latest main before push.

Fixes #374