### PR TITLE
fix(ios): let theme songs play with the phone on silent

### DIFF
--- a/SashimiTests/ThemeSongPlayerTests.swift
+++ b/SashimiTests/ThemeSongPlayerTests.swift
@@ -234,6 +234,109 @@ final class ThemeSongResolutionTests: XCTestCase {
     }
 }
 
+/// The theme is allowed to override the iOS Ring/Silent switch (it sets
+/// `.playback` before starting, issue #393), which means it also claims audio
+/// focus. That is only acceptable because it never does so while another app
+/// owns the audio: a podcast or album the user deliberately started must not
+/// be stopped by walking onto a detail screen.
+///
+/// `isOtherAudioPlaying` is the injectable seam that decision hangs off,
+/// because the real signal (`AVAudioSession.isOtherAudioPlaying`) cannot be
+/// produced on a simulator — and this suite is tvOS-hosted, where the
+/// production default is a constant `false` by design.
+///
+/// Red-verified: inverting the guard in `scheduleStart` to
+/// `guard isOtherAudioPlaying()` makes
+/// `testOtherAudioPlayingSkipsTheThemeEntirely` and
+/// `testNoOtherAudioLetsTheThemeStart` fail, and deleting the guard outright
+/// makes `testOtherAudioPlayingSkipsTheThemeEntirely` fail. Neither passes
+/// against code without the fix.
+@MainActor
+final class ThemeSongOtherAudioGateTests: XCTestCase {
+    /// A reserved, non-routable address: `AVPlayerItem`/`AVPlayer`
+    /// construction and `play()` are local operations, so nothing here needs
+    /// the stream to resolve.
+    private func themeURL() throws -> URL {
+        try XCTUnwrap(URL(string: "http://192.0.2.1:1/theme.mp3"))
+    }
+
+    /// The whole point of the gate: not "start quietly", not "start and duck"
+    /// — nothing happens at all. No session change (there is none to observe
+    /// here, hence the player assertion), and crucially no network request,
+    /// which is why the resolver/urlBuilder counts must both stay at zero.
+    func testOtherAudioPlayingSkipsTheThemeEntirely() async throws {
+        let player = ThemeSongPlayer(timings: ThemeSongTimings(startDelay: 0))
+        PlaybackSettings.shared.playThemeSongs = true
+        var resolverCalls = 0
+        var urlBuilderCalls = 0
+        player.resolver = { _ in resolverCalls += 1; return "theme-item-id" }
+        let url = try themeURL()
+        player.urlBuilder = { _ in urlBuilderCalls += 1; return url }
+        player.isOtherAudioPlaying = { true }
+
+        player.showAppeared(seriesId: "A")
+        try? await Task.sleep(nanoseconds: 50_000_000)
+
+        XCTAssertEqual(resolverCalls, 0, "a skipped visit must not cost a theme lookup")
+        XCTAssertEqual(urlBuilderCalls, 0, "a skipped visit must not build a stream URL either")
+        XCTAssertNil(player.playerForTest, "no AVPlayer may be created when another app owns the audio")
+    }
+
+    /// The other half of the pair. Without this, a gate that skipped
+    /// unconditionally would still satisfy the test above — the exact shape
+    /// of "passes against broken code" this feature has already been bitten
+    /// by on other clients.
+    func testNoOtherAudioLetsTheThemeStart() async throws {
+        let player = ThemeSongPlayer(timings: ThemeSongTimings(startDelay: 0))
+        PlaybackSettings.shared.playThemeSongs = true
+        var urlBuilderCalls = 0
+        player.resolver = { _ in "theme-item-id" }
+        let url = try themeURL()
+        player.urlBuilder = { _ in urlBuilderCalls += 1; return url }
+        player.isOtherAudioPlaying = { false }
+
+        player.showAppeared(seriesId: "A")
+        try? await Task.sleep(nanoseconds: 50_000_000)
+
+        XCTAssertEqual(urlBuilderCalls, 1, "with no competing audio the theme must resolve and start")
+        XCTAssertNotNil(player.playerForTest, "an AVPlayer should have been created")
+    }
+
+    /// The gate lives *after* the start delay on purpose: a show the user
+    /// flicks past is cancelled before the delay elapses and must ask no
+    /// question at all — not of `AVAudioSession`, not of the server. Moving
+    /// the check ahead of the sleep would make every scrolled-past row
+    /// interrogate the audio session.
+    func testShowFlickedPastNeverConsultsTheGate() async {
+        let player = ThemeSongPlayer(timings: ThemeSongTimings(startDelay: 0.75))
+        PlaybackSettings.shared.playThemeSongs = true
+        var probeCalls = 0
+        player.isOtherAudioPlaying = { probeCalls += 1; return false }
+        player.resolver = { _ in "theme-item-id" }
+        player.urlBuilder = { _ in nil }
+
+        player.showAppeared(seriesId: "A")
+        player.detailDismissed(seriesId: "A")
+        try? await Task.sleep(nanoseconds: 50_000_000)
+
+        XCTAssertEqual(probeCalls, 0, "a visit abandoned inside the start delay must not probe the audio session")
+    }
+
+    /// tvOS has no Ring/Silent switch, configures its session once at launch
+    /// in `SashimiApp`, and its theme behaviour is unchanged by this fix. The
+    /// shipped probe must therefore be inert here — if someone ever makes the
+    /// default `AVAudioSession.isOtherAudioPlaying` on every platform, tvOS
+    /// starts silently dropping themes and this catches it.
+    func testShippedProbeIsInertOnTVOS() {
+        let player = ThemeSongPlayer()
+        #if os(tvOS)
+        XCTAssertFalse(player.isOtherAudioPlaying(), "the tvOS default must be a constant false")
+        #else
+        _ = player
+        #endif
+    }
+}
+
 /// `fade()`'s early-return path (taken when a fade is instant, i.e.
 /// `duration <= 0`) must clear `fadeTimer`, not merely invalidate the timer
 /// it points to. Left dangling, an already-enqueued tick from that

