### PR TITLE
feat(tvos): play theme songs on the series detail screen

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -68,3 +68,6 @@ Vendor/
 
 # Claude Code personal settings (project settings.json IS committed)
 .claude/settings.local.json
+
+# Superpowers SDD scratch (ledger, briefs, review packages)
+.superpowers/

--- a/Sashimi/App/SashimiApp.swift
+++ b/Sashimi/App/SashimiApp.swift
@@ -8,6 +8,7 @@ private let logger = Logger(subsystem: "com.sashimi.app", category: "App")
 @main
 struct SashimiApp: App {
     @StateObject private var sessionManager = SessionManager.shared
+    @Environment(\.scenePhase) private var scenePhase
 
     init() {
         configureAudioSession()
@@ -37,6 +38,15 @@ struct SashimiApp: App {
             ContentView()
                 .environmentObject(sessionManager)
                 .toastOverlay()
+        }
+        // The TV button and other backgrounding transitions leave `.active`
+        // without the detail screen's `onDisappear` ever firing (it's a
+        // `fullScreenCover`), so the theme song must be stopped here rather
+        // than relying on the view hierarchy.
+        .onChange(of: scenePhase) { _, newPhase in
+            if newPhase != .active {
+                ThemeSongPlayer.shared.appDidBackground()
+            }
         }
     }
 }

--- a/Sashimi/Views/Detail/MediaDetailView.swift
+++ b/Sashimi/Views/Detail/MediaDetailView.swift
@@ -225,6 +225,7 @@ struct MediaDetailView: View {
                 }
             }
         }
+        .themeSong(for: item)
         .fullScreenCover(isPresented: $showingPlayer) {
             PlayerView(item: selectedEpisode ?? item, startFromBeginning: startFromBeginning)
         }
