### PR TITLE
fix: hero shows the video, not the channel, when several are new

### DIFF
--- a/Shared/Services/JellyfinClient.swift
+++ b/Shared/Services/JellyfinClient.swift
@@ -802,7 +802,7 @@ actor JellyfinClient {
         return response.items
     }
 
-    func getLatestMedia(parentId: String? = nil, limit: Int = 16, includeWatched: Bool = false, collectionType: String? = nil) async throws -> [BaseItemDto] {
+    func getLatestMedia(parentId: String? = nil, limit: Int = 16, includeWatched: Bool = false, collectionType: String? = nil, groupItems: Bool = true) async throws -> [BaseItemDto] {
         guard let userId else { throw JellyfinError.notConfigured }
 
         if includeWatched {
@@ -859,6 +859,16 @@ actor JellyfinClient {
                 URLQueryItem(name: "Fields", value: "Overview,PrimaryImageAspectRatio,CommunityRating,OfficialRating,Genres,Taglines,MediaStreams"),
                 URLQueryItem(name: "EnableImageTypes", value: "Primary,Backdrop,Thumb")
             ]
+
+            // Grouping is ON by default (the Recently Added row wants it: a
+            // channel's burst of new videos should be one card, not five). The
+            // hero passes false — grouped, a channel that posted several videos
+            // collapses into its Series and the hero shows the CHANNEL rather
+            // than a video. Verified against the server: grouped returns a
+            // Series/Episode mix, ungrouped returns 10/10 Episodes.
+            if !groupItems {
+                queryItems.append(URLQueryItem(name: "GroupItems", value: "false"))
+            }
 
             if let parentId {
                 queryItems.append(URLQueryItem(name: "ParentId", value: parentId))

--- a/Shared/ViewModels/HomeViewModel.swift
+++ b/Shared/ViewModels/HomeViewModel.swift
@@ -169,7 +169,7 @@ final class HomeViewModel: ObservableObject {
             for (index, library) in libraries.enumerated() {
                 group.addTask { [client] in
                     do {
-                        let items = try await client.getLatestMedia(parentId: library.id, limit: 10)
+                        let items = try await client.getLatestMedia(parentId: library.id, limit: 10, groupItems: false)
                         return LibraryLatest(index: index, items: items)
                     } catch {
                         // Non-fatal: this library is just missing from the rotation


### PR DESCRIPTION
/Items/Latest defaults GroupItems=true: an item with one new child returns
that child, but several collapse into the parent Series. So a channel that
had posted a few videos appeared in the hero as the CHANNEL, not a video.

Reported on Roku, but tvOS never passed GroupItems either — both clients
had it. Verified against the server: grouped returns a Series/Episode mix,
GroupItems=false returns 10/10 Episodes.

getLatestMedia gains groupItems (default true); only the hero passes false.
The Recently Added rows keep grouping deliberately — a channel's burst of
new videos should be one card there, not five.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01XzUNvRCXML3DJe98KBCGkN
