### PR TITLE
YouTube Continue Watching cards show title only

### DIFF
--- a/Sashimi/Views/Home/ContinueWatchingRow.swift
+++ b/Sashimi/Views/Home/ContinueWatchingRow.swift
@@ -94,9 +94,9 @@ struct ContinueWatchingCard: View {
     }
 
     private var episodeInfoString: String {
-        // For YouTube, show date instead of S/E
-        if isYouTube, let dateStr = DateFormatting.formatDate(item.premiereDate) {
-            return "\(dateStr) - \(item.name)"
+        // For YouTube, show just the video title (no date)
+        if isYouTube {
+            return item.name
         }
         let season = item.parentIndexNumber ?? 1
         let episode = item.indexNumber ?? 1


### PR DESCRIPTION
Drops the `"{date} - "` prefix from the subtitle of **YouTube** videos in Continue Watching, so the card shows just the video title.

Parity change across all three clients (Roku + Android sibling PRs).

`episodeInfoString` now returns `item.name` for YouTube items instead of `"\(dateStr) - \(item.name)"`. Non-YouTube episodes (S/E) and movies are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XzUNvRCXML3DJe98KBCGkN