### PR TITLE
tvOS home: tighten content spacing to the rail

### DIFF
--- a/Sashimi/Views/Home/HomeView.swift
+++ b/Sashimi/Views/Home/HomeView.swift
@@ -472,7 +472,7 @@ struct HeroSection: View {
 
                         Spacer()
                     }
-                    .padding(.horizontal, 80)
+                    .padding(.horizontal, 40)
                 }
             }
             .aspectRatio(32/9, contentMode: .fit)
@@ -555,7 +555,7 @@ struct RecentlyAddedLibraryRow: View {
             Text(sectionTitle)
                 .font(.system(size: 40, weight: .bold))
                 .foregroundStyle(SashimiTheme.textPrimary)
-                .padding(.horizontal, 80)
+                .padding(.horizontal, 40)
 
             if isLoading {
                 HStack {
@@ -611,7 +611,7 @@ struct RecentlyAddedLibraryRow: View {
                             }
                         }
                     }
-                    .padding(.horizontal, 80)
+                    .padding(.horizontal, 40)
                     .padding(.vertical, 20)
                 }
             }


### PR DESCRIPTION
The home content sat `120` (rail) + `80` (horizontal padding) = **200px** from the screen edge — too far off the rail. Halves the padding to **40** on the hero title, section titles, and rows, so content sits closer to the rail. Matches the Roku home spacing fix.

tvOS-only (`Sashimi/Views/Home/HomeView.swift`); three `.padding(.horizontal, 80)` → `40`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XzUNvRCXML3DJe98KBCGkN