### PR TITLE
chore: bump marketing version to 1.4.0

### DIFF
--- a/project.yml
+++ b/project.yml
@@ -66,7 +66,7 @@ targets:
     settings:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.mondominator.sashimi
-        MARKETING_VERSION: 1.3.2
+        MARKETING_VERSION: 1.4.0
         CURRENT_PROJECT_VERSION: 2
         SWIFT_VERSION: 5.9
         SDKROOT: appletvos
@@ -144,7 +144,7 @@ targets:
         # Shared bundle ID with the tvOS app for Universal Purchase (one "Sashimi"
         # app spanning Apple TV + iPhone + iPad). Distinguished by platform.
         PRODUCT_BUNDLE_IDENTIFIER: com.mondominator.sashimi
-        MARKETING_VERSION: 1.3.2
+        MARKETING_VERSION: 1.4.0
         CURRENT_PROJECT_VERSION: 1
         SWIFT_VERSION: 5.9
         SDKROOT: iphoneos
@@ -186,7 +186,7 @@ targets:
     settings:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.mondominator.sashimi.topshelf
-        MARKETING_VERSION: 1.3.2
+        MARKETING_VERSION: 1.4.0
         CURRENT_PROJECT_VERSION: 2
         SWIFT_VERSION: 5.9
         SDKROOT: appletvos


### PR DESCRIPTION
Cuts 1.4.0 for TestFlight.

**Headline:** multi-server people discovery (#379) — tap a cast member, see their filmography across every configured server.

**Also in this build, for iOS specifically:** this is the first iOS TestFlight tag since `ios-v1.2.17-beta1`. The entire 1.3.x line was tagged `v*` (tvOS) only, so iOS testers have not received:

- theme songs on iPhone and iPad (#391)
- theme songs with the Ring/Silent switch on (#394)
- hero shows the video, not the channel, when several are new (#396)

Those ship alongside #379 here.

Minor bump rather than patch, matching how theme songs took 1.3.0 — this is a feature release.

Tags to follow on merge: `v1.4.0-beta1` (tvOS) and `ios-v1.4.0-beta1` (iOS).