@@ -838,6 +839,7 @@ struct MediaDetailView: View {
     /// Play the item's local trailer inline. The button only appears when a
     /// local trailer exists (LocalTrailerCount > 0), matching Roku.
     private func playLocalTrailer() async {
+        ThemeSongPlayer.shared.stopForPlayback()
         if let trailer = try? await JellyfinClient.shared.getLocalTrailers(itemId: item.id).first {
             selectedEpisode = trailer
             startFromBeginning = true
@@ -851,6 +853,7 @@ struct MediaDetailView: View {
         if let ep = try? await JellyfinClient.shared.getRandomItem(parentId: seriesId, itemTypes: [.episode]) {
             selectedEpisode = ep
             startFromBeginning = false
+            ThemeSongPlayer.shared.stopForPlayback()
             showingPlayer = true
         }
     }
@@ -870,6 +873,7 @@ struct MediaDetailView: View {
                 ) {
                     selectedEpisode = nextEp
                     startFromBeginning = false
+                    ThemeSongPlayer.shared.stopForPlayback()
                     showingPlayer = true
                 }
             }
@@ -893,6 +897,7 @@ struct MediaDetailView: View {
                     isPrimary: true
                 ) {
                     startFromBeginning = false
+                    ThemeSongPlayer.shared.stopForPlayback()
                     showingPlayer = true
                 }
 
@@ -903,6 +908,7 @@ struct MediaDetailView: View {
                         isPrimary: false
                     ) {
                         startFromBeginning = true
+                        ThemeSongPlayer.shared.stopForPlayback()
                         showingPlayer = true
                     }
                 }

--- a/Sashimi/Views/Library/SettingsView.swift
+++ b/Sashimi/Views/Library/SettingsView.swift
@@ -674,6 +674,7 @@ struct PlaybackSettingsView: View {
                     SettingsToggleRow(title: "Auto-Play Next Episode", isOn: $settings.autoPlayNextEpisode)
                     SettingsToggleRow(title: "Auto-Skip Intro", isOn: $settings.autoSkipIntro)
                     SettingsToggleRow(title: "Auto-Skip Credits", isOn: $settings.autoSkipCredits)
+                    SettingsToggleRow(title: "Play Theme Songs", isOn: $settings.playThemeSongs)
                 }
 
                 Text("Auto-skip requires the intro-skipper plugin on your server.")

--- a/SashimiTests/ThemeSongPlayerTests.swift
+++ b/SashimiTests/ThemeSongPlayerTests.swift
@@ -117,7 +117,7 @@ final class ThemeSongPlayerTests: XCTestCase {
 @MainActor
 final class ThemeSongResolutionTests: XCTestCase {
     func testResolvesOncePerSeriesThenCaches() async {
-        let player = ThemeSongPlayer(startDelay: 0)
+        let player = ThemeSongPlayer(timings: ThemeSongTimings(startDelay: 0))
         var calls: [String] = []
         player.resolver = { id in calls.append(id); return URL(string: "http://x/\(id).mp3") }
 
@@ -128,7 +128,7 @@ final class ThemeSongResolutionTests: XCTestCase {
 
     func testCachesMissesToo() async {
         // ~40% of series have no theme. Re-entering one must not re-query.
-        let player = ThemeSongPlayer(startDelay: 0)
+        let player = ThemeSongPlayer(timings: ThemeSongTimings(startDelay: 0))
         var calls = 0
         player.resolver = { _ in calls += 1; return nil }
 
@@ -140,7 +140,7 @@ final class ThemeSongResolutionTests: XCTestCase {
     }
 
     func testDisabledSettingResolvesNothing() async {
-        let player = ThemeSongPlayer(startDelay: 0)
+        let player = ThemeSongPlayer(timings: ThemeSongTimings(startDelay: 0))
         var calls = 0
         player.resolver = { _ in calls += 1; return nil }
         PlaybackSettings.shared.playThemeSongs = false
@@ -159,7 +159,7 @@ final class ThemeSongResolutionTests: XCTestCase {
     /// the series would never get its theme resolved again for the session.
     func testThrowingResolverIsNotCached() async {
         struct ResolveFailure: Error {}
-        let player = ThemeSongPlayer(startDelay: 0)
+        let player = ThemeSongPlayer(timings: ThemeSongTimings(startDelay: 0))
         var calls = 0
         player.resolver = { _ in
             calls += 1
@@ -171,5 +171,58 @@ final class ThemeSongResolutionTests: XCTestCase {
         XCTAssertNil(first)
         XCTAssertNil(second)
         XCTAssertEqual(calls, 2, "a thrown error must not be cached; every visit should retry")
+    }
+}
+
+/// The `fadeOutEnding` gap this whole pass exists to fix started as a
+/// `private let` no test ever read — declared, matching spec, and silently
+/// wired to nothing. This suite reads every shipped default directly, and
+/// exercises the end-fade boundary math without loading real audio.
+final class ThemeSongTimingsTests: XCTestCase {
+    func testShippedTimingsMatchSpec() {
+        let timings = ThemeSongTimings()
+        XCTAssertEqual(timings.startDelay, 0.75)
+        XCTAssertEqual(timings.volume, 0.6)
+        XCTAssertEqual(timings.fadeIn, 1.0)
+        XCTAssertEqual(timings.fadeOutEnding, 1.5)
+        XCTAssertEqual(timings.fadeOutShowChange, 0.4)
+        XCTAssertEqual(timings.fadeOutHard, 0.25)
+    }
+
+    /// The player/trailer cut is deliberately the fastest transition
+    /// available — the theme must be gone before the player's own audio
+    /// starts.
+    func testHardCutIsTheFastestFade() {
+        let timings = ThemeSongTimings()
+        XCTAssertLessThan(timings.fadeOutHard, timings.fadeOutShowChange)
+        XCTAssertLessThan(timings.fadeOutHard, timings.fadeIn)
+        XCTAssertLessThan(timings.fadeOutHard, timings.fadeOutEnding)
+    }
+}
+
+@MainActor
+final class ThemeSongEndFadeBoundaryTests: XCTestCase {
+    func testBoundaryStartsFadeOutEndingBeforeTheEnd() {
+        let boundary = ThemeSongPlayer.endFadeBoundary(duration: 30, fadeOutEnding: 1.5)
+        XCTAssertEqual(boundary, 28.5)
+    }
+
+    /// A theme shorter than the fade must degrade to the existing abrupt
+    /// stop at end-of-track, not a negative boundary or an immediate fade.
+    func testThemeShorterThanTheFadeDegradesToNil() {
+        XCTAssertNil(ThemeSongPlayer.endFadeBoundary(duration: 1.0, fadeOutEnding: 1.5))
+    }
+
+    /// A theme exactly as long as the fade also has no room for one - the
+    /// boundary would land at (or before) the start of the track.
+    func testThemeExactlyTheFadeLengthDegradesToNil() {
+        XCTAssertNil(ThemeSongPlayer.endFadeBoundary(duration: 1.5, fadeOutEnding: 1.5))
+    }
+
+    /// `AVPlayerItem.duration` reads as indefinite (NaN) until the asset
+    /// loads; an unfinished or unusable load must degrade the same way.
+    func testUnusableDurationDegradesToNil() {
+        XCTAssertNil(ThemeSongPlayer.endFadeBoundary(duration: .nan, fadeOutEnding: 1.5))
+        XCTAssertNil(ThemeSongPlayer.endFadeBoundary(duration: .infinity, fadeOutEnding: 1.5))
     }
 }

--- a/SashimiTests/ThemeSongPlayerTests.swift
+++ b/SashimiTests/ThemeSongPlayerTests.swift
@@ -150,4 +150,26 @@ final class ThemeSongResolutionTests: XCTestCase {
         try? await Task.sleep(nanoseconds: 20_000_000)
         XCTAssertEqual(calls, 0, "nothing is fetched when the setting is off")
     }
+
+    /// A thrown error (network failure, request cancellation) is not the
+    /// same fact as "this series has no theme" and must not be cached the
+    /// same way `testCachesMissesToo` proves a clean `nil` is. Bouncing in
+    /// and out of a detail screen inside the start delay cancels the
+    /// in-flight request every time; if that got cached as a permanent miss,
+    /// the series would never get its theme resolved again for the session.
+    func testThrowingResolverIsNotCached() async {
+        struct ResolveFailure: Error {}
+        let player = ThemeSongPlayer(startDelay: 0)
+        var calls = 0
+        player.resolver = { _ in
+            calls += 1
+            throw ResolveFailure()
+        }
+
+        let first = await player.resolveForTest("A")
+        let second = await player.resolveForTest("A")
+        XCTAssertNil(first)
+        XCTAssertNil(second)
+        XCTAssertEqual(calls, 2, "a thrown error must not be cached; every visit should retry")
+    }
 }

--- a/SashimiTests/ThemeSongPlayerTests.swift
+++ b/SashimiTests/ThemeSongPlayerTests.swift
@@ -19,4 +19,97 @@ final class ThemeSongPlayerTests: XCTestCase {
         let url = await client.getAudioStreamURL(itemId: "ITEM")
         XCTAssertNil(url)
     }
+
+    // MARK: - ThemeMediaResponse decoding
+    //
+    // `getThemeSongs` swallows decode failures with `try?` and treats the
+    // result as "no theme" - the same outcome as the ~41% of series that
+    // legitimately have none. A CodingKeys typo or wrong nesting here would
+    // compile, pass lint, and be invisible at runtime. These tests decode
+    // `ThemeMediaResponse` directly (moved to file scope in
+    // Shared/Models/JellyfinModels.swift for testability, same pattern as
+    // `AuthenticationResult`/`PlaybackInfoResponse`) so they exercise the
+    // real production type, not a hand-copied re-implementation of it.
+
+    /// `Id`/`Name`/`Type` below are copied verbatim from a real
+    /// `/Items/{id}/ThemeMedia` response captured against a live Jellyfin
+    /// 10.11.11 server for a themed series (surrounding per-item fields
+    /// such as MediaSources/MediaStreams are trimmed - BaseItemDto doesn't
+    /// decode them and they don't affect this test).
+    private static let populatedThemeMediaJSON = """
+    {
+      "ThemeVideosResult": { "Items": [], "TotalRecordCount": 0 },
+      "ThemeSongsResult": {
+        "Items": [
+          {
+            "Name": "theme",
+            "Id": "502e1840465f20b46ae1bbc6412466ed",
+            "Type": "Audio"
+          }
+        ],
+        "TotalRecordCount": 1
+      },
+      "SoundtrackSongsResult": { "Items": [], "TotalRecordCount": 0 }
+    }
+    """
+
+    /// Shape of the normal (no-theme) case: all three result sets present
+    /// with empty `Items` - not an error, ~41% of a typical library.
+    private static let emptyThemeMediaJSON = """
+    {
+      "ThemeVideosResult": { "Items": [], "TotalRecordCount": 0 },
+      "ThemeSongsResult": { "Items": [], "TotalRecordCount": 0 },
+      "SoundtrackSongsResult": { "Items": [], "TotalRecordCount": 0 }
+    }
+    """
+
+    /// Synthetic (not captured) fixture: each of the three sibling result
+    /// sets holds a distinctly-named/ID'd item, so decoding the wrong key
+    /// is caught by an ID mismatch rather than an incidentally-empty array.
+    private static let siblingDiscriminationJSON = """
+    {
+      "ThemeVideosResult": {
+        "Items": [{ "Name": "decoy-video", "Id": "video-decoy-id", "Type": "Video" }],
+        "TotalRecordCount": 1
+      },
+      "ThemeSongsResult": {
+        "Items": [{ "Name": "theme", "Id": "real-theme-id", "Type": "Audio" }],
+        "TotalRecordCount": 1
+      },
+      "SoundtrackSongsResult": {
+        "Items": [{ "Name": "decoy-soundtrack", "Id": "soundtrack-decoy-id", "Type": "Audio" }],
+        "TotalRecordCount": 1
+      }
+    }
+    """
+
+    func testThemeMediaResponseDecodesPopulatedThemeSongsResult() throws {
+        let data = try XCTUnwrap(Self.populatedThemeMediaJSON.data(using: .utf8))
+        let decoded = try JSONDecoder().decode(ThemeMediaResponse.self, from: data)
+        let items = try XCTUnwrap(decoded.themeSongsResult?.items)
+        XCTAssertEqual(items.count, 1)
+        let theme = try XCTUnwrap(items.first)
+        XCTAssertEqual(theme.id, "502e1840465f20b46ae1bbc6412466ed")
+        XCTAssertEqual(theme.name, "theme")
+        // Server sends Type "Audio", which ItemType has no case for; it must
+        // fall back to .unknown (via ItemType's custom init) rather than
+        // throwing - if that fallback is ever "tidied away", this item (and
+        // every real theme song) stops decoding.
+        XCTAssertEqual(theme.type, .unknown)
+    }
+
+    func testThemeMediaResponseDecodesEmptyResultToEmptyArray() throws {
+        let data = try XCTUnwrap(Self.emptyThemeMediaJSON.data(using: .utf8))
+        let decoded = try JSONDecoder().decode(ThemeMediaResponse.self, from: data)
+        XCTAssertEqual(decoded.themeSongsResult?.items ?? [], [])
+    }
+
+    func testThemeMediaResponseReadsThemeSongsResultNotSiblings() throws {
+        let data = try XCTUnwrap(Self.siblingDiscriminationJSON.data(using: .utf8))
+        let decoded = try JSONDecoder().decode(ThemeMediaResponse.self, from: data)
+        let items = try XCTUnwrap(decoded.themeSongsResult?.items)
+        XCTAssertEqual(items.map(\.id), ["real-theme-id"])
+        XCTAssertFalse(items.map(\.id).contains("video-decoy-id"))
+        XCTAssertFalse(items.map(\.id).contains("soundtrack-decoy-id"))
+    }
 }

--- a/SashimiTests/ThemeSongPlayerTests.swift
+++ b/SashimiTests/ThemeSongPlayerTests.swift
@@ -119,11 +119,39 @@ final class ThemeSongResolutionTests: XCTestCase {
     func testResolvesOncePerSeriesThenCaches() async {
         let player = ThemeSongPlayer(timings: ThemeSongTimings(startDelay: 0))
         var calls: [String] = []
-        player.resolver = { id in calls.append(id); return URL(string: "http://x/\(id).mp3") }
+        player.resolver = { id in calls.append(id); return "theme-\(id)" }
+        player.urlBuilder = { themeId in URL(string: "http://x/\(themeId).mp3") }
 
         _ = await player.resolveForTest("A")
         _ = await player.resolveForTest("A")
         XCTAssertEqual(calls, ["A"], "second lookup must come from cache")
+    }
+
+    /// `getAudioStreamURL` bakes the *current* access token into the URL it
+    /// returns. If that URL were cached alongside the theme item id, an
+    /// in-session re-login would leave every previously-visited series
+    /// carrying a stale token — permanently silent for the rest of the
+    /// session. Caching only the id (never the URL) is what this test pins:
+    /// the id lookup happens once, but the URL reflects whatever credential
+    /// is current at the moment of each individual resolve.
+    func testCachedThemeIdSurvivesCredentialChangeAndBuildsAFreshURL() async {
+        let player = ThemeSongPlayer(timings: ThemeSongTimings(startDelay: 0))
+        var resolverCalls = 0
+        player.resolver = { _ in resolverCalls += 1; return "theme-item-id" }
+
+        var currentToken = "TOKEN-1"
+        player.urlBuilder = { themeId in URL(string: "http://x/\(themeId).mp3?api_key=\(currentToken)") }
+
+        let first = await player.resolveForTest("A")
+        currentToken = "TOKEN-2" // simulate an in-session re-login rotating the access token
+        let second = await player.resolveForTest("A")
+
+        XCTAssertEqual(resolverCalls, 1, "the theme item id is cached - no second lookup for the same series")
+        XCTAssertEqual(first?.absoluteString, "http://x/theme-item-id.mp3?api_key=TOKEN-1")
+        XCTAssertEqual(
+            second?.absoluteString, "http://x/theme-item-id.mp3?api_key=TOKEN-2",
+            "the URL must be rebuilt fresh on every resolve, not cached alongside the id"
+        )
     }
 
     func testCachesMissesToo() async {
@@ -172,6 +200,38 @@ final class ThemeSongResolutionTests: XCTestCase {
         XCTAssertNil(second)
         XCTAssertEqual(calls, 2, "a thrown error must not be cached; every visit should retry")
     }
+
+    /// Backgrounding does not dismiss the detail screens on top of it - they
+    /// stay mounted, so returning to the same show (e.g. opening a season
+    /// after backgrounding from its Series screen) must still read as the
+    /// *same* visit, not a fresh one. `appDidBackground()` resetting the
+    /// visit state would make the very next `showAppeared` for that series
+    /// look new and replay the theme a second time.
+    func testBackgroundingDoesNotReplayTheThemeForTheSameVisit() async {
+        let player = ThemeSongPlayer(timings: ThemeSongTimings(startDelay: 0))
+        player.resolver = { _ in "theme-item-id" }
+        // Counting `urlBuilder` calls, not `resolver` calls: the theme item
+        // id is cached per series, so a naive resolver-call count would stay
+        // 1 either way and silently fail to catch the regression - the id
+        // cache would mask it. `urlBuilder` runs once per *attempt* to start
+        // a theme (it is deliberately never cached, per fix 3 above), so its
+        // call count is what actually reflects whether `showAppeared`
+        // treated the second call as a new visit.
+        var urlBuilderCalls = 0
+        player.urlBuilder = { _ in urlBuilderCalls += 1; return nil }
+
+        player.showAppeared(seriesId: "A")
+        try? await Task.sleep(nanoseconds: 20_000_000)
+
+        player.appDidBackground()
+
+        // The season screen appears next, for the same series - still the
+        // same visit.
+        player.showAppeared(seriesId: "A")
+        try? await Task.sleep(nanoseconds: 20_000_000)
+
+        XCTAssertEqual(urlBuilderCalls, 1, "returning to the same visit after backgrounding must not re-trigger a theme start")
+    }
 }
 
 /// `fade()`'s early-return path (taken when a fade is instant, i.e.
@@ -204,6 +264,74 @@ final class ThemeSongFadeLifecycleTests: XCTestCase {
 
         player.fadeForTest(to: 0, over: 0)
         XCTAssertNil(player.fadeTimerForTest, "an immediate fade must clear fadeTimer, not merely invalidate it")
+    }
+
+    /// `play()` tears down before doing anything else, specifically so a
+    /// second `play()` before the first has finished can't strand the prior
+    /// AVPlayer - the worst failure mode: two themes audible at once.
+    ///
+    /// `fadeTimerForTest.isValid` alone does **not** distinguish this fix
+    /// from its absence: `fade(to:over:completion:)`, called unconditionally
+    /// at the end of every `play()`, invalidates whatever the *current*
+    /// `fadeTimer` is as its own first line - regardless of whether
+    /// `teardown()` ran first. Confirmed by removing the `teardown()` call
+    /// from `play()` and re-running: a timer-validity-only version of this
+    /// test still passed, which is exactly the "passes either way" trap the
+    /// review warned against. `player?.pause()`, by contrast, happens
+    /// *only* inside `teardown()` - nothing else in `play()`/`fade()` ever
+    /// pauses a player - so it's the assertion that actually exercises the
+    /// fix. `playerForTest` (added alongside this test) exposes that.
+    func testSecondPlayPausesTheFirstPlaysPlayer() throws {
+        let player = ThemeSongPlayer(timings: ThemeSongTimings())
+        let firstURL = try XCTUnwrap(URL(string: "http://192.0.2.1:1/first-theme.mp3"))
+        let secondURL = try XCTUnwrap(URL(string: "http://192.0.2.1:1/second-theme.mp3"))
+
+        player.playForTest(url: firstURL)
+        let firstPlayer = try XCTUnwrap(player.playerForTest)
+        let firstTimer = try XCTUnwrap(player.fadeTimerForTest)
+
+        player.playForTest(url: secondURL)
+
+        XCTAssertEqual(firstPlayer.rate, 0, "a second play() must pause the first play's AVPlayer, not strand it running")
+        XCTAssertFalse(firstTimer.isValid, "the first play's fade-in timer should also no longer be valid")
+    }
+
+    /// The timer-identity guard inside the fade timer's own tick closure
+    /// exists so a tick that has already fired - and been *enqueued* as a
+    /// MainActor `Task`, not yet run - can't act on stale state by the time
+    /// it's finally dequeued, if a newer fade replaced `fadeTimer` in the
+    /// meantime. `Timer.fire()` triggers a timer's block synchronously
+    /// without waiting on the real run loop, which is what makes this
+    /// reproducible deterministically: fire the first fade's (single-step)
+    /// timer to enqueue its tick's Task without running it, replace it with
+    /// a second fade, then yield so the stale Task actually executes and
+    /// can be observed failing its own identity check.
+    func testStaleTimerTickCannotClobberANewerFade() async throws {
+        let player = ThemeSongPlayer(timings: ThemeSongTimings())
+        let url = try XCTUnwrap(URL(string: "http://192.0.2.1:1/unreachable-theme.mp3"))
+        player.playForTest(url: url)
+
+        var staleCompletionFired = false
+        // A single-step fade (steps = max(1, 0.05/0.05) = 1): one `.fire()`
+        // is its *last* tick, the one that would otherwise invalidate the
+        // timer and run its completion.
+        player.fadeForTest(to: 0.6, over: 0.05) { staleCompletionFired = true }
+        let staleTimer = try XCTUnwrap(player.fadeTimerForTest)
+        staleTimer.fire()
+
+        var liveCompletionFired = false
+        player.fadeForTest(to: 0, over: 1.0) { liveCompletionFired = true }
+        let liveTimer = try XCTUnwrap(player.fadeTimerForTest)
+        XCTAssertFalse(liveTimer === staleTimer, "sanity: the newer fade must be a different timer instance")
+
+        // Let the stale tick's already-enqueued Task actually run. A short
+        // sleep, not a wall-clock fade duration - the same "let async work
+        // settle" pattern as `testDisabledSettingResolvesNothing` above.
+        try? await Task.sleep(nanoseconds: 20_000_000)
+
+        XCTAssertTrue(player.fadeTimerForTest === liveTimer, "a stale tick must not nil out the newer fade's live timer")
+        XCTAssertFalse(staleCompletionFired, "a stale tick must not fire the superseded fade's completion")
+        XCTAssertFalse(liveCompletionFired, "the newer fade's own completion must not fire from someone else's tick")
     }
 }
 

--- a/SashimiTests/ThemeSongPlayerTests.swift
+++ b/SashimiTests/ThemeSongPlayerTests.swift
@@ -1,0 +1,22 @@
+import XCTest
+@testable import Sashimi
+
+final class ThemeSongPlayerTests: XCTestCase {
+    func testAudioStreamURLShape() async throws {
+        let client = JellyfinClient.shared
+        let serverURL = try XCTUnwrap(URL(string: "http://example.test:8096"))
+        await client.configure(serverURL: serverURL, accessToken: "TOKEN", userId: "USER")
+        let audioURL = await client.getAudioStreamURL(itemId: "ITEM")
+        let url = try XCTUnwrap(audioURL)
+        // stream.mp3, not /universal - universal returns 400 without a profile.
+        XCTAssertTrue(url.absoluteString.contains("/Audio/ITEM/stream.mp3"), url.absoluteString)
+        XCTAssertTrue(url.absoluteString.contains("api_key=TOKEN"), url.absoluteString)
+    }
+
+    func testAudioStreamURLIsNilWhenUnconfigured() async {
+        let client = JellyfinClient.shared
+        await client.clearCredentials()
+        let url = await client.getAudioStreamURL(itemId: "ITEM")
+        XCTAssertNil(url)
+    }
+}

--- a/SashimiTests/ThemeSongPlayerTests.swift
+++ b/SashimiTests/ThemeSongPlayerTests.swift
@@ -174,6 +174,39 @@ final class ThemeSongResolutionTests: XCTestCase {
     }
 }
 
+/// `fade()`'s early-return path (taken when a fade is instant, i.e.
+/// `duration <= 0`) must clear `fadeTimer`, not merely invalidate the timer
+/// it points to. Left dangling, an already-enqueued tick from that
+/// invalidated timer would pass the `fadeTimer === timer` identity guard in
+/// the timer's own closure (added to prevent exactly this class of stale-
+/// tick bug) and nudge volume after this "instant" fade already set it.
+///
+/// Unreachable through `play()` alone with shipped defaults, because `play()`
+/// always tears down (and therefore clears `fadeTimer`) immediately before
+/// its own fade call — there's nothing to dangle at that specific call site.
+/// It becomes reachable the moment an instant fade (`duration <= 0`, e.g. an
+/// injected `fadeIn: 0`, or any fade call that isn't preceded by a
+/// synchronous teardown) runs while a real fade timer is still live — which
+/// is exactly what `playForTest`/`fadeForTest` (added alongside this test)
+/// let this suite construct deterministically, without waiting on a real
+/// timer race.
+@MainActor
+final class ThemeSongFadeLifecycleTests: XCTestCase {
+    func testImmediateFadeClearsAnyPriorTimerReference() throws {
+        let player = ThemeSongPlayer(timings: ThemeSongTimings())
+        // A reserved, non-routable address: AVPlayerItem/AVPlayer
+        // construction and `play()` are local operations that don't need the
+        // stream to actually resolve for this test.
+        let url = try XCTUnwrap(URL(string: "http://192.0.2.1:1/unreachable-theme.mp3"))
+
+        player.playForTest(url: url)
+        XCTAssertNotNil(player.fadeTimerForTest, "sanity: play() should install a live fade-in timer")
+
+        player.fadeForTest(to: 0, over: 0)
+        XCTAssertNil(player.fadeTimerForTest, "an immediate fade must clear fadeTimer, not merely invalidate it")
+    }
+}
+
 /// The `fadeOutEnding` gap this whole pass exists to fix started as a
 /// `private let` no test ever read — declared, matching spec, and silently
 /// wired to nothing. This suite reads every shipped default directly, and

--- a/SashimiTests/ThemeSongPlayerTests.swift
+++ b/SashimiTests/ThemeSongPlayerTests.swift
@@ -113,3 +113,41 @@ final class ThemeSongPlayerTests: XCTestCase {
         XCTAssertFalse(items.map(\.id).contains("soundtrack-decoy-id"))
     }
 }
+
+@MainActor
+final class ThemeSongResolutionTests: XCTestCase {
+    func testResolvesOncePerSeriesThenCaches() async {
+        let player = ThemeSongPlayer(startDelay: 0)
+        var calls: [String] = []
+        player.resolver = { id in calls.append(id); return URL(string: "http://x/\(id).mp3") }
+
+        _ = await player.resolveForTest("A")
+        _ = await player.resolveForTest("A")
+        XCTAssertEqual(calls, ["A"], "second lookup must come from cache")
+    }
+
+    func testCachesMissesToo() async {
+        // ~40% of series have no theme. Re-entering one must not re-query.
+        let player = ThemeSongPlayer(startDelay: 0)
+        var calls = 0
+        player.resolver = { _ in calls += 1; return nil }
+
+        let first = await player.resolveForTest("A")
+        let second = await player.resolveForTest("A")
+        XCTAssertNil(first)
+        XCTAssertNil(second)
+        XCTAssertEqual(calls, 1, "a miss must be cached, not retried")
+    }
+
+    func testDisabledSettingResolvesNothing() async {
+        let player = ThemeSongPlayer(startDelay: 0)
+        var calls = 0
+        player.resolver = { _ in calls += 1; return nil }
+        PlaybackSettings.shared.playThemeSongs = false
+        defer { PlaybackSettings.shared.playThemeSongs = true }
+
+        player.showAppeared(seriesId: "A")
+        try? await Task.sleep(nanoseconds: 20_000_000)
+        XCTAssertEqual(calls, 0, "nothing is fetched when the setting is off")
+    }
+}

--- a/SashimiTests/ThemeSongVisitStateTests.swift
+++ b/SashimiTests/ThemeSongVisitStateTests.swift
@@ -1,0 +1,65 @@
+import XCTest
+@testable import Sashimi
+
+final class ThemeSongVisitStateTests: XCTestCase {
+    func testFirstAppearanceStarts() {
+        var s = ThemeSongVisitState()
+        XCTAssertEqual(s.showAppeared(seriesId: "A"), .start(seriesId: "A"))
+    }
+
+    func testDrillingIntoSameShowDoesNotRestart() {
+        // Series -> Season -> Episode is ONE visit. Each level presents a new
+        // fullScreenCover, so this fires three times for one show.
+        var s = ThemeSongVisitState()
+        _ = s.showAppeared(seriesId: "A")
+        XCTAssertEqual(s.showAppeared(seriesId: "A"), .ignore)
+        XCTAssertEqual(s.showAppeared(seriesId: "A"), .ignore)
+    }
+
+    func testDifferentShowStartsAgain() {
+        var s = ThemeSongVisitState()
+        _ = s.showAppeared(seriesId: "A")
+        XCTAssertEqual(s.showAppeared(seriesId: "B"), .start(seriesId: "B"))
+    }
+
+    func testReturningToTheSameShowAfterLeavingStartsAgain() {
+        var s = ThemeSongVisitState()
+        _ = s.showAppeared(seriesId: "A")
+        _ = s.detailDismissed(seriesId: "A")
+        XCTAssertEqual(s.showAppeared(seriesId: "A"), .start(seriesId: "A"))
+    }
+
+    func testDismissingAnInnerScreenDoesNotEndTheVisit() {
+        // Backing out of Episode to Series is still the same visit; the theme
+        // must not restart when the series screen becomes frontmost again.
+        //
+        // Deviation from the brief: the brief's version of this test omitted
+        // the second showAppeared call that simulates drilling from Series
+        // into Episode. Without it, this test's two-call prefix
+        // (showAppeared, detailDismissed) is byte-for-byte identical to
+        // testReturningToTheSameShowAfterLeavingStartsAgain's prefix, yet the
+        // two tests asserted opposite outcomes for the state afterward -- a
+        // contradiction no implementation could satisfy, since identical
+        // inputs to a pure function must produce identical resulting state.
+        // Added the missing drill-down call so this test actually exercises
+        // "dismissing an inner screen" as its name and comment describe.
+        var s = ThemeSongVisitState()
+        _ = s.showAppeared(seriesId: "A")
+        _ = s.showAppeared(seriesId: "A")
+        XCTAssertEqual(s.detailDismissed(seriesId: "A"), .ignore)
+        XCTAssertEqual(s.showAppeared(seriesId: "A"), .ignore)
+    }
+
+    func testNilSeriesIdNeverStarts() {
+        // Movies and anything without a series key.
+        var s = ThemeSongVisitState()
+        XCTAssertEqual(s.showAppeared(seriesId: nil), .ignore)
+    }
+
+    func testResetClearsTheVisit() {
+        var s = ThemeSongVisitState()
+        _ = s.showAppeared(seriesId: "A")
+        s.reset()
+        XCTAssertEqual(s.showAppeared(seriesId: "A"), .start(seriesId: "A"))
+    }
+}

--- a/SashimiTests/ThemeSongVisitStateTests.swift
+++ b/SashimiTests/ThemeSongVisitStateTests.swift
@@ -25,7 +25,7 @@ final class ThemeSongVisitStateTests: XCTestCase {
     func testReturningToTheSameShowAfterLeavingStartsAgain() {
         var s = ThemeSongVisitState()
         _ = s.showAppeared(seriesId: "A")
-        _ = s.detailDismissed(seriesId: "A")
+        XCTAssertEqual(s.detailDismissed(seriesId: "A"), .stop)
         XCTAssertEqual(s.showAppeared(seriesId: "A"), .start(seriesId: "A"))
     }
 

--- a/Shared/Models/JellyfinModels.swift
+++ b/Shared/Models/JellyfinModels.swift
@@ -232,6 +232,20 @@ struct PlaybackInfoResponse: Codable {
     }
 }
 
+/// Response shape for `/Items/{id}/ThemeMedia`. The server returns three
+/// sibling result sets (songs, videos, soundtrack); only `ThemeSongsResult`
+/// is relevant here. A file-scope (not function-local) type so tests can
+/// decode it directly via `@testable import Sashimi` and exercise the real
+/// `CodingKeys` mapping, rather than re-implementing it and testing a copy.
+struct ThemeMediaResponse: Decodable {
+    struct Result: Decodable {
+        let items: [BaseItemDto]?
+        enum CodingKeys: String, CodingKey { case items = "Items" }
+    }
+    let themeSongsResult: Result?
+    enum CodingKeys: String, CodingKey { case themeSongsResult = "ThemeSongsResult" }
+}
+
 struct MediaSourceInfo: Codable {
     let id: String
     let path: String?

--- a/Shared/Services/JellyfinClient.swift
+++ b/Shared/Services/JellyfinClient.swift
@@ -1516,12 +1516,6 @@ actor JellyfinClient {
     /// typical library, which is normal and not an error.
     func getThemeSongs(itemId: String) async throws -> [BaseItemDto] {
         let data = try await request(path: "/Items/\(itemId)/ThemeMedia", queryItems: [])
-        struct ThemeMediaResponse: Decodable {
-            struct Result: Decodable { let items: [BaseItemDto]?
-                enum CodingKeys: String, CodingKey { case items = "Items" } }
-            let themeSongsResult: Result?
-            enum CodingKeys: String, CodingKey { case themeSongsResult = "ThemeSongsResult" }
-        }
         let decoded = try? JSONDecoder().decode(ThemeMediaResponse.self, from: data)
         return decoded?.themeSongsResult?.items ?? []
     }

--- a/Shared/Services/JellyfinClient.swift
+++ b/Shared/Services/JellyfinClient.swift
@@ -1228,6 +1228,24 @@ actor JellyfinClient {
         return components?.url
     }
 
+    /// Direct audio stream for a theme. `/Audio/{id}/universal` returns 400
+    /// without a full device profile; `stream.mp3` serves the file as-is,
+    /// which is what a theme is.
+    func getAudioStreamURL(itemId: String) -> URL? {
+        guard let serverURL, let accessToken else { return nil }
+        var components = URLComponents(string: serverURL.absoluteString.trimmingCharacters(in: CharacterSet(charactersIn: "/")))
+        components?.path += "/Audio/\(itemId)/stream.mp3"
+        components?.queryItems = [
+            URLQueryItem(name: "Static", value: "true"),
+            // api_key stays in the URL because AVPlayer fetches this itself and
+            // has no supported way to attach auth headers - same reasoning as
+            // getPlaybackURL above.
+            URLQueryItem(name: "api_key", value: accessToken),
+            URLQueryItem(name: "DeviceId", value: deviceId)
+        ]
+        return components?.url
+    }
+
     func imageURL(itemId: String, imageType: String = "Primary", maxWidth: Int = 400) -> URL? {
         guard let serverURL else { return nil }
 
@@ -1490,6 +1508,22 @@ actor JellyfinClient {
         guard let userId else { throw JellyfinError.notConfigured }
         let data = try await request(path: "/Users/\(userId)/Items/\(itemId)/LocalTrailers", queryItems: [])
         return (try? JSONDecoder().decode([BaseItemDto].self, from: data)) ?? []
+    }
+
+    /// Theme songs Jellyfin has for an item. Populated by the Theme Songs
+    /// server plugin, which writes `theme.mp3` into the series folder.
+    /// Returns an empty array when the series has none — roughly 40% of a
+    /// typical library, which is normal and not an error.
+    func getThemeSongs(itemId: String) async throws -> [BaseItemDto] {
+        let data = try await request(path: "/Items/\(itemId)/ThemeMedia", queryItems: [])
+        struct ThemeMediaResponse: Decodable {
+            struct Result: Decodable { let items: [BaseItemDto]?
+                enum CodingKeys: String, CodingKey { case items = "Items" } }
+            let themeSongsResult: Result?
+            enum CodingKeys: String, CodingKey { case themeSongsResult = "ThemeSongsResult" }
+        }
+        let decoded = try? JSONDecoder().decode(ThemeMediaResponse.self, from: data)
+        return decoded?.themeSongsResult?.items ?? []
     }
 
     func getItemAncestors(itemId: String) async throws -> [BaseItemDto] {

--- a/Shared/Services/PlaybackSettings.swift
+++ b/Shared/Services/PlaybackSettings.swift
@@ -11,6 +11,7 @@ class PlaybackSettings: ObservableObject {
     @AppStorage("autoPlayNextEpisode") var autoPlayNextEpisode = true
     @AppStorage("autoSkipIntro") var autoSkipIntro = false
     @AppStorage("autoSkipCredits") var autoSkipCredits = false
+    @AppStorage("playThemeSongs") var playThemeSongs = true
     @AppStorage("resumeThresholdSeconds") var resumeThresholdSeconds = 30
     @AppStorage("preferredAudioLanguage") var preferredAudioLanguage = ""
     @AppStorage("preferredSubtitleLanguage") var preferredSubtitleLanguage = ""

--- a/Shared/Services/ThemeSongPlayer.swift
+++ b/Shared/Services/ThemeSongPlayer.swift
@@ -334,3 +334,31 @@ final class ThemeSongPlayer: ObservableObject {
     func fadeForTest(to target: Float, over duration: TimeInterval) { fade(to: target, over: duration) }
     var fadeTimerForTest: Timer? { fadeTimer }
 }
+
+extension View {
+    /// Reports to `ThemeSongPlayer` which show this detail screen belongs to.
+    /// Reports intent only — never starts or stops playback directly.
+    func themeSong(for item: BaseItemDto) -> some View {
+        modifier(ThemeSongModifier(item: item))
+    }
+}
+
+private struct ThemeSongModifier: ViewModifier {
+    let item: BaseItemDto
+
+    /// series -> its own id; season/episode -> the parent series. Anything else
+    /// (movies, videos) has no key and never plays a theme.
+    private var seriesKey: String? {
+        switch item.type {
+        case .series: return item.id
+        case .season, .episode: return item.seriesId
+        default: return nil
+        }
+    }
+
+    func body(content: Content) -> some View {
+        content
+            .onAppear { ThemeSongPlayer.shared.showAppeared(seriesId: seriesKey) }
+            .onDisappear { ThemeSongPlayer.shared.detailDismissed(seriesId: seriesKey) }
+    }
+}

--- a/Shared/Services/ThemeSongPlayer.swift
+++ b/Shared/Services/ThemeSongPlayer.swift
@@ -1,0 +1,166 @@
+import AVFoundation
+import SwiftUI
+import os
+
+private let logger = Logger(subsystem: "com.mondominator.sashimi", category: "ThemeSongPlayer")
+
+/// Plays a series' theme song on the detail screen, once per visit to a show.
+///
+/// This is app-level rather than per-view on purpose: detail screens are
+/// presented with `fullScreenCover`, so a parent view is never removed and its
+/// `onDisappear` never fires. Views report intent here; all decisions live in
+/// one place.
+///
+/// Every failure path is silence. Background music is never worth an error.
+@MainActor
+final class ThemeSongPlayer: ObservableObject {
+    static let shared = ThemeSongPlayer()
+
+    private var visit = ThemeSongVisitState()
+    private var player: AVPlayer?
+    private var fadeTimer: Timer?
+    private var startTask: Task<Void, Never>?
+    private var endObserver: Any?
+
+    /// seriesId -> theme URL, or nil for "this series has no theme". Misses are
+    /// cached too: ~40% of a library has none and must not be re-queried.
+    private var cache: [String: URL?] = [:]
+
+    private let startDelay: TimeInterval
+    private let volume: Float = 0.6
+    private let fadeIn: TimeInterval = 1.0
+    private let fadeOutShowChange: TimeInterval = 0.4
+    private let fadeOutHard: TimeInterval = 0.25
+    private let fadeOutEnding: TimeInterval = 1.5
+
+    /// Overridden in tests. Production resolves through JellyfinClient.
+    var resolver: (String) async -> URL?
+
+    init(startDelay: TimeInterval = 0.75) {
+        self.startDelay = startDelay
+        self.resolver = { seriesId in
+            guard let theme = try? await JellyfinClient.shared.getThemeSongs(itemId: seriesId).first else { return nil }
+            return await JellyfinClient.shared.getAudioStreamURL(itemId: theme.id)
+        }
+    }
+
+    // MARK: - Intent from views
+
+    func showAppeared(seriesId: String?) {
+        guard PlaybackSettings.shared.playThemeSongs else { return }
+        switch visit.showAppeared(seriesId: seriesId) {
+        case .start(let id): scheduleStart(seriesId: id)
+        case .stop, .ignore: break
+        }
+    }
+
+    func detailDismissed(seriesId: String?) {
+        switch visit.detailDismissed(seriesId: seriesId) {
+        case .stop: stop(fadeOver: fadeOutShowChange)
+        case .start, .ignore: break
+        }
+    }
+
+    /// Play or Trailer pressed. Deliberately the fastest transition available —
+    /// the theme must be gone before the player's own audio starts.
+    func stopForPlayback() {
+        startTask?.cancel()
+        startTask = nil
+        stop(fadeOver: fadeOutHard)
+    }
+
+    func appDidBackground() {
+        startTask?.cancel()
+        startTask = nil
+        visit.reset()
+        stop(fadeOver: 0)
+    }
+
+    // MARK: - Internals
+
+    private func scheduleStart(seriesId: String) {
+        startTask?.cancel()
+        stop(fadeOver: fadeOutShowChange)
+        startTask = Task { [weak self] in
+            guard let self else { return }
+            if startDelay > 0 {
+                try? await Task.sleep(nanoseconds: UInt64(startDelay * 1_000_000_000))
+            }
+            guard !Task.isCancelled else { return }
+            guard let url = await resolve(seriesId: seriesId) else { return }
+            guard !Task.isCancelled, visit.currentSeriesId == seriesId else { return }
+            play(url: url)
+        }
+    }
+
+    private func resolve(seriesId: String) async -> URL? {
+        if let cached = cache[seriesId] { return cached }
+        let url = await resolver(seriesId)
+        cache[seriesId] = url
+        return url
+    }
+
+    private func play(url: URL) {
+        let item = AVPlayerItem(url: url)
+        let p = AVPlayer(playerItem: item)
+        p.volume = 0
+        player = p
+
+        endObserver = NotificationCenter.default.addObserver(
+            forName: .AVPlayerItemDidPlayToEndTime, object: item, queue: .main
+        ) { [weak self] _ in
+            Task { @MainActor in self?.stop(fadeOver: 0) }
+        }
+
+        p.play()
+        fade(to: volume, over: fadeIn)
+        logger.debug("theme song started")
+    }
+
+    private func stop(fadeOver duration: TimeInterval) {
+        startTask?.cancel()
+        startTask = nil
+        guard player != nil else { return }
+        if duration <= 0 {
+            teardown()
+            return
+        }
+        fade(to: 0, over: duration) { [weak self] in self?.teardown() }
+    }
+
+    private func teardown() {
+        fadeTimer?.invalidate()
+        fadeTimer = nil
+        player?.pause()
+        player = nil
+        if let endObserver { NotificationCenter.default.removeObserver(endObserver) }
+        endObserver = nil
+    }
+
+    private func fade(to target: Float, over duration: TimeInterval, completion: (() -> Void)? = nil) {
+        fadeTimer?.invalidate()
+        guard let p = player, duration > 0 else {
+            player?.volume = target
+            completion?()
+            return
+        }
+        let steps = max(1, Int(duration / 0.05))
+        let delta = (target - p.volume) / Float(steps)
+        var remaining = steps
+        fadeTimer = Timer.scheduledTimer(withTimeInterval: 0.05, repeats: true) { [weak self] timer in
+            Task { @MainActor in
+                guard let self, let p = self.player else { timer.invalidate(); return }
+                remaining -= 1
+                p.volume = remaining <= 0 ? target : p.volume + delta
+                if remaining <= 0 {
+                    timer.invalidate()
+                    self.fadeTimer = nil
+                    completion?()
+                }
+            }
+        }
+    }
+
+    // Test seam.
+    func resolveForTest(_ seriesId: String) async -> URL? { await resolve(seriesId: seriesId) }
+}

--- a/Shared/Services/ThemeSongPlayer.swift
+++ b/Shared/Services/ThemeSongPlayer.swift
@@ -10,7 +10,7 @@ private let logger = Logger(subsystem: "com.mondominator.sashimi", category: "Th
 ///
 /// This type exists because none of it was true before: every constant was a
 /// `private let` with no test seam, which is exactly how a declared-but-
-/// unused `fadeOutEnding` survived a green suite. `ThemeSongResolutionTests
+/// unused `fadeOutEnding` survived a green suite. `ThemeSongTimingsTests
 /// .testShippedTimingsMatchSpec` reads these values directly so a constant
 /// can't go silently unused (or silently wrong) again.
 struct ThemeSongTimings {
@@ -52,26 +52,41 @@ final class ThemeSongPlayer: ObservableObject {
     /// boundary observer on an already-discarded `AVPlayer`.
     private var durationLoadTask: Task<Void, Never>?
 
-    /// seriesId -> theme URL, or nil for "this series has no theme". Misses are
-    /// cached too: ~40% of a library has none and must not be re-queried.
-    private var cache: [String: URL?] = [:]
+    /// seriesId -> theme item id, or nil for "this series has no theme".
+    /// Misses are cached too: ~40% of a library has none and must not be
+    /// re-queried. Deliberately the item id, not the playable URL:
+    /// `JellyfinClient.getAudioStreamURL` bakes the *current* access token
+    /// into the URL it returns, so caching a URL would freeze a stale token
+    /// into every future play after an in-session re-login — every
+    /// previously-visited series would go silent for the rest of the
+    /// session. The id has no such expiry, so it alone is safe to keep.
+    private var cache: [String: String?] = [:]
 
     private let timings: ThemeSongTimings
 
-    /// Overridden in tests. Production resolves through JellyfinClient.
+    /// Resolves a series to its theme item id (or nil if it has none).
+    /// Overridden in tests. Production resolves through `JellyfinClient`.
     ///
     /// Throws on a real failure (network error, cancellation) rather than
-    /// swallowing it to `nil` — `resolve(seriesId:)` relies on that
+    /// swallowing it to `nil` — `resolveThemeId(seriesId:)` relies on that
     /// distinction to avoid caching a transient failure as a permanent
     /// "this series has no theme".
-    var resolver: (String) async throws -> URL?
+    var resolver: (String) async throws -> String?
+
+    /// Builds the playable URL for a theme item id. Overridden in tests.
+    /// Deliberately **not** cached, unlike `resolver`'s result: see the
+    /// `cache` doc comment above for why a URL can't be treated the same way
+    /// an id can.
+    var urlBuilder: (String) async -> URL?
 
     init(timings: ThemeSongTimings = ThemeSongTimings()) {
         self.timings = timings
         self.resolver = { seriesId in
             let themes = try await JellyfinClient.shared.getThemeSongs(itemId: seriesId)
-            guard let theme = themes.first else { return nil }
-            return await JellyfinClient.shared.getAudioStreamURL(itemId: theme.id)
+            return themes.first?.id
+        }
+        self.urlBuilder = { themeId in
+            await JellyfinClient.shared.getAudioStreamURL(itemId: themeId)
         }
     }
 
@@ -103,7 +118,12 @@ final class ThemeSongPlayer: ObservableObject {
     func appDidBackground() {
         startTask?.cancel()
         startTask = nil
-        visit.reset()
+        // No `visit.reset()` here: the detail views are still mounted across
+        // a background/foreground cycle. Resetting would make the next
+        // `showAppeared(seriesId:)` for the *same* series look like a fresh
+        // visit and play the theme a second time. A killed process starts
+        // with an empty `ThemeSongVisitState` anyway, and a torn-down scene
+        // unwinds `depth` back to zero through `onDisappear` on its own.
         stop(fadeOver: 0)
     }
 
@@ -125,15 +145,25 @@ final class ThemeSongPlayer: ObservableObject {
     }
 
     private func resolve(seriesId: String) async -> URL? {
+        guard let themeId = await resolveThemeId(seriesId: seriesId) else { return nil }
+        // Built fresh on every call, never cached: see the `cache` doc
+        // comment for why a URL (unlike the id above it) can't be kept
+        // around for the session. A `nil` here — e.g. the client isn't
+        // configured yet — is just this attempt failing; it must not be
+        // confused with (or stored as) "this series has no theme".
+        return await urlBuilder(themeId)
+    }
+
+    private func resolveThemeId(seriesId: String) async -> String? {
         if let cached = cache[seriesId] { return cached }
         do {
-            let url = try await resolver(seriesId)
+            let themeId = try await resolver(seriesId)
             // A cancellation can slip past a `try?`-free resolver as a normal
             // return rather than a thrown error; don't let that race cache a
             // series as themeless.
             guard !Task.isCancelled else { return nil }
-            cache[seriesId] = url
-            return url
+            cache[seriesId] = themeId
+            return themeId
         } catch {
             // A thrown error (network failure, request cancellation) is never
             // cached: it says nothing about whether the series has a theme,
@@ -328,11 +358,21 @@ final class ThemeSongPlayer: ObservableObject {
     }
 
     // MARK: - Test seams
+    //
+    // Unlike `resolver`/`urlBuilder` above (which ship in the production
+    // binary because production itself needs a default implementation to
+    // override), these exist purely to let SashimiTests reach otherwise-
+    // private behavior and have no reason to compile into a release build.
 
+    #if DEBUG
     func resolveForTest(_ seriesId: String) async -> URL? { await resolve(seriesId: seriesId) }
     func playForTest(url: URL) { play(url: url) }
-    func fadeForTest(to target: Float, over duration: TimeInterval) { fade(to: target, over: duration) }
+    func fadeForTest(to target: Float, over duration: TimeInterval, completion: (() -> Void)? = nil) {
+        fade(to: target, over: duration, completion: completion)
+    }
     var fadeTimerForTest: Timer? { fadeTimer }
+    var playerForTest: AVPlayer? { player }
+    #endif
 }
 
 extension View {

--- a/Shared/Services/ThemeSongPlayer.swift
+++ b/Shared/Services/ThemeSongPlayer.swift
@@ -210,8 +210,27 @@ final class ThemeSongPlayer: ObservableObject {
             self.endFadeBoundaryObserver = player.addBoundaryTimeObserver(
                 forTimes: [NSValue(time: boundaryTime)], queue: .main
             ) { [weak self, weak player] in
-                guard let self, let player, self.player === player else { return }
-                self.fade(to: 0, over: self.timings.fadeOutEnding)
+                // `queue: .main` and the MainActor executor are the same
+                // context, but the compiler can't prove that from a plain
+                // closure — `assumeIsolated` turns the convention into a
+                // runtime-checked precondition instead of a warning (an
+                // error under Swift 6) and keeps this synchronous. Do not
+                // replace this with `Task { @MainActor in ... }`: that would
+                // defer the fade to a later dequeue, reopening the same
+                // stale-tick reordering hazard the identity guard in
+                // `fade(to:over:completion:)` exists to prevent.
+                MainActor.assumeIsolated {
+                    guard let self, let player, self.player === player else { return }
+                    // The end-of-track fade must tear itself down on
+                    // completion: if the item stalls right after this
+                    // boundary (dropped connection, server hiccup),
+                    // `AVPlayerItemDidPlayToEndTime` may never fire, and
+                    // without this the player and its notification token
+                    // would stay alive until the next `play()`/`stop()`.
+                    self.fade(to: 0, over: self.timings.fadeOutEnding) { [weak self] in
+                        self?.teardown()
+                    }
+                }
             }
         }
     }
@@ -257,6 +276,14 @@ final class ThemeSongPlayer: ObservableObject {
     private func fade(to target: Float, over duration: TimeInterval, completion: (() -> Void)? = nil) {
         fadeTimer?.invalidate()
         guard let p = player, duration > 0 else {
+            // `invalidate()` above stops the timer from firing again, but
+            // doesn't clear this reference. Left dangling, an already-
+            // enqueued tick from that same (now-invalidated) timer would
+            // still pass the `self.fadeTimer === timer` identity guard
+            // below — since it's comparing against itself — and nudge
+            // `p.volume` by the previous fade's delta after this "fade" was
+            // supposed to be a plain, immediate volume set.
+            fadeTimer = nil
             player?.volume = target
             completion?()
             return
@@ -300,6 +327,10 @@ final class ThemeSongPlayer: ObservableObject {
         RunLoop.main.add(timer, forMode: .common)
     }
 
-    // Test seam.
+    // MARK: - Test seams
+
     func resolveForTest(_ seriesId: String) async -> URL? { await resolve(seriesId: seriesId) }
+    func playForTest(url: URL) { play(url: url) }
+    func fadeForTest(to target: Float, over duration: TimeInterval) { fade(to: target, over: duration) }
+    var fadeTimerForTest: Timer? { fadeTimer }
 }

--- a/Shared/Services/ThemeSongPlayer.swift
+++ b/Shared/Services/ThemeSongPlayer.swift
@@ -34,12 +34,18 @@ final class ThemeSongPlayer: ObservableObject {
     private let fadeOutEnding: TimeInterval = 1.5
 
     /// Overridden in tests. Production resolves through JellyfinClient.
-    var resolver: (String) async -> URL?
+    ///
+    /// Throws on a real failure (network error, cancellation) rather than
+    /// swallowing it to `nil` — `resolve(seriesId:)` relies on that
+    /// distinction to avoid caching a transient failure as a permanent
+    /// "this series has no theme".
+    var resolver: (String) async throws -> URL?
 
     init(startDelay: TimeInterval = 0.75) {
         self.startDelay = startDelay
         self.resolver = { seriesId in
-            guard let theme = try? await JellyfinClient.shared.getThemeSongs(itemId: seriesId).first else { return nil }
+            let themes = try await JellyfinClient.shared.getThemeSongs(itemId: seriesId)
+            guard let theme = themes.first else { return nil }
             return await JellyfinClient.shared.getAudioStreamURL(itemId: theme.id)
         }
     }
@@ -95,12 +101,28 @@ final class ThemeSongPlayer: ObservableObject {
 
     private func resolve(seriesId: String) async -> URL? {
         if let cached = cache[seriesId] { return cached }
-        let url = await resolver(seriesId)
-        cache[seriesId] = url
-        return url
+        do {
+            let url = try await resolver(seriesId)
+            // A cancellation can slip past a `try?`-free resolver as a normal
+            // return rather than a thrown error; don't let that race cache a
+            // series as themeless.
+            guard !Task.isCancelled else { return nil }
+            cache[seriesId] = url
+            return url
+        } catch {
+            // A thrown error (network failure, request cancellation) is never
+            // cached: it says nothing about whether the series has a theme,
+            // unlike a clean empty result, which is cached above.
+            logger.debug("theme resolve failed: \(error.localizedDescription)")
+            return nil
+        }
     }
 
     private func play(url: URL) {
+        // A prior player/observer must never be stranded: without this, a
+        // second `play()` before the first has torn down leaks the old
+        // AVPlayer and its NotificationCenter token forever.
+        teardown()
         let item = AVPlayerItem(url: url)
         let p = AVPlayer(playerItem: item)
         p.volume = 0
@@ -147,9 +169,29 @@ final class ThemeSongPlayer: ObservableObject {
         let steps = max(1, Int(duration / 0.05))
         let delta = (target - p.volume) / Float(steps)
         var remaining = steps
-        fadeTimer = Timer.scheduledTimer(withTimeInterval: 0.05, repeats: true) { [weak self] timer in
+        // Built unscheduled and added to `.common` explicitly: a timer handed
+        // to `Timer.scheduledTimer` installs in the default run-loop mode
+        // only, so it stalls whenever tvOS switches the main run loop to
+        // tracking mode (focus movement, row scrolling) — the fade freezes
+        // mid-volume and its `weak self` closure is never fired again.
+        let timer = Timer(timeInterval: 0.05, repeats: true) { [weak self] timer in
             Task { @MainActor in
-                guard let self, let p = self.player else { timer.invalidate(); return }
+                // The closure's body runs when the Task is *dequeued*, not
+                // when the timer fires, so a newer fade can already have
+                // replaced `fadeTimer` by the time this executes. Without
+                // this identity check, a stale tick can nil out (and
+                // therefore orphan) the timer that's actually driving the
+                // current fade, and its own belated completion can later
+                // tear down a theme that only just started.
+                guard let self, self.fadeTimer === timer else {
+                    timer.invalidate()
+                    return
+                }
+                guard let p = self.player else {
+                    timer.invalidate()
+                    self.fadeTimer = nil
+                    return
+                }
                 remaining -= 1
                 p.volume = remaining <= 0 ? target : p.volume + delta
                 if remaining <= 0 {
@@ -159,6 +201,8 @@ final class ThemeSongPlayer: ObservableObject {
                 }
             }
         }
+        fadeTimer = timer
+        RunLoop.main.add(timer, forMode: .common)
     }
 
     // Test seam.

--- a/Shared/Services/ThemeSongPlayer.swift
+++ b/Shared/Services/ThemeSongPlayer.swift
@@ -4,6 +4,24 @@ import os
 
 private let logger = Logger(subsystem: "com.mondominator.sashimi", category: "ThemeSongPlayer")
 
+/// Fade/timing constants for `ThemeSongPlayer`, injected so tests can both
+/// assert the shipped values and exercise fades without waiting on real
+/// wall-clock durations.
+///
+/// This type exists because none of it was true before: every constant was a
+/// `private let` with no test seam, which is exactly how a declared-but-
+/// unused `fadeOutEnding` survived a green suite. `ThemeSongResolutionTests
+/// .testShippedTimingsMatchSpec` reads these values directly so a constant
+/// can't go silently unused (or silently wrong) again.
+struct ThemeSongTimings {
+    var startDelay: TimeInterval = 0.75
+    var volume: Float = 0.6
+    var fadeIn: TimeInterval = 1.0
+    var fadeOutEnding: TimeInterval = 1.5
+    var fadeOutShowChange: TimeInterval = 0.4
+    var fadeOutHard: TimeInterval = 0.25
+}
+
 /// Plays a series' theme song on the detail screen, once per visit to a show.
 ///
 /// This is app-level rather than per-view on purpose: detail screens are
@@ -22,16 +40,23 @@ final class ThemeSongPlayer: ObservableObject {
     private var startTask: Task<Void, Never>?
     private var endObserver: Any?
 
+    /// Boundary-time token for the pre-end fade. Removed in `teardown()` on
+    /// every path, exactly like `endObserver`: an `AVPlayer` time observer
+    /// that outlives its player leaks the same way an un-removed
+    /// `NotificationCenter` token does.
+    private var endFadeBoundaryObserver: Any?
+
+    /// Loads the current item's duration to compute the end-fade boundary.
+    /// Cancelled and cleared in `teardown()`: without that, a `play()` that
+    /// replaces the player mid-load could let a stale load install a
+    /// boundary observer on an already-discarded `AVPlayer`.
+    private var durationLoadTask: Task<Void, Never>?
+
     /// seriesId -> theme URL, or nil for "this series has no theme". Misses are
     /// cached too: ~40% of a library has none and must not be re-queried.
     private var cache: [String: URL?] = [:]
 
-    private let startDelay: TimeInterval
-    private let volume: Float = 0.6
-    private let fadeIn: TimeInterval = 1.0
-    private let fadeOutShowChange: TimeInterval = 0.4
-    private let fadeOutHard: TimeInterval = 0.25
-    private let fadeOutEnding: TimeInterval = 1.5
+    private let timings: ThemeSongTimings
 
     /// Overridden in tests. Production resolves through JellyfinClient.
     ///
@@ -41,8 +66,8 @@ final class ThemeSongPlayer: ObservableObject {
     /// "this series has no theme".
     var resolver: (String) async throws -> URL?
 
-    init(startDelay: TimeInterval = 0.75) {
-        self.startDelay = startDelay
+    init(timings: ThemeSongTimings = ThemeSongTimings()) {
+        self.timings = timings
         self.resolver = { seriesId in
             let themes = try await JellyfinClient.shared.getThemeSongs(itemId: seriesId)
             guard let theme = themes.first else { return nil }
@@ -62,7 +87,7 @@ final class ThemeSongPlayer: ObservableObject {
 
     func detailDismissed(seriesId: String?) {
         switch visit.detailDismissed(seriesId: seriesId) {
-        case .stop: stop(fadeOver: fadeOutShowChange)
+        case .stop: stop(fadeOver: timings.fadeOutShowChange)
         case .start, .ignore: break
         }
     }
@@ -72,7 +97,7 @@ final class ThemeSongPlayer: ObservableObject {
     func stopForPlayback() {
         startTask?.cancel()
         startTask = nil
-        stop(fadeOver: fadeOutHard)
+        stop(fadeOver: timings.fadeOutHard)
     }
 
     func appDidBackground() {
@@ -86,11 +111,11 @@ final class ThemeSongPlayer: ObservableObject {
 
     private func scheduleStart(seriesId: String) {
         startTask?.cancel()
-        stop(fadeOver: fadeOutShowChange)
+        stop(fadeOver: timings.fadeOutShowChange)
         startTask = Task { [weak self] in
             guard let self else { return }
-            if startDelay > 0 {
-                try? await Task.sleep(nanoseconds: UInt64(startDelay * 1_000_000_000))
+            if timings.startDelay > 0 {
+                try? await Task.sleep(nanoseconds: UInt64(timings.startDelay * 1_000_000_000))
             }
             guard !Task.isCancelled else { return }
             guard let url = await resolve(seriesId: seriesId) else { return }
@@ -121,7 +146,7 @@ final class ThemeSongPlayer: ObservableObject {
     private func play(url: URL) {
         // A prior player/observer must never be stranded: without this, a
         // second `play()` before the first has torn down leaks the old
-        // AVPlayer and its NotificationCenter token forever.
+        // AVPlayer and its NotificationCenter/time-observer tokens forever.
         teardown()
         let item = AVPlayerItem(url: url)
         let p = AVPlayer(playerItem: item)
@@ -134,9 +159,73 @@ final class ThemeSongPlayer: ObservableObject {
             Task { @MainActor in self?.stop(fadeOver: 0) }
         }
 
+        scheduleEndOfTrackFade(item: item, player: p)
+
         p.play()
-        fade(to: volume, over: fadeIn)
+        fade(to: timings.volume, over: timings.fadeIn)
         logger.debug("theme song started")
+    }
+
+    /// Starts the fade-out `fadeOutEnding` seconds before the theme's natural
+    /// end, so the track actually fades instead of cutting — by the time
+    /// `AVPlayerItemDidPlayToEndTime` fires there's no audio left to fade.
+    ///
+    /// `AVPlayerItem.duration` is `.indefinite` until the asset loads, so the
+    /// boundary can't be computed synchronously in `play()`. Uses the async
+    /// `AVAsset.load(.duration)` API rather than KVO on `item.status`/
+    /// `item.duration` so there's no sixth lifecycle object to track and
+    /// tear down — a `Task`, cancelled in `teardown()` exactly like
+    /// `startTask`, is enough.
+    private func scheduleEndOfTrackFade(item: AVPlayerItem, player: AVPlayer) {
+        durationLoadTask = Task { [weak self] in
+            guard let self else { return }
+            let duration: CMTime
+            do {
+                duration = try await item.asset.load(.duration)
+            } catch {
+                return
+            }
+            // The player this load was for may already be gone by the time
+            // it resolves — torn down, or replaced by a second `play()`
+            // that raced this load. Installing a boundary observer on it
+            // now would orphan an AVPlayer time-observer token nobody holds
+            // a reference to remove: the same shape as the leak in `play()`,
+            // one layer down.
+            guard !Task.isCancelled, self.player === player else { return }
+            guard duration.isNumeric,
+                  let boundarySeconds = Self.endFadeBoundary(
+                      duration: duration.seconds, fadeOutEnding: self.timings.fadeOutEnding
+                  ) else {
+                // Too short (or an unusable duration) to fit the fade —
+                // degrade to the existing abrupt stop at end-of-track rather
+                // than a negative boundary or fading immediately.
+                return
+            }
+            let boundaryTime = CMTime(seconds: boundarySeconds, preferredTimescale: 600)
+            // Both captures are weak: `player` is retained by the observer
+            // registration itself, so a strong capture here would be a
+            // reference cycle that only `removeTimeObserver` in `teardown()`
+            // ever breaks — exactly the fragility this pass is fixing, not
+            // reintroducing.
+            self.endFadeBoundaryObserver = player.addBoundaryTimeObserver(
+                forTimes: [NSValue(time: boundaryTime)], queue: .main
+            ) { [weak self, weak player] in
+                guard let self, let player, self.player === player else { return }
+                self.fade(to: 0, over: self.timings.fadeOutEnding)
+            }
+        }
+    }
+
+    /// Pure boundary math, kept separate from the AVAsset/AVPlayer plumbing
+    /// above so it's testable without loading real audio. Returns the offset
+    /// (in seconds) at which the end-of-track fade should begin, or `nil`
+    /// when there isn't room for one (a theme shorter than the fade, or an
+    /// unusable duration).
+    static func endFadeBoundary(duration: TimeInterval, fadeOutEnding: TimeInterval) -> TimeInterval? {
+        guard duration.isFinite, duration > 0 else { return nil }
+        let boundary = duration - fadeOutEnding
+        guard boundary > 0 else { return nil }
+        return boundary
     }
 
     private func stop(fadeOver duration: TimeInterval) {
@@ -151,8 +240,14 @@ final class ThemeSongPlayer: ObservableObject {
     }
 
     private func teardown() {
+        durationLoadTask?.cancel()
+        durationLoadTask = nil
         fadeTimer?.invalidate()
         fadeTimer = nil
+        if let endFadeBoundaryObserver {
+            player?.removeTimeObserver(endFadeBoundaryObserver)
+        }
+        endFadeBoundaryObserver = nil
         player?.pause()
         player = nil
         if let endObserver { NotificationCenter.default.removeObserver(endObserver) }

--- a/Shared/Services/ThemeSongVisitState.swift
+++ b/Shared/Services/ThemeSongVisitState.swift
@@ -1,0 +1,52 @@
+import Foundation
+
+/// Tracks which show the user is currently visiting, so a theme plays once per
+/// visit rather than once per screen.
+///
+/// Detail screens are presented with `fullScreenCover`, not pushed, so
+/// Series -> Season -> Episode stacks three live views for one show and the
+/// parent's `onDisappear` never fires. Keying on the series — not the screen —
+/// is what makes drill-down silent and return-from-player silent with one rule.
+struct ThemeSongVisitState {
+    enum Decision: Equatable {
+        case start(seriesId: String)
+        case stop
+        case ignore
+    }
+
+    /// The show whose visit is currently active, if any.
+    private(set) var currentSeriesId: String?
+
+    /// How many detail screens for `currentSeriesId` are on screen. Drill-down
+    /// increments, backing out decrements; the visit ends only at zero.
+    private var depth = 0
+
+    mutating func showAppeared(seriesId: String?) -> Decision {
+        guard let seriesId else { return .ignore }
+
+        if seriesId == currentSeriesId {
+            depth += 1
+            return .ignore
+        }
+
+        currentSeriesId = seriesId
+        depth = 1
+        return .start(seriesId: seriesId)
+    }
+
+    mutating func detailDismissed(seriesId: String?) -> Decision {
+        guard let seriesId, seriesId == currentSeriesId else { return .ignore }
+
+        depth -= 1
+        guard depth <= 0 else { return .ignore }
+
+        currentSeriesId = nil
+        depth = 0
+        return .stop
+    }
+
+    mutating func reset() {
+        currentSeriesId = nil
+        depth = 0
+    }
+}


### PR DESCRIPTION
Fixes #388

Plays a series' theme song on the tvOS detail screen, using the `theme.mp3` files written by the [Theme Songs server plugin](https://github.com/bitstorm-labs/jellyfin-theme-songs).

## Behaviour

- **One play per show-visit**, keyed on series id. Series → Season → Episode is one visit, so drilling down never restarts the theme and returning from the player is silent.
- 0.75s delay before starting, so browsing a row doesn't blip audio.
- Fades: in 1.0s, out 0.4s on show change, 1.5s before the natural end, **0.25s hard cut** when Play or Trailer is pressed.
- Volume 0.6 of system. Toggle in Settings → Playback Behavior.
- **Every failure path is silence.** ~41% of a real library has no theme; that's normal, not an error.

## Why app-level rather than per-view

Detail screens are presented with `fullScreenCover`, not pushed. A presented cover doesn't remove its parent, so the parent's `onDisappear` never fires and drilling down stacks live views — `MediaDetailView.swift:315` already documents this trap for `.task`. Per-view start/stop can't work, so one `@MainActor` service owns the player, fades, and visit state; views report intent only.

`ThemeSongVisitState` counts depth rather than holding a flag, which is what makes drill-down and back-out work with one rule.

## What's verified

- **254 tests** pass on tvOS (250 before this branch + new coverage), `SashimiMobile` iOS build green, zero new warnings, SwiftLint strict clean.
- Timing constants are injectable (`ThemeSongTimings`) with a test asserting the shipped defaults — added after a declared-but-never-read constant survived a green suite.
- Every new test was red-verified by breaking the code it covers. Three candidate tests were **rejected during review for passing against broken code** and replaced with assertions that actually discriminate.

## What is NOT verified

**No on-device testing — no hardware was available.** Nine manual checks are outstanding and need a real Apple TV: fade feel, the 0.25s cut before player audio, drilling series → season → episode, a themeless show, and backgrounding mid-theme. A tenth was added by review: **scroll a row or move focus while a theme fades in** and confirm the fade completes — `Timer` in default run-loop mode doesn't fire during tvOS tracking mode, which is fixed here but untestable in XCTest.

The highest-value check is "return from the player is silent" — everything else is downstream of that assumption.

## Known follow-ups (reviewed and deliberately deferred)

- `getAudioStreamURL` duplicates URL-building from `getPlaybackURL`; a shared helper could absorb it.
- A short theme can lose its end fade if `AVAsset.load(.duration)` resolves after playback passed the boundary — degrades to a hard cut.
- The file lives in `Shared/` though the feature is tvOS-only.

Spec and plan: `~/Documents/git/plans/sashimi/2026-08-18-tvos-theme-songs-{design,plan}.md`