### PR TITLE
feat(ios): theme songs on iPhone and iPad

### DIFF
--- a/SashimiMobile/App/SashimiMobileApp.swift
+++ b/SashimiMobile/App/SashimiMobileApp.swift
@@ -16,6 +16,7 @@ class AppDelegate: NSObject, UIApplicationDelegate {
 struct SashimiMobileApp: App {
     @UIApplicationDelegateAdaptor(AppDelegate.self) var appDelegate
     @StateObject private var sessionManager = SessionManager.shared
+    @Environment(\.scenePhase) private var scenePhase
 
     let modelContainer: ModelContainer
 
@@ -36,6 +37,14 @@ struct SashimiMobileApp: App {
                 .environmentObject(sessionManager)
         }
         .modelContainer(modelContainer)
+        // Mirrors SashimiApp (tvOS): background/lock is a scene-phase change,
+        // not a view teardown, so the theme has to be stopped from here
+        // rather than relying on a detail screen's `onDisappear`.
+        .onChange(of: scenePhase) { _, newPhase in
+            if newPhase != .active {
+                ThemeSongPlayer.shared.appDidBackground()
+            }
+        }
     }
 }
 

--- a/SashimiMobile/Views/Detail/MobileDetailView.swift
+++ b/SashimiMobile/Views/Detail/MobileDetailView.swift
@@ -957,8 +957,11 @@ struct MobileDetailView: View {
     /// Play the item's local trailer inline (Trailarr). The button only appears
     /// when a local trailer exists (LocalTrailerCount > 0), matching Roku.
     private func playLocalTrailer() async {
+        // Matches tvOS: stopped before the network round-trip, not after —
+        // otherwise the theme keeps playing through the whole
+        // getLocalTrailers() fetch and never stops at all if it fails.
+        ThemeSongPlayer.shared.stopForPlayback()
         if let trailer = try? await JellyfinClient.shared.getLocalTrailers(itemId: item.id).first {
-            ThemeSongPlayer.shared.stopForPlayback()
             playingItem = trailer
         }
     }

--- a/SashimiMobile/Views/Detail/MobileDetailView.swift
+++ b/SashimiMobile/Views/Detail/MobileDetailView.swift
@@ -212,6 +212,7 @@ struct MobileDetailView: View {
             }
             .ignoresSafeArea()
         }
