### PR TITLE
chore: bump marketing version to 1.3.0

### DIFF
--- a/project.yml
+++ b/project.yml
@@ -66,7 +66,7 @@ targets:
     settings:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.mondominator.sashimi
-        MARKETING_VERSION: 1.2.17
+        MARKETING_VERSION: 1.3.0
         CURRENT_PROJECT_VERSION: 2
         SWIFT_VERSION: 5.9
         SDKROOT: appletvos
@@ -144,7 +144,7 @@ targets:
         # Shared bundle ID with the tvOS app for Universal Purchase (one "Sashimi"
         # app spanning Apple TV + iPhone + iPad). Distinguished by platform.
         PRODUCT_BUNDLE_IDENTIFIER: com.mondominator.sashimi
-        MARKETING_VERSION: 1.2.17
+        MARKETING_VERSION: 1.3.0
         CURRENT_PROJECT_VERSION: 1
         SWIFT_VERSION: 5.9
         SDKROOT: iphoneos
@@ -186,7 +186,7 @@ targets:
     settings:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.mondominator.sashimi.topshelf
-        MARKETING_VERSION: 1.2.17
+        MARKETING_VERSION: 1.3.0
         CURRENT_PROJECT_VERSION: 2
         SWIFT_VERSION: 5.9
         SDKROOT: appletvos


### PR DESCRIPTION
Theme songs (#389 tvOS, #391 iOS) are a user-visible feature across both targets, so this is a minor bump rather than a patch.

All three `MARKETING_VERSION` entries in `project.yml` (tvOS, iOS, shared) move together — shipping several TestFlight builds under one version makes them indistinguishable in TestFlight and in Jellyfin's `ApplicationVersion`, which has cost real debugging time before.

Tagging `v1.3.0-beta1` after this merges will auto-deploy to TestFlight.