### PR TITLE
iOS Continue Watching: YouTube cards show title only (+ v1.2.16)

### DIFF
--- a/SashimiMobile/Views/Components/MobileContinueWatchingCard.swift
+++ b/SashimiMobile/Views/Components/MobileContinueWatchingCard.swift
@@ -79,12 +79,13 @@ struct MobileContinueWatchingCard: View {
         }
     }
 
-    // Episode info like tvOS: "S1:E1 - Episode Name" or "date - Episode Name" for YouTube
+    // Episode info like tvOS: "S1:E1 - Episode Name", or just the video title for YouTube
     private var episodeInfoText: String? {
         guard item.type == .episode else { return nil }
 
-        if isYouTube, let dateStr = item.premiereDate {
-            return "\(formatDate(dateStr)) - \(item.name)"
+        // YouTube: show just the video title (no date) — parity across platforms.
+        if isYouTube {
+            return item.name
         }
 
         let season = item.parentIndexNumber ?? 1
@@ -236,10 +237,6 @@ struct MobileContinueWatchingCard: View {
             }
         }
         .frame(height: 4)
-    }
-
-    private func formatDate(_ isoDate: String) -> String {
-        DateFormatting.formatShortNumericDate(isoDate) ?? ""
     }
 }
 

--- a/Shared/Extensions/DateFormatting.swift
+++ b/Shared/Extensions/DateFormatting.swift
@@ -29,12 +29,6 @@ enum DateFormatting {
         return formatter
     }()
 
-    private static let shortNumericFormatter: DateFormatter = {
-        let formatter = DateFormatter()
-        formatter.dateFormat = "M-d-yyyy"
-        return formatter
-    }()
-
     /// Long form, e.g. "May 7, 2026". Callers used to build two
     /// ISO8601DateFormatters plus a DateFormatter inline, inside computed
     /// properties — so three expensive allocations on every body evaluation, per
@@ -54,12 +48,6 @@ enum DateFormatting {
     static func formatMediumDate(_ isoString: String?) -> String? {
         guard let date = parseDate(isoString) else { return nil }
         return mediumDisplayFormatter.string(from: date)
-    }
-
-    /// Compact numeric form, e.g. "5-7-2026".
-    static func formatShortNumericDate(_ isoString: String?) -> String? {
-        guard let date = parseDate(isoString) else { return nil }
-        return shortNumericFormatter.string(from: date)
     }
 
     /// Parse an ISO8601 date string (with or without fractional seconds) and return a display string.

--- a/project.yml
+++ b/project.yml
@@ -66,7 +66,7 @@ targets:
     settings:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.mondominator.sashimi
-        MARKETING_VERSION: 1.2.15
+        MARKETING_VERSION: 1.2.16
         CURRENT_PROJECT_VERSION: 2
         SWIFT_VERSION: 5.9
         SDKROOT: appletvos
@@ -144,7 +144,7 @@ targets:
         # Shared bundle ID with the tvOS app for Universal Purchase (one "Sashimi"
         # app spanning Apple TV + iPhone + iPad). Distinguished by platform.
         PRODUCT_BUNDLE_IDENTIFIER: com.mondominator.sashimi
-        MARKETING_VERSION: 1.2.15
+        MARKETING_VERSION: 1.2.16
         CURRENT_PROJECT_VERSION: 1
         SWIFT_VERSION: 5.9
         SDKROOT: iphoneos
@@ -186,7 +186,7 @@ targets:
     settings:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.mondominator.sashimi.topshelf
-        MARKETING_VERSION: 1.2.15
+        MARKETING_VERSION: 1.2.16
         CURRENT_PROJECT_VERSION: 2
         SWIFT_VERSION: 5.9
         SDKROOT: appletvos


### PR DESCRIPTION
The earlier "YouTube CW cards show title only" change missed the **iOS** card — `MobileContinueWatchingCard` still returned `"{date} - {title}"`. This returns just the video title, so iOS matches tvOS, Roku, and Android.

Also removes the now-orphaned `DateFormatting.formatShortNumericDate` helper + its cached formatter (the CW card was its only caller).

Bumps `MARKETING_VERSION` → **1.2.16** (all three targets) for the TestFlight build.

Verified: builds clean locally for tvOS (installed to a device). iOS covered by CI (`Build iOS App` + SwiftLint).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XzUNvRCXML3DJe98KBCGkN