--- a/Shared/Services/ThemeSongPlayer.swift
+++ b/Shared/Services/ThemeSongPlayer.swift
@@ -30,6 +30,37 @@ struct ThemeSongTimings {
 /// one place.
 ///
 /// Every failure path is silence. Background music is never worth an error.
+///
+/// ## `AVAudioSession` — what this type is allowed to do
+///
+/// The original rule here was "never touch `AVAudioSession`", because tvOS
+/// configures it once at launch (`SashimiApp.configureAudioSession`) and
+/// reconfiguring it would break video playback. That rule is deliberately
+/// relaxed for **one narrow iOS-only case** (issue #393): the mobile app
+/// configures no session at all, so a theme played under iOS's default
+/// `.soloAmbient` category obeys the Ring/Silent switch and is inaudible on
+/// a phone that's on silent. A user who turned theme songs on asked for
+/// them; a hardware switch they set weeks ago shouldn't veto that.
+///
+/// So, on iOS only, and only immediately before starting a theme, this type
+/// sets `.playback` / `.moviePlayback` and activates the session — the exact
+/// category `PlayerViewModel.loadMedia` already sets for every video and
+/// never reverts, so the session ends up there regardless. The theme just
+/// gets there first.
+///
+/// Three parts of that are load-bearing; do not "tidy" any of them away:
+///
+/// - **It never deactivates the session.** `PlayerViewModel` doesn't either.
+///   Deactivating on stop is what would break video, Picture-in-Picture and
+///   background audio.
+/// - **It never takes audio from the user.** `.playback` claims audio focus,
+///   which would stop a podcast or album the user deliberately started, so
+///   the theme is skipped entirely — no session change, no request, no
+///   retry — whenever `isOtherAudioPlaying` reports another app is already
+///   playing.
+/// - **None of it applies to tvOS.** There is no silent switch there, the
+///   session is already configured at launch, and the tvOS behaviour of this
+///   type is unchanged.
 @MainActor
 final class ThemeSongPlayer: ObservableObject {
     static let shared = ThemeSongPlayer()
@@ -78,6 +109,33 @@ final class ThemeSongPlayer: ObservableObject {
     /// `cache` doc comment above for why a URL can't be treated the same way
     /// an id can.
     var urlBuilder: (String) async -> URL?
+
+    /// Reports whether audio belonging to *another* app is already playing.
+    /// A theme must never interrupt it (see the type's `AVAudioSession`
+    /// note above).
+    ///
+    /// Injectable purely so the gate is unit-testable: `SashimiTests` is
+    /// tvOS-hosted, and there is no way to make a simulator report another
+    /// app's audio. Tests override this; nothing else does.
+    ///
+    /// The production default is platform-specific rather than the whole
+    /// gate being `#if os(iOS)`, so there is exactly one code path to reason
+    /// about. On tvOS it is a constant `false`: no silent switch, no
+    /// competing-audio concern in the same form, and the tvOS behaviour of
+    /// this type must not change.
+    ///
+    /// `AVAudioSession.isOtherAudioPlaying` is specifically *other* apps'
+    /// audio — it does not report this app's own theme back to itself, so
+    /// there is no need for the "I already own the audio" escape hatch a
+    /// same-process signal (e.g. Android's `AudioManager.isMusicActive`)
+    /// would require to survive its own fade-out during a show change.
+    var isOtherAudioPlaying: () -> Bool = {
+        #if os(iOS)
+        return AVAudioSession.sharedInstance().isOtherAudioPlaying
+        #else
+        return false
+        #endif
+    }
 
     init(timings: ThemeSongTimings = ThemeSongTimings()) {
         self.timings = timings
@@ -138,6 +196,17 @@ final class ThemeSongPlayer: ObservableObject {
                 try? await Task.sleep(nanoseconds: UInt64(timings.startDelay * 1_000_000_000))
             }
             guard !Task.isCancelled else { return }
+            // Placed *after* the delay so a show flicked past never asks the
+            // question, and *before* the lookup so a skipped visit costs no
+            // network request. The visit needs no extra "spent" bookkeeping:
+            // `ThemeSongVisitState` only returns `.start` when the series
+            // actually changes, so returning here ends this visit's one and
+            // only attempt — drilling into a season, or coming back from
+            // background, is still the same visit and won't retry.
+            guard !isOtherAudioPlaying() else {
+                logger.debug("theme skipped: another app is playing audio")
+                return
+            }
             guard let url = await resolve(seriesId: seriesId) else { return }
             guard !Task.isCancelled, visit.currentSeriesId == seriesId else { return }
             play(url: url)
@@ -178,6 +247,7 @@ final class ThemeSongPlayer: ObservableObject {
         // second `play()` before the first has torn down leaks the old
         // AVPlayer and its NotificationCenter/time-observer tokens forever.
         teardown()
+        activatePlaybackSessionIfNeeded()
         let item = AVPlayerItem(url: url)
         let p = AVPlayer(playerItem: item)
         p.volume = 0
@@ -194,6 +264,27 @@ final class ThemeSongPlayer: ObservableObject {
         p.play()
         fade(to: timings.volume, over: timings.fadeIn)
         logger.debug("theme song started")
+    }
+
+    /// Points the shared session at the category a theme needs to be audible
+    /// with the Ring/Silent switch on, immediately before the theme starts.
+    /// See the type's `AVAudioSession` note for why this is allowed at all,
+    /// why it is iOS-only, and why the session is never deactivated again.
+    ///
+    /// Reached only once `isOtherAudioPlaying()` has said no other app owns
+    /// the audio, so it can't take playback away from anyone. Failure is
+    /// silence, like every other path here: the theme still tries to play,
+    /// it just stays subject to whatever category the session already had.
+    private func activatePlaybackSessionIfNeeded() {
+        #if os(iOS)
+        do {
+            let session = AVAudioSession.sharedInstance()
+            try session.setCategory(.playback, mode: .moviePlayback)
+            try session.setActive(true)
+        } catch {
+            logger.debug("theme audio session setup failed: \(error.localizedDescription)")
+        }
+        #endif
     }
 
     /// Starts the fade-out `fadeOutEnding` seconds before the theme's natural


### PR DESCRIPTION
Fixes #393. Reported as "theme songs don't work on iPhone".

## Cause

The wiring was fine — it was the audio session.

**tvOS** sets `.playback`/`.moviePlayback` and activates at launch (`SashimiApp.swift:27-30`), so its audio ignores the mute switch. **The mobile app never configured a session at all** — only `PlayerViewModel.loadMedia` does, during video. So a theme on iPhone played under iOS's default `.soloAmbient`, which **respects the Ring/Silent switch**. Phone on silent, no theme.

Stacked on top of the default being off on iPhone, there were two independent reasons to hear nothing, and either alone looks exactly like "broken". That's a design problem, not a coding one.

## Fix

The theme now plays regardless of the silent switch — the user opted in by enabling the setting.

**But it never takes audio from anyone.** `.playback` grabs focus and would stop a podcast someone deliberately started, so this mirrors the Android client:

- **Other audio already playing → skip the theme entirely.** No session change, no request, no retry; the visit is marked spent. The gate sits *after* the 0.75s delay (a show flicked past checks nothing) and *before* the theme lookup (a skipped visit costs no request).
- **Otherwise** set `.playback`/`.moviePlayback`, activate, and play.

Setting that category isn't new risk: `PlayerViewModel.loadMedia` already sets byte-for-byte the same thing on every video and never reverts, so the session ends up there anyway — the theme just gets there first. **The session is never deactivated**, matching existing behaviour; deactivating is what would break video and PiP.

iOS-only. tvOS behaviour is unchanged.

## `isOtherAudioPlaying` does not report our own audio

Android needed an `alreadyOwnsAudio` escape hatch because `isMusicActive` is process-agnostic and stays true on the tail of our own fade-out, so a show-change gated itself off. iOS doesn't have that problem — **measured, not assumed**: a probe generated a 3s PCM tone, played it through an `AVPlayer` exactly as `ThemeSongPlayer` does, and sampled the flag — `false` at baseline, `false` throughout playback, `false` immediately after. Matches the documented contract. The escape hatch was deliberately not ported.

## Verified

- **266 tvOS tests** (262 before), `SashimiMobile` builds clean, SwiftLint strict clean.
- Red-verified three ways: inverting the guard fails both directional tests; **deleting** it fails the skip test while the play test still passes (ruling out a passes-either-way test); moving it ahead of the 0.75s delay fails the flicked-past test, pinning placement rather than mere existence.

## Not verified

**The simulator has no Ring/Silent switch**, so "a silenced phone now plays the theme" rests on the category being the documented cause, not on an observation. No device run at all — video, PiP, background audio and Bluetooth/AirPlay routing are unverified here; the non-regression case is that the category is identical to what video already sets, which is an argument rather than a measurement.

Worth checking on a real phone before this rides a deploy tag.

## Note for future work

The plan doc (`~/Documents/git/plans/sashimi/2026-08-18-tvos-theme-songs-plan.md`) states an absolute "never touch `AVAudioSession`" constraint. That rule is now deliberately relaxed for this one narrow case, and the reasoning is documented on the type itself so it doesn't get reverted as a mistake.