+        .themeSong(for: item)
         .fullScreenPlayer(item: $playingItem)
         .fullScreenPlayer(item: $startOverItem, startFromBeginning: true)
         .sheet(item: $showingEpisodeDetail) { episode in
@@ -712,6 +713,7 @@ struct MobileDetailView: View {
     private func shuffleEpisode() async {
         let seriesId = isSeries ? item.id : (item.seriesId ?? item.id)
         if let ep = try? await JellyfinClient.shared.getRandomItem(parentId: seriesId, itemTypes: [.episode]) {
+            ThemeSongPlayer.shared.stopForPlayback()
             playingItem = ep
         }
     }
@@ -735,6 +737,7 @@ struct MobileDetailView: View {
                 }()
 
                 Button {
+                    ThemeSongPlayer.shared.stopForPlayback()
                     playingItem = nextEp
                 } label: {
                     Label(epLabel, systemImage: "play.fill")
@@ -744,6 +747,7 @@ struct MobileDetailView: View {
 
                 if epHasProgress {
                     Button {
+                        ThemeSongPlayer.shared.stopForPlayback()
                         startOverItem = nextEp
                     } label: {
                         Image(systemName: "arrow.counterclockwise")
@@ -853,6 +857,7 @@ struct MobileDetailView: View {
     private var episodeActionButtons: some View {
         HStack(spacing: MobileSpacing.md) {
             Button {
+                ThemeSongPlayer.shared.stopForPlayback()
                 playingItem = item
             } label: {
                 Label(hasProgress ? "Resume" : "Play", systemImage: "play.fill")
@@ -862,6 +867,7 @@ struct MobileDetailView: View {
 
             if hasProgress {
                 Button {
+                    ThemeSongPlayer.shared.stopForPlayback()
                     startOverItem = item
                 } label: {
                     Image(systemName: "arrow.counterclockwise")
@@ -904,6 +910,7 @@ struct MobileDetailView: View {
     private var movieActionButtons: some View {
         HStack(spacing: MobileSpacing.md) {
             Button {
+                ThemeSongPlayer.shared.stopForPlayback()
                 playingItem = item
             } label: {
                 Label(hasProgress ? "Resume" : "Play", systemImage: "play.fill")
@@ -913,6 +920,7 @@ struct MobileDetailView: View {
 
             if hasProgress {
                 Button {
+                    ThemeSongPlayer.shared.stopForPlayback()
                     startOverItem = item
                 } label: {
                     Image(systemName: "arrow.counterclockwise")
@@ -950,6 +958,7 @@ struct MobileDetailView: View {
     /// when a local trailer exists (LocalTrailerCount > 0), matching Roku.
     private func playLocalTrailer() async {
         if let trailer = try? await JellyfinClient.shared.getLocalTrailers(itemId: item.id).first {
+            ThemeSongPlayer.shared.stopForPlayback()
             playingItem = trailer
         }
     }

--- a/SashimiMobile/Views/Library/MobileLibraryBrowseView.swift
+++ b/SashimiMobile/Views/Library/MobileLibraryBrowseView.swift
@@ -90,6 +90,7 @@ struct MobileLibraryBrowseView: View {
     private func shufflePlay() async {
         let types: [ItemType] = collectionType == "tvshows" ? [.episode] : [.movie]
         if let item = try? await JellyfinClient.shared.getRandomItem(parentId: libraryId, itemTypes: types) {
+            ThemeSongPlayer.shared.stopForPlayback()
             shuffleItem = item
         }
     }

--- a/SashimiMobile/Views/Offline/OfflineHomeView.swift
+++ b/SashimiMobile/Views/Offline/OfflineHomeView.swift
@@ -87,7 +87,10 @@ struct OfflineHomeView: View {
             ScrollView(.horizontal, showsIndicators: false) {
                 LazyHStack(spacing: MobileSpacing.md) {
                     ForEach(continueWatchingItems, id: \.itemId) { item in
-                        Button { playingItem = item.asBaseItemDto } label: {
+                        Button {
+                            ThemeSongPlayer.shared.stopForPlayback()
+                            playingItem = item.asBaseItemDto
+                        } label: {
                             offlineContinueCard(item)
                         }
                         .buttonStyle(.plain)
@@ -174,7 +177,10 @@ struct OfflineHomeView: View {
             ScrollView(.horizontal, showsIndicators: false) {
                 LazyHStack(spacing: MobileSpacing.sm) {
                     ForEach(movieItems, id: \.itemId) { item in
-                        Button { playingItem = item.asBaseItemDto } label: {
+                        Button {
+                            ThemeSongPlayer.shared.stopForPlayback()
+                            playingItem = item.asBaseItemDto
+                        } label: {
                             offlinePosterCard(itemId: item.itemId, title: item.name)
                         }
                         .buttonStyle(.plain)

--- a/SashimiMobile/Views/Offline/OfflineSeriesView.swift
+++ b/SashimiMobile/Views/Offline/OfflineSeriesView.swift
@@ -71,7 +71,10 @@ struct OfflineSeriesView: View {
                     // Episode list
                     LazyVStack(spacing: MobileSpacing.sm) {
                         ForEach(filteredEpisodes, id: \.itemId) { episode in
-                            Button { playingItem = episode.asBaseItemDto } label: {
+                            Button {
+                                ThemeSongPlayer.shared.stopForPlayback()
+                                playingItem = episode.asBaseItemDto
+                            } label: {
                                 episodeRow(episode)
                             }
                             .buttonStyle(.plain)

--- a/SashimiMobile/Views/Phone/PhoneDetailView.swift
+++ b/SashimiMobile/Views/Phone/PhoneDetailView.swift
@@ -127,6 +127,7 @@ struct PhoneDetailView: View {
         .clipped()
         .background(MobileColors.background)
         .navigationBarTitleDisplayMode(.inline)
+        .themeSong(for: item)
         .fullScreenPlayer(item: $playingItem)
         .fullScreenPlayer(item: $startOverItem, startFromBeginning: true)
         .navigationDestination(isPresented: $showSeriesDetail) {
@@ -656,6 +657,7 @@ struct PhoneDetailView: View {
     /// when a local trailer exists (LocalTrailerCount > 0), matching Roku.
     private func playLocalTrailer() async {
         if let trailer = try? await JellyfinClient.shared.getLocalTrailers(itemId: item.id).first {
+            ThemeSongPlayer.shared.stopForPlayback()
             playingItem = trailer
         }
     }
@@ -663,6 +665,7 @@ struct PhoneDetailView: View {
     /// Shuffle: play a random episode of this series.
     private func shuffleEpisode() async {
         if let ep = try? await JellyfinClient.shared.getRandomItem(parentId: contentSeriesId, itemTypes: [.episode]) {
+            ThemeSongPlayer.shared.stopForPlayback()
             playingItem = ep
         }
     }
@@ -705,6 +708,7 @@ struct PhoneDetailView: View {
                 }()
 
                 Button {
+                    ThemeSongPlayer.shared.stopForPlayback()
                     playingItem = nextEp
                 } label: {
                     Label(epLabel, systemImage: "play.fill")
@@ -775,6 +779,7 @@ struct PhoneDetailView: View {
                     if let nextEp = nextEpisodeToPlay,
                        (nextEp.userData?.playbackPositionTicks ?? 0) > 0 {
                         Button {
+                            ThemeSongPlayer.shared.stopForPlayback()
                             startOverItem = nextEp
                         } label: {
                             Label("Start Over", systemImage: "arrow.counterclockwise")
@@ -817,6 +822,7 @@ struct PhoneDetailView: View {
     private var episodeActionButtons: some View {
         HStack(spacing: MobileSpacing.sm) {
             Button {
+                ThemeSongPlayer.shared.stopForPlayback()
                 playingItem = item
             } label: {
                 Label(hasProgress ? "Resume" : "Play", systemImage: "play.fill")
@@ -834,6 +840,7 @@ struct PhoneDetailView: View {
                 overflowMenu {
                     if hasProgress {
                         Button {
+                            ThemeSongPlayer.shared.stopForPlayback()
                             startOverItem = item
                         } label: {
                             Label("Start Over", systemImage: "arrow.counterclockwise")
@@ -857,6 +864,7 @@ struct PhoneDetailView: View {
     private var movieActionButtons: some View {
         HStack(spacing: MobileSpacing.sm) {
             Button {
+                ThemeSongPlayer.shared.stopForPlayback()
                 playingItem = item
             } label: {
                 Label(hasProgress ? "Resume" : "Play", systemImage: "play.fill")
@@ -874,6 +882,7 @@ struct PhoneDetailView: View {
                 overflowMenu {
                     if hasProgress {
                         Button {
+                            ThemeSongPlayer.shared.stopForPlayback()
                             startOverItem = item
                         } label: {
                             Label("Start Over", systemImage: "arrow.counterclockwise")

--- a/SashimiMobile/Views/Phone/PhoneDetailView.swift
+++ b/SashimiMobile/Views/Phone/PhoneDetailView.swift
@@ -656,8 +656,11 @@ struct PhoneDetailView: View {
     /// Play the item's local trailer inline (Trailarr). The button only appears
     /// when a local trailer exists (LocalTrailerCount > 0), matching Roku.
     private func playLocalTrailer() async {
+        // Matches tvOS: stopped before the network round-trip, not after —
+        // otherwise the theme keeps playing through the whole
+        // getLocalTrailers() fetch and never stops at all if it fails.
+        ThemeSongPlayer.shared.stopForPlayback()
         if let trailer = try? await JellyfinClient.shared.getLocalTrailers(itemId: item.id).first {
-            ThemeSongPlayer.shared.stopForPlayback()
             playingItem = trailer
         }
     }

--- a/SashimiMobile/Views/Settings/MobileSettingsView.swift
+++ b/SashimiMobile/Views/Settings/MobileSettingsView.swift
@@ -72,6 +72,7 @@ struct MobileSettingsView: View {
                 Toggle("Auto-Play Next Episode", isOn: $playbackSettings.autoPlayNextEpisode)
                 Toggle("Auto-Skip Intro", isOn: $playbackSettings.autoSkipIntro)
                 Toggle("Auto-Skip Credits", isOn: $playbackSettings.autoSkipCredits)
+                Toggle("Play Theme Songs", isOn: $playbackSettings.playThemeSongs)
                 Toggle("Always Play Original", isOn: $playbackSettings.forceDirectPlay)
                 // tvOS parity — same values as the tvOS Resume Threshold screen
                 Picker("Resume Threshold", selection: $playbackSettings.resumeThresholdSeconds) {

--- a/SashimiTests/PlaybackSettingsTests.swift
+++ b/SashimiTests/PlaybackSettingsTests.swift
@@ -1,0 +1,41 @@
+import XCTest
+@testable import Sashimi
+
+/// `PlaybackSettings.defaultPlayThemeSongs(idiom:)` is the pure mapping
+/// pulled out of the `@AppStorage("playThemeSongs")` initializer so it can be
+/// exercised for every idiom without faking `UIDevice.current` (not
+/// mockable) or a real `UserDefaults` suite. The property itself only reads
+/// this default once, at first access, when nothing is already stored — that
+/// part isn't under test here, just the idiom -> Bool logic that feeds it.
+final class PlaybackSettingsDefaultThemeSongsTests: XCTestCase {
+    func testPhoneDefaultsOff() {
+        XCTAssertFalse(PlaybackSettings.defaultPlayThemeSongs(idiom: .phone))
+    }
+
+    func testPadDefaultsOn() {
+        XCTAssertTrue(PlaybackSettings.defaultPlayThemeSongs(idiom: .pad))
+    }
+
+    /// The shipped tvOS default was `true` before this change; this pins
+    /// that the idiom-derived expression doesn't regress it.
+    func testTVDefaultsOnMatchingTheShippedTVOSDefault() {
+        XCTAssertTrue(PlaybackSettings.defaultPlayThemeSongs(idiom: .tv))
+    }
+
+    /// This test host IS the tvOS app — `UIDevice.current.userInterfaceIdiom`
+    /// really is `.tv` here, so calling the no-argument overload (the exact
+    /// expression `@AppStorage` evaluates) exercises the production default
+    /// end to end on the platform that shipped first, not just the pure
+    /// function in isolation.
+    func testRealDeviceIdiomOnThisTestHostDefaultsOn() {
+        XCTAssertEqual(UIDevice.current.userInterfaceIdiom, .tv, "sanity: this suite runs in the tvOS host app")
+        XCTAssertTrue(PlaybackSettings.defaultPlayThemeSongs())
+    }
+
+    /// Every other idiom (car display, Mac, unspecified, vision) should stay
+    /// on too — only `.phone` is singled out.
+    func testUnspecifiedAndOtherIdiomsDefaultOn() {
+        XCTAssertTrue(PlaybackSettings.defaultPlayThemeSongs(idiom: .unspecified))
+        XCTAssertTrue(PlaybackSettings.defaultPlayThemeSongs(idiom: .carPlay))
+    }
+}

--- a/SashimiTests/PlaybackSettingsTests.swift
+++ b/SashimiTests/PlaybackSettingsTests.swift
@@ -39,3 +39,71 @@ final class PlaybackSettingsDefaultThemeSongsTests: XCTestCase {
         XCTAssertTrue(PlaybackSettings.defaultPlayThemeSongs(idiom: .carPlay))
     }
 }
+
+/// Exercises the actual `@AppStorage("playThemeSongs")` wiring on
+/// `PlaybackSettings` itself — not just the pure `defaultPlayThemeSongs`
+/// function above. `PlaybackSettings` has an implicit internal `init`, and
+/// `@AppStorage` outside a `View` reads/writes `UserDefaults.standard`
+/// directly, so a fresh instance is enough to observe both halves of the
+/// contract: the idiom-derived default applies when nothing is stored, and
+/// a stored value always wins over it (an existing install's choice is
+/// never silently overridden).
+@MainActor
+final class PlaybackSettingsAppStorageWiringTests: XCTestCase {
+    private let key = "playThemeSongs"
+    private var hadStoredValue = false
+    private var previousValue = false
+
+    override func setUp() {
+        super.setUp()
+        // Save whatever's there (if anything) so this suite can restore it
+        // in tearDown and not leak state into other tests/suites that touch
+        // the same UserDefaults.standard key.
+        hadStoredValue = UserDefaults.standard.object(forKey: key) != nil
+        if hadStoredValue {
+            previousValue = UserDefaults.standard.bool(forKey: key)
+        }
+    }
+
+    override func tearDown() {
+        if hadStoredValue {
+            UserDefaults.standard.set(previousValue, forKey: key)
+        } else {
+            UserDefaults.standard.removeObject(forKey: key)
+        }
+        super.tearDown()
+    }
+
+    /// Exercises the real `@AppStorage` initializer end to end (not just the
+    /// pure function it delegates to) — a fresh instance, nothing stored,
+    /// must come up `true` on this host.
+    ///
+    /// Red-verify note: reverting `PlaybackSettings.swift`'s `playThemeSongs`
+    /// declaration back to the old hardcoded `= true` does NOT fail this
+    /// test. `.tv`'s idiom-derived default and the old hardcoded default are
+    /// both `true`, and this suite only ever runs on the tvOS test host
+    /// (`SashimiTests` has no iOS counterpart) — so no boolean read of
+    /// `playThemeSongs` on this host can distinguish "computed from
+    /// `defaultPlayThemeSongs()`" from "hardcoded `true`". Confirmed by
+    /// actually doing that revert and rerunning: this test stayed green.
+    /// The genuinely discriminating coverage for the idiom-dependent part of
+    /// this change is `PlaybackSettingsDefaultThemeSongsTests.testPhoneDefaultsOff`
+    /// / `testPadDefaultsOn` above, which pass the idiom in as an argument
+    /// and don't depend on which platform hosts the test; both were
+    /// red-verified successfully. This test is kept because "a fresh
+    /// install defaults on" and "the `@AppStorage` wrapper itself works" are
+    /// still real, worth-pinning facts — just not ones that isolate this
+    /// specific wiring change on this host.
+    func testFreshInstallUsesTheIdiomDerivedDefault() {
+        UserDefaults.standard.removeObject(forKey: key)
+        XCTAssertTrue(PlaybackSettings().playThemeSongs, "a fresh install on this (tvOS) host should default on")
+    }
+
+    /// A value already in `UserDefaults` — an existing install's explicit
+    /// choice — must win over the idiom default, not be silently replaced
+    /// by it.
+    func testExistingStoredValueWinsOverTheDefault() {
+        UserDefaults.standard.set(false, forKey: key)
+        XCTAssertFalse(PlaybackSettings().playThemeSongs, "a stored value must not be overridden by the idiom default")
+    }
+}

--- a/SashimiTests/ThemeSongVisitStateTests.swift
+++ b/SashimiTests/ThemeSongVisitStateTests.swift
@@ -62,4 +62,36 @@ final class ThemeSongVisitStateTests: XCTestCase {
         s.reset()
         XCTAssertEqual(s.showAppeared(seriesId: "A"), .start(seriesId: "A"))
     }
+
+    /// Pins the real invariant a `NavigationStack` push/pop depends on:
+    /// SwiftUI inserts the incoming view before removing the outgoing one,
+    /// in BOTH directions. On push, the pushed (incoming) child's
+    /// `onAppear` fires before the parent's (outgoing) `onDisappear`; on
+    /// pop, the reappearing (incoming) parent's `onAppear` fires before the
+    /// popped (outgoing) child's `onDisappear`. `depth` therefore goes
+    /// 1 -> 2 -> 1 on push and 1 -> 2 -> 1 again on pop — it never reaches
+    /// zero, so the visit never ends and never spuriously restarts.
+    ///
+    /// This is NOT the same claim as `fullScreenCover` parity (the parent
+    /// never disappearing at all, per the doc comment on the type above) —
+    /// pushing over a `NavigationStack` DOES fire the parent's
+    /// `onDisappear`, confirmed empirically. What saves this from
+    /// restarting the theme is purely the incoming-before-outgoing
+    /// ordering pinned here. If a future SwiftUI version ever inverted
+    /// that ordering (outgoing before incoming), `depth` would hit zero on
+    /// push, `currentSeriesId` would clear, and the pop would return
+    /// `.start` — restarting the theme every time someone backs out of an
+    /// episode to its series.
+    func testIncomingBeforeOutgoingOnBothPushAndPopNeverEndsTheVisit() {
+        var s = ThemeSongVisitState()
+        _ = s.showAppeared(seriesId: "S") // initial screen (e.g. Series) starts the visit
+
+        // Push: the pushed child appears before the parent disappears.
+        XCTAssertEqual(s.showAppeared(seriesId: "S"), .ignore, "child appearing mid-push must not read as a new visit")
+        XCTAssertEqual(s.detailDismissed(seriesId: "S"), .ignore, "parent disappearing after the child already appeared must not end the visit")
+
+        // Pop: the parent reappears before the popped child disappears.
+        XCTAssertEqual(s.showAppeared(seriesId: "S"), .ignore, "parent reappearing mid-pop must not read as a new visit")
+        XCTAssertEqual(s.detailDismissed(seriesId: "S"), .ignore, "child disappearing after the parent already reappeared must not end the visit")
+    }
 }

--- a/Shared/Services/PlaybackSettings.swift
+++ b/Shared/Services/PlaybackSettings.swift
@@ -1,4 +1,5 @@
 import SwiftUI
+import UIKit
 
 @MainActor
 class PlaybackSettings: ObservableObject {
@@ -11,7 +12,13 @@ class PlaybackSettings: ObservableObject {
     @AppStorage("autoPlayNextEpisode") var autoPlayNextEpisode = true
     @AppStorage("autoSkipIntro") var autoSkipIntro = false
     @AppStorage("autoSkipCredits") var autoSkipCredits = false
-    @AppStorage("playThemeSongs") var playThemeSongs = true
+    // On by default everywhere except iPhone: a phone theme plays under
+    // whatever's in someone's pocket or on a table nearby, which reads as
+    // noisy in a way the same feature doesn't on a TV across the room or an
+    // iPad usually held with intent. `@AppStorage`'s default only applies
+    // when nothing is stored yet, so this only affects a fresh install —
+    // an iPhone user who explicitly turns it on keeps that choice.
+    @AppStorage("playThemeSongs") var playThemeSongs = PlaybackSettings.defaultPlayThemeSongs()
     @AppStorage("resumeThresholdSeconds") var resumeThresholdSeconds = 30
     @AppStorage("preferredAudioLanguage") var preferredAudioLanguage = ""
     @AppStorage("preferredSubtitleLanguage") var preferredSubtitleLanguage = ""
@@ -33,4 +40,14 @@ class PlaybackSettings: ObservableObject {
     // exists to verify the negotiation, not to play video. Replaced by the
     // real engine setting when the VLC engine lands.
     @AppStorage("debugVLCDeviceProfile") var debugVLCDeviceProfile = false
+
+    /// Pure idiom -> default mapping, pulled out of the `@AppStorage`
+    /// initializer so a test can exercise the logic for every idiom without
+    /// needing to fake `UIDevice.current` (which isn't mockable) or spin up
+    /// a real `UserDefaults` suite. `.phone` is the only idiom that defaults
+    /// off; tvOS's `.tv` and iPad's `.pad` both stay on, matching the
+    /// pre-existing (shipped) tvOS default of `true`.
+    nonisolated static func defaultPlayThemeSongs(idiom: UIUserInterfaceIdiom = UIDevice.current.userInterfaceIdiom) -> Bool {
+        idiom != .phone
+    }
 }


### PR DESCRIPTION
Fixes #390. Parity with tvOS (#389).

`ThemeSongPlayer` already compiled into the mobile target, so this is wiring plus three genuine platform differences.

## Behaviour

Identical to tvOS — one play per show-visit keyed on series id, 0.75s delay, fades (1.0 in / 0.4 show-change / 1.5 end / **0.25 hard cut** on Play or Trailer), volume 0.6, silence on every failure.

**Default is OFF on iPhone, ON on iPad and tvOS.** A phone often isn't a lean-back context, and audio starting unprompted in public or on headphones is a bug report waiting to happen. `@AppStorage` defaults only apply when nothing is stored, so existing installs on any platform keep whatever the user chose.

## The navigation lifecycle, stated correctly

Mobile pushes with `NavigationLink`; tvOS presents with `fullScreenCover`. The risk was that a push fires the parent's `onDisappear` and a pop re-fires `onAppear`, restarting the theme when you back out of an episode.

**It does both of those things** — verified with a throwaway probe app driving real navigation with proper settling. An earlier claim in review that the parent "stays mounted, exactly like tvOS" was wrong, and raced its own logging.

What actually makes this safe is narrower: **SwiftUI inserts the incoming view before removing the outgoing one, in both directions**, so `ThemeSongVisitState.depth` goes 1→2→1 and never reaches zero. That invariant is now pinned by a test (`testPushPopOrderingKeepsTheVisitAlive`) and red-verified — remove `depth += 1` from the same-series branch and it fails.

This distinction matters: if that ordering ever inverted, depth would hit 0 on push and the pop would return `.start`.

## Verified

- **262 tvOS tests** (254 before this branch), `SashimiMobile` builds clean, SwiftLint strict clean.
- 20 `stopForPlayback()` sites, each independently verified as a genuine playback-start site with the call preceding the state change. Mobile has more than tvOS's 5 because it uses separate Play/Start-Over buttons per content type across three parallel detail views.
- `.themeSong(for:)` is applied to `PhoneDetailView` as well as `MobileDetailView` — portrait iPhone routes through the former, so without it the toggle would be a no-op for exactly the users the setting targets.

## Not verified

No on-device testing. Simulator has no Ring/Silent switch, and iPad runtime wasn't exercised (probes ran on iPhone 17 / iOS 26.5).

**One test is honestly non-discriminating:** `testFreshInstallUsesTheIdiomDerivedDefault` cannot fail on a tvOS host, because `.tv`'s idiom-derived default coincidentally equals the old hardcoded `true`. There is no iOS unit-test target in this project. The genuinely discriminating coverage is `testPhoneDefaultsOff`/`testPadDefaultsOn`, which pass the idiom as an argument.

## Follow-ups (not in this PR)

- **`AVAudioSession` category never reverts.** `PlayerViewModel.loadMedia` sets `.playback`/`.moviePlayback` and nothing restores it, so after the first video of a session a theme ignores the silent switch. Bounded (only post-video, volume 0.6, self-terminating, and `scenePhase` silences on lock) and mitigated by the phone default being off — but real. Fixing it touches shared PiP-critical code.
- `SashimiMobile/Views/Offline/OfflineSeriesView.swift` is **dead** — 202 lines, zero references; `OfflineHomeView` pushes `AdaptiveDetailView` instead. One of the 20 stop sites is therefore unreachable.
- The 20 stop sites could fold into `FullScreenPlayerModifier` as a single `.onChange`.