### PR TITLE
Continue Watching order, YouTube channel rows, detail polish (v1.2.17)

### DIFF
--- a/.claude/commands/install-tvs.md
+++ b/.claude/commands/install-tvs.md
@@ -1,0 +1,40 @@
+---
+description: Build the tvOS app and install it on both Apple TVs
+argument-hint: "[living|bedroom|both] (default: both)"
+---
+
+Build the current working tree and install it on the Apple TVs so I can look at
+it on a real screen. Argument picks the target; default both.
+
+```bash
+cd "$CLAUDE_PROJECT_DIR"
+xcodegen generate    # only if project.yml changed — it is the source of truth
+
+xcodebuild -project Sashimi.xcodeproj -scheme Sashimi -configuration Debug \
+  -destination 'platform=tvOS,name=Living Room' \
+  -allowProvisioningUpdates -derivedDataPath build/dd build
+```
+
+Then install the same built product to each device:
+
+| Device | ID |
+| --- | --- |
+| Living Room | `3DEAD265-908E-5316-B8C4-A29524449F94` |
+| Bedroom | `097AEE6F-7257-56FF-9247-2C4C2FFE238F` |
+
+```bash
+xcrun devicectl device install app --device <ID> \
+  build/dd/Build/Products/Debug-appletvos/Sashimi.app
+```
+
+Report which devices succeeded. Notes:
+
+- Build once, install twice — don't rebuild per device.
+- `xcrun devicectl list devices` re-discovers the IDs if one has changed.
+- The installed build reports the `MARKETING_VERSION` currently in `project.yml`,
+  which lags behind release branches. Don't read the version string as proof of
+  which code is running — the build timestamp is the reliable signal.
+- If a TV still shows the old UI, the app was running when it was replaced; tell
+  me to back out to the tvOS home screen and relaunch.
+- Anything focus-, remote-, or playback-related can only be judged on the device.
+  Say plainly what you verified and what you didn't.

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,36 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(xcodegen generate:*)",
+      "Bash(xcodebuild:*)",
+      "Bash(xcrun devicectl device install app:*)",
+      "Bash(xcrun devicectl list devices:*)",
+      "Bash(xcrun devicectl device info:*)",
+      "Bash(swiftlint lint:*)",
+      "Bash(swift build:*)",
+      "Bash(git status:*)",
+      "Bash(git diff:*)",
+      "Bash(git log:*)",
+      "Bash(git branch:*)",
+      "Bash(gh pr view:*)",
+      "Bash(gh pr checks:*)",
+      "Bash(gh run list:*)",
+      "Bash(gh run view:*)"
+    ]
+  },
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "Write|Edit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "jq -r \".tool_input.file_path // .tool_response.filePath // empty\" | { read -r f || exit 0; case \"$f\" in *.swift) ;; *) exit 0 ;; esac; cd \"${CLAUDE_PROJECT_DIR:-.}\" || exit 0; out=$(swiftlint lint --quiet --strict \"$f\" 2>&1) || { printf \"%s\\n\" \"$out\" | head -20; exit 2; }; }",
+            "timeout": 60,
+            "statusMessage": "SwiftLint..."
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -65,3 +65,6 @@ Thumbs.db
 *.provisionprofile
 .aider*
 Vendor/
+
+# Claude Code personal settings (project settings.json IS committed)
+.claude/settings.local.json

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,6 +32,15 @@ xcodebuild -project Sashimi.xcodeproj -scheme SashimiMobile -destination 'platfo
 xcodegen generate
 ```
 
+## Claude Code helpers
+
+`.claude/` holds this repo's automation (committed; `settings.local.json` is
+personal and gitignored):
+
+- **`/install-tvs`** — build the tvOS app and install it on both Apple TVs
+- A `PostToolUse` hook runs `swiftlint --strict` on each edited `.swift` file, so
+  violations surface at the edit rather than failing CI.
+
 ## Architecture
 
 ### MVVM Pattern

--- a/Sashimi/Views/Components/MediaRow.swift
+++ b/Sashimi/Views/Components/MediaRow.swift
@@ -226,7 +226,22 @@ struct MediaPosterButton: View {
                 }
                 .frame(width: cardWidth, height: cardHeight)
                 .clipShape(isCircular ? AnyShape(Circle()) : AnyShape(RoundedRectangle(cornerRadius: 12)))
-                // Circular overlays (outside the clip shape)
+                // Focus ring first: overlays stack in application order, so the
+                // badge below has to be added AFTER the ring or the 4pt stroke
+                // paints straight through it — on a circle the ring curve runs
+                // right under the top-trailing badge.
+                .overlay(
+                    Group {
+                        if isCircular {
+                            Circle()
+                                .stroke(isFocused ? SashimiTheme.focus : .clear, lineWidth: 4)
+                        } else {
+                            RoundedRectangle(cornerRadius: 12)
+                                .stroke(isFocused ? SashimiTheme.focus : .clear, lineWidth: 4)
+                        }
+                    }
+                )
+                // Circular overlays (outside the clip shape, above the ring)
                 .overlay(alignment: .topTrailing) {
                     if isCircular {
                         if let count = badgeCount, count >= 1 {
@@ -247,17 +262,6 @@ struct MediaPosterButton: View {
                         }
                     }
                 }
-                .overlay(
-                    Group {
-                        if isCircular {
-                            Circle()
-                                .stroke(isFocused ? SashimiTheme.focus : .clear, lineWidth: 4)
-                        } else {
-                            RoundedRectangle(cornerRadius: 12)
-                                .stroke(isFocused ? SashimiTheme.focus : .clear, lineWidth: 4)
-                        }
-                    }
-                )
                 .shadow(color: isFocused ? SashimiTheme.focusGlow : .clear, radius: 15, x: 0, y: 0)
 
                 MarqueeText(

--- a/Sashimi/Views/Detail/MediaDetailView.swift
+++ b/Sashimi/Views/Detail/MediaDetailView.swift
@@ -43,6 +43,24 @@ struct MediaDetailView: View {
     private var isSeries: Bool { item.type == .series }
     private var isEpisode: Bool { item.type == .episode }
     private var isVideo: Bool { item.type == .video }
+    private var isMovie: Bool { item.type == .movie }
+
+    /// Resolution / video codec / audio codec chips. Shared so movies can put
+    /// them on their own row while series and episodes keep them inline.
+    @ViewBuilder
+    private var qualityBadges: some View {
+        if let info = mediaInfo {
+            if let resolution = info.videoResolution {
+                mediaInfoBadge(resolution)
+            }
+            if let videoCodec = info.videoCodec {
+                mediaInfoBadge(formatCodec(videoCodec))
+            }
+            if let audioCodec = info.audioCodec, let channels = info.audioChannels {
+                audioInfoBadge(codec: audioCodec, channels: channels)
+            }
+        }
+    }
 
     // YouTube-style content uses landscape thumbnails instead of portrait posters
     private var isYouTubeStyle: Bool {
@@ -106,6 +124,20 @@ struct MediaDetailView: View {
         return "Backdrop"
     }
 
+    /// Fraction of the layout width the backdrop fills in its top-right section.
+    /// Single source of truth: the frame and the image request both derive from
+    /// it, so resizing the layout can't silently leave the request undersized.
+    ///
+    /// Sized so the backdrop's left edge clears the info column rather than
+    /// sitting under it. The poster is 200pt at x=60, so text runs from ~300;
+    /// at 0.45 the backdrop starts near x=1010, leaving ~700pt of clean space
+    /// for the title — a two-column composition instead of an overlap rescued
+    /// by a scrim. Series run slightly wider (logo, less body text) and YouTube
+    /// wider still (low-detail banners, short info column).
+    private var backdropWidthFraction: CGFloat {
+        isYouTubeSeriesStyle ? 0.58 : (isSeries ? 0.50 : 0.45)
+    }
+
     var body: some View {
         ScrollView {
             VStack(spacing: 0) {
@@ -122,21 +154,29 @@ struct MediaDetailView: View {
 
                     // Background image - top right (Plex-style)
                     VStack(spacing: 0) {
-                        Spacer().frame(height: 80)
+                        // Half the 120pt right inset: the artwork sits higher than
+                        // it is inset from the right, which reads better than an
+                        // equal inset because the page's weight is along the top.
+                        Spacer().frame(height: 60)
                         HStack {
                             Spacer()
                             AsyncItemImage(
                                 itemId: backdropId,
                                 imageType: backdropImageType,
-                                // Rendered into geometry.size.width * 0.45; a 4K
-                                // decode here is ~33 MB of backing store for no
-                                // visible gain on a 1080p layout space.
-                                maxWidth: 1920,
+                                // Request at native pixel density: tvOS lays out
+                                // in 1920pt but Apple TV 4K renders @2x, so a
+                                // point-width frame needs twice that many pixels
+                                // or the backdrop is upscaled and reads soft.
+                                maxWidth: Int(geometry.size.width * backdropWidthFraction * 2),
                                 contentMode: .fit,
                                 fallbackImageTypes: isYouTubeSeriesStyle ? ["Backdrop", "Thumb", "Primary"] : ["Thumb", "Backdrop", "Primary"]
                             )
                             .id(refreshID)
-                            .frame(width: geometry.size.width * (isYouTubeSeriesStyle ? 0.65 : (isSeries ? 0.55 : 0.45)), alignment: .topTrailing)
+                            // Fill the top-right section rather than floating in
+                            // it. The soft edge mask below means the extra width
+                            // reaching left under the text reads as a blend, not
+                            // a collision, so a little overlap is fine.
+                            .frame(width: geometry.size.width * backdropWidthFraction, alignment: .topTrailing)
                             // Soft edge gradients fading into background
                             .mask(
                                 // Use a combined gradient mask for smooth edges on all sides
@@ -160,7 +200,11 @@ struct MediaDetailView: View {
                                     )
                                 )
                             )
-                            .padding(.trailing, 140)
+                            // Deliberately wider than the content column's 60pt
+                            // gutter: the artwork is a background element, and
+                            // pulling it in off the right edge stops it reading as
+                            // pinned to the corner.
+                            .padding(.trailing, 120)
                         }
                         Spacer()
                     }
@@ -591,21 +635,26 @@ struct MediaDetailView: View {
                 }
             }
 
-            HStack(spacing: 16) {
-                if !isSeries {
+            if isMovie {
+                // Movies: ratings on one row, quality badges on their own row
+                // beneath, so a well-tagged release doesn't run off in one long
+                // line. The badge row is conditional on its own so nothing shows
+                // an empty row's worth of spacing before playback info lands.
+                HStack(spacing: 16) {
                     ratingsRow
                 }
-
-                if let info = mediaInfo {
-                    if let resolution = info.videoResolution {
-                        mediaInfoBadge(resolution)
+                if mediaInfo != nil {
+                    HStack(spacing: 16) {
+                        qualityBadges
                     }
-                    if let videoCodec = info.videoCodec {
-                        mediaInfoBadge(formatCodec(videoCodec))
+                }
+            } else {
+                // Series and episodes keep the single combined line.
+                HStack(spacing: 16) {
+                    if !isSeries {
+                        ratingsRow
                     }
-                    if let audioCodec = info.audioCodec, let channels = info.audioChannels {
-                        audioInfoBadge(codec: audioCodec, channels: channels)
-                    }
+                    qualityBadges
                 }
             }
 

--- a/Sashimi/Views/Home/HomeView.swift
+++ b/Sashimi/Views/Home/HomeView.swift
@@ -472,7 +472,17 @@ struct HeroSection: View {
 
                         Spacer()
                     }
-                    .padding(.horizontal, 40)
+                    // Wider margin than the rows below (which sit at 40 against
+                    // the rail): this is 64pt display type, and tightening it to
+                    // match the poster rows pushed the block uncomfortably far
+                    // left. Large type needs the extra breathing room.
+                    .padding(.horizontal, 80)
+                    // Centre the text in the hero's *solid* area, not its full
+                    // height. The bottom 10% is masked to transparent (and the
+                    // first row overlaps it), so centring on the raw height puts
+                    // the block visibly low. Reserving the faded band lifts it
+                    // to the optical centre.
+                    .padding(.bottom, geometry.size.height * 0.1)
                 }
             }
             .aspectRatio(32/9, contentMode: .fit)
@@ -538,6 +548,7 @@ struct RecentlyAddedLibraryRow: View {
     let onSelect: (BaseItemDto) -> Void
     @State private var items: [BaseItemDto] = []
     @State private var episodeCounts: [String: Int] = [:]  // seriesId -> count of new episodes
+    @State private var newestEpisodes: [String: BaseItemDto] = [:]  // channelId -> newest video
     @State private var isLoading = true
     @State private var loadError = false
 
@@ -607,7 +618,12 @@ struct RecentlyAddedLibraryRow: View {
                                 isCircular: isYouTubeLibrary,
                                 badgeCount: (unplayedCount ?? 0) >= 1 ? unplayedCount : nil
                             ) {
-                                onSelect(item)
+                                // The row lists channels (so one prolific uploader
+                                // can't crowd the others out), but opening a channel
+                                // page isn't what you want from "Recently Added" —
+                                // jump to the video that put it here. Falls back to
+                                // the channel if the prefetch hasn't landed.
+                                onSelect(newestEpisodes[item.id] ?? item)
                             }
                         }
                     }
@@ -633,8 +649,7 @@ struct RecentlyAddedLibraryRow: View {
                 parentId: library.id,
                 limit: fetchLimit,
                 includeWatched: true,
-                collectionType: library.collectionType,
-                isYouTubeLibrary: isYouTubeLibrary
+                collectionType: library.collectionType
             )
             let dedupedItems = deduplicateBySeries(latestItems)
             items = dedupedItems
@@ -642,6 +657,9 @@ struct RecentlyAddedLibraryRow: View {
             // Fetch actual unplayed counts from series (for TV shows)
             if isTVLibrary {
                 await loadUnplayedCounts(for: dedupedItems)
+            }
+            if isYouTubeLibrary {
+                await loadNewestEpisodes(for: dedupedItems)
             }
         } catch is CancellationError {
             // Ignore cancellation errors - expected during navigation
@@ -689,6 +707,43 @@ struct RecentlyAddedLibraryRow: View {
         counts.merge(fetched) { _, new in new }
 
         episodeCounts = counts
+    }
+
+    /// Resolve each channel's most recently added video, so selecting a card in a
+    /// YouTube row opens that video rather than the channel page. Prefetched
+    /// concurrently while the row renders, so the press itself never waits on a
+    /// round-trip.
+    private func loadNewestEpisodes(for items: [BaseItemDto]) async {
+        let channelIds = items.compactMap { $0.type == .series ? $0.id : nil }
+
+        let fetched = await withTaskGroup(of: (String, BaseItemDto)?.self) { group in
+            for channelId in channelIds {
+                group.addTask {
+                    do {
+                        let response = try await JellyfinClient.shared.getItems(
+                            parentId: channelId,
+                            includeTypes: [.episode],
+                            sortBy: "DateCreated",
+                            sortOrder: "Descending",
+                            limit: 1
+                        )
+                        guard let newest = response.items.first else { return nil }
+                        return (channelId, newest)
+                    } catch {
+                        // A channel that fails to resolve just falls back to
+                        // opening the channel page.
+                        return nil
+                    }
+                }
+            }
+            var out: [String: BaseItemDto] = [:]
+            for await result in group {
+                if let (channelId, episode) = result { out[channelId] = episode }
+            }
+            return out
+        }
+
+        newestEpisodes = fetched
     }
 
     private func deduplicateBySeries(_ items: [BaseItemDto]) -> [BaseItemDto] {

--- a/SashimiMobile/Views/Components/MobileRecentlyAddedRow.swift
+++ b/SashimiMobile/Views/Components/MobileRecentlyAddedRow.swift
@@ -118,8 +118,7 @@ struct MobileRecentlyAddedRow<Destination: View>: View {
                 parentId: libraryId,
                 limit: fetchLimit,
                 includeWatched: true,
-                collectionType: collectionType,
-                isYouTubeLibrary: isYouTubeLibrary
+                collectionType: collectionType
             )
             let dedupedItems = deduplicateBySeries(latestItems)
             items = dedupedItems

--- a/Shared/Services/JellyfinClient.swift
+++ b/Shared/Services/JellyfinClient.swift
@@ -802,7 +802,7 @@ actor JellyfinClient {
         return response.items
     }
 
-    func getLatestMedia(parentId: String? = nil, limit: Int = 16, includeWatched: Bool = false, collectionType: String? = nil, isYouTubeLibrary: Bool = false) async throws -> [BaseItemDto] {
+    func getLatestMedia(parentId: String? = nil, limit: Int = 16, includeWatched: Bool = false, collectionType: String? = nil) async throws -> [BaseItemDto] {
         guard let userId else { throw JellyfinError.notConfigured }
 
         if includeWatched {
@@ -811,8 +811,12 @@ actor JellyfinClient {
             if let collectionType = collectionType?.lowercased() {
                 switch collectionType {
                 case "tvshows":
-                    // Fetch series directly sorted by when content was last added
-                    itemTypes = isYouTubeLibrary ? "Episode" : "Series"
+                    // Series (YouTube channels are series too) sorted by when
+                    // content was last added. YouTube used to fetch Episodes and
+                    // let the caller dedupe them down to channels — but a channel
+                    // that uploads a burst then fills the whole limit, and the row
+                    // collapses to one or two avatars until the next channel posts.
+                    itemTypes = "Series"
                 case "movies":
                     itemTypes = "Movie"
                 default:
@@ -824,7 +828,7 @@ actor JellyfinClient {
 
             // Use /Items endpoint with date sorting to include watched items
             // For TV series, sort by DateLastContentAdded to show series with newest episodes first
-            let isTVSeries = collectionType?.lowercased() == "tvshows" && !isYouTubeLibrary
+            let isTVSeries = collectionType?.lowercased() == "tvshows"
             let sortBy = isTVSeries ? "DateLastContentAdded,SortName" : "DateCreated,SortName"
 
             var queryItems = [

--- a/Shared/ViewModels/HomeViewModel.swift
+++ b/Shared/ViewModels/HomeViewModel.swift
@@ -209,6 +209,14 @@ final class HomeViewModel: ObservableObject {
         await loadContent()
     }
 
+    /// A Continue Watching candidate paired with the activity date it sorts on.
+    private struct ContinueCandidate {
+        let item: BaseItemDto
+        let date: Date
+        /// Resume items win date ties — see the sort below.
+        let isResume: Bool
+    }
+
     private func mergeAndSortContinueItems(resume: [BaseItemDto], nextUp: [BaseItemDto]) -> [BaseItemDto] {
         // Both APIs return items sorted by activity:
         // - Resume: by DatePlayed descending (most recently played partial episode first)
@@ -218,47 +226,49 @@ final class HomeViewModel: ObservableObject {
         // For Resume items: use their lastPlayedDate
         // For NextUp items: use current time based on position (trust the API order)
 
-        let now = Date()
-
-        // Get effective dates for Resume items
-        let resumeDates: [Date] = resume.map { item in
-            parseDate(item.userData?.lastPlayedDate) ?? now
+        // Give every candidate a real, comparable activity date.
+        //
+        // Resume items carry their own lastPlayedDate. NextUp items usually do
+        // too (Jellyfin returns the in-progress episode), but a genuinely
+        // unstarted "next" episode has none — so carry the previous NextUp
+        // item's date forward a second at a time. NextUp is already ordered by
+        // series activity, which keeps each undated item beside its neighbours.
+        //
+        // NextUp used to be stamped with `now`, which is newer than every real
+        // timestamp, so all of NextUp sorted ahead of all of Resume. Episodes
+        // still looked right (most reach the row via NextUp), but a movie —
+        // Resume-only, and with no seriesId to dedupe against — always landed
+        // behind the entire NextUp block no matter how recently it was played.
+        var candidates: [ContinueCandidate] = resume.map { item in
+            ContinueCandidate(
+                item: item,
+                date: parseDate(item.userData?.lastPlayedDate) ?? .distantPast,
+                isResume: true
+            )
         }
 
-        // For NextUp, assign dates based on position: first item = now, each subsequent = 1 second earlier
-        // This trusts the NextUp API's sorting by series activity
-        let nextUpDates: [Date] = nextUp.indices.map { index in
-            now.addingTimeInterval(-Double(index))
+        var carried = Date()
+        for item in nextUp {
+            if let played = parseDate(item.userData?.lastPlayedDate) {
+                carried = played
+            } else {
+                carried = carried.addingTimeInterval(-1)
+            }
+            candidates.append(ContinueCandidate(item: item, date: carried, isResume: false))
         }
 
-        // Merge the two sorted lists
+        // Newest first. Resume wins ties so a part-watched episode is offered
+        // for resuming rather than skipped past to the next one.
+        candidates.sort { lhs, rhs in
+            lhs.date == rhs.date ? (lhs.isResume && !rhs.isResume) : (lhs.date > rhs.date)
+        }
+
         var merged: [BaseItemDto] = []
         var seenSeriesIds = Set<String>()
         var seenIds = Set<String>()
 
-        var resumeIdx = 0
-        var nextUpIdx = 0
-
-        while resumeIdx < resume.count || nextUpIdx < nextUp.count {
-            let useResume: Bool
-
-            if resumeIdx >= resume.count {
-                useResume = false
-            } else if nextUpIdx >= nextUp.count {
-                useResume = true
-            } else {
-                // Compare dates - take the more recent one
-                useResume = resumeDates[resumeIdx] >= nextUpDates[nextUpIdx]
-            }
-
-            let item: BaseItemDto
-            if useResume {
-                item = resume[resumeIdx]
-                resumeIdx += 1
-            } else {
-                item = nextUp[nextUpIdx]
-                nextUpIdx += 1
-            }
+        for candidate in candidates {
+            let item = candidate.item
 
             // Skip duplicates
             guard !seenIds.contains(item.id) else { continue }

--- a/project.yml
+++ b/project.yml
@@ -66,7 +66,7 @@ targets:
     settings:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.mondominator.sashimi
-        MARKETING_VERSION: 1.2.16
+        MARKETING_VERSION: 1.2.17
         CURRENT_PROJECT_VERSION: 2
         SWIFT_VERSION: 5.9
         SDKROOT: appletvos
@@ -144,7 +144,7 @@ targets:
         # Shared bundle ID with the tvOS app for Universal Purchase (one "Sashimi"
         # app spanning Apple TV + iPhone + iPad). Distinguished by platform.
         PRODUCT_BUNDLE_IDENTIFIER: com.mondominator.sashimi
-        MARKETING_VERSION: 1.2.16
+        MARKETING_VERSION: 1.2.17
         CURRENT_PROJECT_VERSION: 1
         SWIFT_VERSION: 5.9
         SDKROOT: iphoneos
@@ -186,7 +186,7 @@ targets:
     settings:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.mondominator.sashimi.topshelf
-        MARKETING_VERSION: 1.2.16
+        MARKETING_VERSION: 1.2.17
         CURRENT_PROJECT_VERSION: 2
         SWIFT_VERSION: 5.9
         SDKROOT: appletvos


### PR DESCRIPTION
Everything from a long polish session, verified against the live server and on both Apple TVs.

### Continue Watching: movies always at the back
NextUp items were stamped with `now` — newer than any real timestamp — so `resumeDates[i] >= nextUpDates[j]` was false every iteration and the whole NextUp list drained before a single Resume item. Episodes looked fine (most reach the row via NextUp); a movie is Resume-only with no `seriesId` to dedupe against, so it washed to the back.

Now NextUp gets a real date (most items already carry `lastPlayedDate`; an unstarted next episode carries the previous item's forward), then one sort. **Resume wins ties** so a part-watched episode is offered for resuming rather than skipped.

Simulated against live data: a movie watched Aug 11 moves **position 12 → 4**, landing between Aug 12 and Aug 10 items. Episode order unchanged.

### Recently Added YouTube: row collapsing
Fetched the newest 30 episodes, then deduped to channels — so one channel's upload burst starved the rest. Measured live: the newest 30 videos spanned **1 channel**, so the row showed a single avatar. Now fetches Series by `DateLastContentAdded`.

Selecting a card still opens the channel's **newest video**, resolved by a concurrent prefetch so the press never blocks. **Fixes iOS too** (shared client method); removed the now-dead `isYouTubeLibrary` parameter.

### Detail screen
- Backdrop requested at **native 2x density** instead of a hardcoded 1920. It was being upscaled — the actual cause of what looked like a sizing problem.
- Resized to **0.45** so its left edge (~x1010) clears the info column (~x300) instead of sitting under it. A two-column composition rather than an overlap rescued by a scrim.
- Inset **60 top / 120 right**.
- **Quality badges on their own row for movies only**; series and episodes keep the single combined line.

### Home
- Hero text centres on the hero's **solid** area — the bottom 10% is masked to transparent, which was pulling the block visibly low.
- Hero keeps an **80pt** margin while rows stay at **40**: 64pt display type needs more room than a poster row.

### Cards
Focus ring no longer paints over the "N new" badge or watched checkmark — overlays stack in application order, so the ring had to be applied before the badge.

### Also
`.claude/` config: `/install-tvs`, a permission allowlist, and a `PostToolUse` hook running `swiftlint --strict` per edited file. It caught a `large_tuple` violation in this changeset before CI would have.

Bumps `MARKETING_VERSION` → **1.2.17**. SwiftLint strict clean; built and exercised on Living Room + Bedroom Apple TVs. iOS changes are compile-verified only, not device-tested.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XzUNvRCXML3DJe98KBCGkN