### PR TITLE
feat: edit saved server settings

### DIFF
--- a/Sashimi/App/SashimiApp.swift
+++ b/Sashimi/App/SashimiApp.swift
@@ -67,9 +67,10 @@ struct ContentView: View {
         Group {
             if sessionManager.isAuthenticated {
                 // Rebuild the entire tab hierarchy when the active server
-                // changes — every view model reloads against the new server.
+                // changes or its connection credentials are edited — every
+                // view model reloads against the current server.
                 MainTabView()
-                    .id(sessionManager.activeServerId)
+                    .id(sessionManager.activeSessionIdentity)
             } else {
                 ServerConnectionView(
                     prefillServerURL: sessionManager.reauthServer?.url,
@@ -531,7 +532,7 @@ struct MainTabView: View {
         .focused($focusedNav, equals: .avatar)
         .confirmationDialog("Switch Server", isPresented: $showServerSwitcher, titleVisibility: .visible) {
             ForEach(sessionManager.servers) { server in
-                Button(server.id == sessionManager.activeServerId ? "✓ \(server.name)" : server.name) {
+                Button(server.id == sessionManager.activeServerId ? "✓ \(server.displayName)" : server.displayName) {
                     Task { await sessionManager.switchServer(to: server.id) }
                 }
             }

--- a/Sashimi/Views/Library/SettingsView.swift
+++ b/Sashimi/Views/Library/SettingsView.swift
@@ -1126,6 +1126,7 @@ struct AppIconButton: View {
 struct ServersSettingsView: View {
     @EnvironmentObject private var sessionManager: SessionManager
     @State private var showAddServer = false
+    @State private var serverBeingEdited: ServerConfig?
     @State private var serverPendingRemoval: ServerConfig?
 
     var body: some View {
@@ -1135,36 +1136,51 @@ struct ServersSettingsView: View {
                     .font(.largeTitle.bold())
                     .frame(maxWidth: .infinity, alignment: .leading)
 
-                Text("Select a server to switch. Hold to remove.")
+                Text("Select a server to switch, or edit its details. Hold to remove.")
                     .font(.callout)
                     .foregroundStyle(SashimiTheme.textSecondary)
                     .frame(maxWidth: .infinity, alignment: .leading)
 
                 ForEach(sessionManager.servers) { server in
-                    Button {
-                        Task { await sessionManager.switchServer(to: server.id) }
-                    } label: {
-                        HStack {
-                            Image(systemName: "server.rack")
-                                .foregroundStyle(SashimiTheme.accent)
-                            VStack(alignment: .leading, spacing: 4) {
-                                Text(server.name)
-                                    .foregroundStyle(SashimiTheme.textPrimary)
-                                Text("\(server.username) • \(server.url.absoluteString)")
-                                    .font(.caption)
-                                    .foregroundStyle(SashimiTheme.textTertiary)
-                            }
-                            Spacer()
-                            if server.id == sessionManager.activeServerId {
-                                Image(systemName: "checkmark.circle.fill")
+                    HStack(spacing: 18) {
+                        Button {
+                            Task { await sessionManager.switchServer(to: server.id) }
+                        } label: {
+                            HStack {
+                                Image(systemName: "server.rack")
                                     .foregroundStyle(SashimiTheme.accent)
+                                VStack(alignment: .leading, spacing: 4) {
+                                    Text(server.displayName)
+                                        .foregroundStyle(SashimiTheme.textPrimary)
+                                    Text("\(server.username) • \(server.url.absoluteString)")
+                                        .font(.caption)
+                                        .foregroundStyle(SashimiTheme.textTertiary)
+                                }
+                                Spacer()
+                                if server.id == sessionManager.activeServerId {
+                                    Image(systemName: "checkmark.circle.fill")
+                                        .foregroundStyle(SashimiTheme.accent)
+                                }
                             }
+                            .frame(maxWidth: .infinity, alignment: .leading)
                         }
-                        .padding()
-                        .background(SashimiTheme.cardBackground)
-                        .clipShape(RoundedRectangle(cornerRadius: 12))
+                        .buttonStyle(.plain)
+
+                        Button {
+                            serverBeingEdited = server
+                        } label: {
+                            Image(systemName: "pencil")
+                                .font(.title3)
+                                .foregroundStyle(SashimiTheme.textSecondary)
+                                .frame(width: 44, height: 44)
+                                .contentShape(Rectangle())
+                        }
+                        .buttonStyle(.plain)
+                        .accessibilityLabel("Edit \(server.displayName)")
                     }
-                    .buttonStyle(.plain)
+                    .padding()
+                    .background(SashimiTheme.cardBackground)
+                    .clipShape(RoundedRectangle(cornerRadius: 12))
                     .contextMenu {
                         Button(role: .destructive) {
                             serverPendingRemoval = server
@@ -1191,8 +1207,12 @@ struct ServersSettingsView: View {
         .fullScreenCover(isPresented: $showAddServer) {
             AddServerSheet()
         }
+        .fullScreenCover(item: $serverBeingEdited) { server in
+            ServerEditView(server: server)
+                .environmentObject(sessionManager)
+        }
         .alert(
-            "Remove \(serverPendingRemoval?.name ?? "server")?",
+            "Remove \(serverPendingRemoval?.displayName ?? "server")?",
             isPresented: Binding(
                 get: { serverPendingRemoval != nil },
                 set: { if !$0 { serverPendingRemoval = nil } }

--- a/SashimiMobile/App/SashimiMobileApp.swift
+++ b/SashimiMobile/App/SashimiMobileApp.swift
@@ -81,7 +81,7 @@ struct ContentView: View {
                         PhoneTabView()
                     }
                 }
-                .id(sessionManager.activeServerId)
+                .id(sessionManager.activeSessionIdentity)
                 .task {
                     await DownloadManager.shared.syncPendingProgress()
                 }

--- a/SashimiMobile/Views/Navigation/SidebarView.swift
+++ b/SashimiMobile/Views/Navigation/SidebarView.swift
@@ -259,9 +259,9 @@ struct MainNavigationView: View {
                         Task { await sessionManager.switchServer(to: server.id) }
                     } label: {
                         if server.id == sessionManager.activeServerId {
-                            Label(server.name, systemImage: "checkmark")
+                            Label(server.displayName, systemImage: "checkmark")
                         } else {
-                            Text(server.name)
+                            Text(server.displayName)
                         }
                     }
                 }

--- a/SashimiMobile/Views/Phone/PhoneHomeView.swift
+++ b/SashimiMobile/Views/Phone/PhoneHomeView.swift
@@ -30,9 +30,9 @@ struct PhoneHomeView: View {
                             Task { await sessionManager.switchServer(to: server.id) }
                         } label: {
                             if server.id == sessionManager.activeServerId {
-                                Label(server.name, systemImage: "checkmark")
+                                Label(server.displayName, systemImage: "checkmark")
                             } else {
-                                Text(server.name)
+                                Text(server.displayName)
                             }
                         }
                     }

--- a/SashimiMobile/Views/Settings/MobileSettingsView.swift
+++ b/SashimiMobile/Views/Settings/MobileSettingsView.swift
@@ -16,28 +16,41 @@ struct MobileSettingsView: View {
     ]
     @State private var showingDeleteAllDownloads = false
     @State private var showAddServer = false
+    @State private var serverBeingEdited: ServerConfig?
 
     var body: some View {
         List {
             // Servers (multi-server switcher; swipe to remove)
             Section("Servers") {
                 ForEach(sessionManager.servers) { server in
-                    Button {
-                        Task { await sessionManager.switchServer(to: server.id) }
-                    } label: {
-                        HStack {
+                    HStack {
+                        Button {
+                            Task { await sessionManager.switchServer(to: server.id) }
+                        } label: {
                             VStack(alignment: .leading, spacing: 2) {
-                                Text(server.name)
+                                Text(server.displayName)
                                     .foregroundStyle(.primary)
                                 Text("\(server.username) • \(server.url.absoluteString)")
                                     .font(.caption)
                                     .foregroundStyle(.secondary)
                             }
-                            Spacer()
-                            if server.id == sessionManager.activeServerId {
-                                Image(systemName: "checkmark.circle.fill")
-                                    .foregroundStyle(.tint)
-                            }
+                            .frame(maxWidth: .infinity, alignment: .leading)
+                        }
+                        .buttonStyle(.plain)
+
+                        Button {
+                            serverBeingEdited = server
+                        } label: {
+                            Image(systemName: "pencil")
+                                .foregroundStyle(.tint)
+                                .frame(width: 32, height: 32)
+                        }
+                        .buttonStyle(.borderless)
+                        .accessibilityLabel("Edit \(server.displayName)")
+
+                        if server.id == sessionManager.activeServerId {
+                            Image(systemName: "checkmark.circle.fill")
+                                .foregroundStyle(.tint)
                         }
                     }
                 }
@@ -141,6 +154,10 @@ struct MobileSettingsView: View {
         }
         .sheet(isPresented: $showAddServer) {
             MobileAddServerSheet()
+        }
+        .fullScreenCover(item: $serverBeingEdited) { server in
+            ServerEditView(server: server)
+                .environmentObject(sessionManager)
         }
         .navigationTitle("Settings")
         .confirmationDialog("Delete All Downloads?", isPresented: $showingDeleteAllDownloads) {

--- a/SashimiTests/ServerEditTests.swift
+++ b/SashimiTests/ServerEditTests.swift
@@ -1,0 +1,377 @@
+import XCTest
+@testable import Sashimi
+
+final class ServerEditTests: XCTestCase {
+    func testDisplayNameUsesAliasAndFallsBackToJellyfinName() {
+        let server = makeServer(name: "Finney", nameOverride: "Home")
+        XCTAssertEqual(server.displayName, "Home")
+
+        let cleared = makeServer(name: "Finney", nameOverride: "   ")
+        XCTAssertEqual(cleared.displayName, "Finney")
+    }
+
+    func testLegacyServerConfigDecodesWithoutAnAlias() throws {
+        let data = """
+        {
+            "id": "server-1",
+            "name": "Finney",
+            "url": "https://fin.example",
+            "username": "tester",
+            "userId": "user-1"
+        }
+        """.data(using: .utf8)!
+
+        let server = try JSONDecoder().decode(ServerConfig.self, from: data)
+        XCTAssertNil(server.nameOverride)
+        XCTAssertEqual(server.displayName, "Finney")
+    }
+
+    func testAliasOnlyEditSkipsAuthentication() async throws {
+        let calls = AuthenticationCallCounter()
+        let current = makeServer(name: "Finney")
+        let request = ServerEditRequest(
+            nameOverride: "Living Room",
+            serverURL: current.url,
+            username: current.username,
+            password: nil
+        )
+
+        let prepared = try await ServerEditCoordinator.prepare(current: current, request: request) { _, _, _ in
+            await calls.increment()
+            return ServerEditAuthentication(
+                accessToken: "unused",
+                username: current.username,
+                userId: current.userId,
+                serverName: current.name
+            )
+        }
+
+        let authenticationCalls = await calls.value
+        XCTAssertEqual(authenticationCalls, 0)
+        XCTAssertEqual(prepared.server.displayName, "Living Room")
+        XCTAssertEqual(prepared.server.userId, current.userId)
+        XCTAssertNil(prepared.accessToken)
+        XCTAssertFalse(request.changesConnection(from: current))
+    }
+
+    func testAliasOnlyEditTreatsTrailingSlashAsTheSameConnection() async throws {
+        let current = makeServer(
+            name: "Finney",
+            url: URL(string: "https://fin.example/")!
+        )
+        let request = ServerEditRequest(
+            nameOverride: "Living Room",
+            serverURL: current.url,
+            username: current.username,
+            password: nil
+        )
+
+        let prepared = try await ServerEditCoordinator.prepare(current: current, request: request) { _, _, _ in
+            XCTFail("Authentication should not start for an alias-only edit")
+            return ServerEditAuthentication(
+                accessToken: "unused",
+                username: current.username,
+                userId: current.userId,
+                serverName: current.name
+            )
+        }
+
+        XCTAssertFalse(request.urlChanged(from: current))
+        XCTAssertFalse(request.changesConnection(from: current))
+        XCTAssertEqual(prepared.server.url, current.url)
+        XCTAssertEqual(prepared.server.displayName, "Living Room")
+        XCTAssertNil(prepared.accessToken)
+    }
+
+    func testCredentialEditKeepsIdentityAndUsesFreshAuthentication() async throws {
+        let current = makeServer(name: "Finney")
+        let newURL = URL(string: "https://new-fin.example")!
+        let request = ServerEditRequest(
+            nameOverride: "Updated Finney",
+            serverURL: newURL,
+            username: "new-user",
+            password: "new-password"
+        )
+
+        let prepared = try await ServerEditCoordinator.prepare(current: current, request: request) { url, username, password in
+            XCTAssertEqual(url, newURL)
+            XCTAssertEqual(username, "new-user")
+            XCTAssertEqual(password, "new-password")
+            return ServerEditAuthentication(
+                accessToken: "fresh-token",
+                username: "new-user",
+                userId: "new-user-id",
+                serverName: "New Finney"
+            )
+        }
+
+        XCTAssertEqual(prepared.server.id, current.id)
+        XCTAssertEqual(prepared.server.url, newURL)
+        XCTAssertEqual(prepared.server.username, "new-user")
+        XCTAssertEqual(prepared.server.userId, "new-user-id")
+        XCTAssertEqual(prepared.server.name, "New Finney")
+        XCTAssertEqual(prepared.server.displayName, "Updated Finney")
+        XCTAssertEqual(prepared.accessToken, "fresh-token")
+        XCTAssertTrue(request.changesConnection(from: current))
+    }
+
+    @MainActor
+    func testSessionUpdatePersistsAliasWithoutRefreshingActiveSession() async throws {
+        let harness = SessionManagerTestHarness()
+        defer { harness.restore() }
+        harness.installToken("old-token")
+        let current = harness.server
+
+        let initialIdentity = harness.manager.activeSessionIdentity
+        try await harness.manager.updateServer(
+            id: harness.server.id,
+            nameOverride: "Living Room",
+            serverURL: harness.server.url,
+            username: harness.server.username,
+            password: nil,
+            authenticate: { _, _, _ in
+                XCTFail("Alias-only edits should not authenticate")
+                return ServerEditAuthentication(
+                    accessToken: "unused",
+                    username: current.username,
+                    userId: current.userId,
+                    serverName: current.name
+                )
+            }
+        )
+
+        XCTAssertEqual(harness.manager.activeSessionIdentity, initialIdentity)
+        XCTAssertEqual(harness.manager.servers.first?.displayName, "Living Room")
+        XCTAssertEqual(harness.persistedServer()?.displayName, "Living Room")
+        await harness.clearClient()
+    }
+
+    @MainActor
+    func testSessionUpdatePersistsCredentialsAndRefreshesActiveSession() async throws {
+        let harness = SessionManagerTestHarness()
+        defer { harness.restore() }
+        harness.installToken("old-token")
+
+        let newURL = URL(string: "https://new-fin.example")!
+        let initialIdentity = harness.manager.activeSessionIdentity
+        try await harness.manager.updateServer(
+            id: harness.server.id,
+            nameOverride: "Updated Finney",
+            serverURL: newURL,
+            username: "new-user",
+            password: "new-password",
+            authenticate: { url, username, password in
+                XCTAssertEqual(url, newURL)
+                XCTAssertEqual(username, "new-user")
+                XCTAssertEqual(password, "new-password")
+                return ServerEditAuthentication(
+                    accessToken: "fresh-token",
+                    username: "new-user",
+                    userId: "new-user-id",
+                    serverName: "New Finney"
+                )
+            }
+        )
+
+        XCTAssertNotEqual(harness.manager.activeSessionIdentity, initialIdentity)
+        XCTAssertEqual(harness.manager.serverConnectionRevision, 1)
+        XCTAssertEqual(harness.manager.serverURL, newURL)
+        XCTAssertEqual(harness.manager.servers.first?.url, newURL)
+        XCTAssertEqual(harness.manager.servers.first?.userId, "new-user-id")
+        XCTAssertEqual(KeychainHelper.get(forKey: harness.manager.tokenKey(harness.server.id)), "fresh-token")
+        XCTAssertEqual(harness.persistedServer()?.url, newURL)
+        await harness.clearClient()
+    }
+
+    @MainActor
+    func testSessionUpdateFailureLeavesSessionAndPersistenceUnchanged() async throws {
+        let harness = SessionManagerTestHarness()
+        defer { harness.restore() }
+        harness.installToken("old-token")
+
+        let initialIdentity = harness.manager.activeSessionIdentity
+        do {
+            try await harness.manager.updateServer(
+                id: harness.server.id,
+                nameOverride: "Should Not Save",
+                serverURL: URL(string: "https://new-fin.example")!,
+                username: "new-user",
+                password: "bad-password",
+                authenticate: { _, _, _ in
+                    throw TestAuthenticationError.denied
+                }
+            )
+            XCTFail("The failed authentication should be returned")
+        } catch TestAuthenticationError.denied {
+            // Expected.
+        }
+
+        XCTAssertEqual(harness.manager.activeSessionIdentity, initialIdentity)
+        XCTAssertEqual(harness.manager.servers, [harness.server])
+        XCTAssertEqual(harness.persistedServer(), harness.server)
+        XCTAssertEqual(KeychainHelper.get(forKey: harness.manager.tokenKey(harness.server.id)), "old-token")
+        await harness.clearClient()
+    }
+
+    func testConnectionChangeRequiresPassword() async {
+        let current = makeServer(name: "Finney")
+        let request = ServerEditRequest(
+            nameOverride: nil,
+            serverURL: URL(string: "https://new-fin.example")!,
+            username: current.username,
+            password: nil
+        )
+
+        do {
+            _ = try await ServerEditCoordinator.prepare(current: current, request: request) { _, _, _ in
+                XCTFail("Authentication should not start without a password")
+                return ServerEditAuthentication(
+                    accessToken: "unused",
+                    username: current.username,
+                    userId: current.userId,
+                    serverName: current.name
+                )
+            }
+            XCTFail("The edit should require a password")
+        } catch let error as SessionError {
+            XCTAssertEqual(error.localizedDescription, SessionError.passwordRequiredForConnectionChange.localizedDescription)
+        } catch {
+            XCTFail("Unexpected error: \(error)")
+        }
+    }
+
+    func testAuthenticationFailureDoesNotMutateTheOriginalRecord() async {
+        let current = makeServer(name: "Finney")
+        let original = current
+        let request = ServerEditRequest(
+            nameOverride: "Should Not Save",
+            serverURL: current.url,
+            username: current.username,
+            password: "bad-password"
+        )
+
+        do {
+            _ = try await ServerEditCoordinator.prepare(current: current, request: request) { _, _, _ in
+                throw TestAuthenticationError.denied
+            }
+            XCTFail("The authentication error should be returned")
+        } catch TestAuthenticationError.denied {
+            XCTAssertEqual(current, original)
+            XCTAssertEqual(current.displayName, "Finney")
+        } catch {
+            XCTFail("Unexpected error: \(error)")
+        }
+    }
+
+    private func makeServer(
+        name: String,
+        nameOverride: String? = nil,
+        url: URL = URL(string: "https://fin.example")!
+    ) -> ServerConfig {
+        ServerConfig(
+            id: "server-1",
+            name: name,
+            url: url,
+            username: "tester",
+            userId: "user-1",
+            nameOverride: nameOverride
+        )
+    }
+}
+
+private actor AuthenticationCallCounter {
+    private(set) var value = 0
+
+    func increment() {
+        value += 1
+    }
+}
+
+private enum TestAuthenticationError: Error {
+    case denied
+}
+
+@MainActor
+private final class SessionManagerTestHarness {
+    private static let defaultKeys = [
+        "servers",
+        "activeServerId",
+        "serverURL",
+        "userId",
+        "userName",
+        "legacyAccessTokenServerID"
+    ]
+
+    let manager: SessionManager
+    let server: ServerConfig
+    private let defaultValues: [String: Any]
+    private let keychainValues: [String: String]
+
+    init() {
+        let defaults = UserDefaults.standard
+        var defaultValues: [String: Any] = [:]
+        for key in Self.defaultKeys {
+            if let value = defaults.object(forKey: key) {
+                defaultValues[key] = value
+            }
+        }
+
+        let manager = SessionManager(restoreOnLaunch: false)
+        let server = ServerConfig(
+            id: "server-edit-harness-\(UUID().uuidString)",
+            name: "Finney",
+            url: URL(string: "https://fin.example")!,
+            username: "tester",
+            userId: "user-1"
+        )
+        let keychainKeys = [manager.tokenKey(server.id), "accessToken"]
+        var keychainValues: [String: String] = [:]
+        for key in keychainKeys {
+            if let value = KeychainHelper.get(forKey: key) {
+                keychainValues[key] = value
+            }
+        }
+
+        self.manager = manager
+        self.server = server
+        self.defaultValues = defaultValues
+        self.keychainValues = keychainValues
+
+        manager.servers = [server]
+        manager.activeServerId = server.id
+        _ = manager.saveServers()
+    }
+
+    func installToken(_ token: String) {
+        _ = KeychainHelper.save(token, forKey: manager.tokenKey(server.id))
+    }
+
+    func persistedServer() -> ServerConfig? {
+        guard let data = UserDefaults.standard.data(forKey: "servers") else { return nil }
+        return try? JSONDecoder().decode([ServerConfig].self, from: data).first
+    }
+
+    func clearClient() async {
+        await JellyfinClient.shared.clearCredentials()
+    }
+
+    func restore() {
+        let defaults = UserDefaults.standard
+        for key in Self.defaultKeys {
+            if let value = defaultValues[key] {
+                defaults.set(value, forKey: key)
+            } else {
+                defaults.removeObject(forKey: key)
+            }
+        }
+
+        let tokenKeys = [manager.tokenKey(server.id), "accessToken"]
+        for key in tokenKeys {
+            if let value = keychainValues[key] {
+                _ = KeychainHelper.save(value, forKey: key)
+            } else {
+                _ = KeychainHelper.delete(forKey: key)
+            }
+        }
+    }
+}

--- a/Shared/Services/JellyfinClient.swift
+++ b/Shared/Services/JellyfinClient.swift
@@ -1671,7 +1671,7 @@ enum MultiServerSearchService {
                             ServerMediaResult(
                                 item: $0,
                                 serverID: server.id,
-                                serverName: server.name,
+                                serverName: server.displayName,
                                 serverURL: server.url
                             )
                         }
@@ -1862,7 +1862,7 @@ enum MultiServerPeopleService {
             ServerMediaResult(
                 item: $0,
                 serverID: request.server.id,
-                serverName: request.server.name,
+                serverName: request.server.displayName,
                 serverURL: request.server.url
             )
         }

--- a/Shared/Services/ServerEditCoordinator.swift
+++ b/Shared/Services/ServerEditCoordinator.swift
@@ -1,0 +1,198 @@
+import Foundation
+
+/// Values collected by the saved-server editor. A blank password means that
+/// the existing session credential should be retained when the connection
+/// identity has not changed.
+struct ServerEditRequest: Equatable {
+    let nameOverride: String?
+    let serverURL: URL
+    let username: String
+    let password: String?
+
+    init(nameOverride: String?, serverURL: URL, username: String, password: String?) {
+        let trimmedAlias = nameOverride?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+        self.nameOverride = trimmedAlias.isEmpty ? nil : trimmedAlias
+        self.serverURL = Self.normalize(serverURL) ?? serverURL
+        self.username = username.trimmingCharacters(in: .whitespacesAndNewlines)
+        self.password = password?.isEmpty == true ? nil : password
+    }
+
+    /// Normalizes the same inputs accepted by the sign-in forms, including a
+    /// host entered without an explicit scheme.
+    static func normalize(_ rawValue: String) -> URL? {
+        var value = rawValue.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !value.isEmpty else { return nil }
+        if !value.lowercased().hasPrefix("http://") && !value.lowercased().hasPrefix("https://") {
+            value = "https://" + value
+        }
+        while value.hasSuffix("/") {
+            value.removeLast()
+        }
+        guard let url = URL(string: value),
+              let scheme = url.scheme?.lowercased(),
+              ["http", "https"].contains(scheme),
+              let host = url.host,
+              !host.isEmpty else {
+            return nil
+        }
+        return url
+    }
+
+    static func normalize(_ url: URL) -> URL? {
+        normalize(url.absoluteString)
+    }
+
+    func urlChanged(from current: ServerConfig) -> Bool {
+        let normalizedCurrent = Self.normalize(current.url) ?? current.url
+        return serverURL != normalizedCurrent
+    }
+
+    func changesConnection(from current: ServerConfig) -> Bool {
+        urlChanged(from: current) || username != current.username || password != nil
+    }
+}
+
+struct ServerEditAuthentication: Equatable {
+    let accessToken: String
+    let username: String
+    let userId: String
+    let serverName: String?
+}
+
+struct PreparedServerEdit: Equatable {
+    let server: ServerConfig
+    let accessToken: String?
+}
+
+enum ServerEditCoordinator {
+    typealias Authenticator = @Sendable (URL, String, String) async throws -> ServerEditAuthentication
+
+    static func prepare(
+        current: ServerConfig,
+        request: ServerEditRequest,
+        authenticate: @escaping Authenticator
+    ) async throws -> PreparedServerEdit {
+        guard !request.username.isEmpty else {
+            throw SessionError.invalidUsername
+        }
+
+        let urlChanged = request.urlChanged(from: current)
+        let usernameChanged = request.username != current.username
+        let requiresAuthentication = request.changesConnection(from: current)
+
+        if (urlChanged || usernameChanged) && request.password == nil {
+            throw SessionError.passwordRequiredForConnectionChange
+        }
+
+        guard requiresAuthentication else {
+            return PreparedServerEdit(
+                server: ServerConfig(
+                    id: current.id,
+                    name: current.name,
+                    url: current.url,
+                    username: current.username,
+                    userId: current.userId,
+                    nameOverride: request.nameOverride
+                ),
+                accessToken: nil
+            )
+        }
+
+        guard let password = request.password else {
+            throw SessionError.passwordRequiredForConnectionChange
+        }
+        let authentication = try await authenticate(request.serverURL, request.username, password)
+        let authenticatedName = authentication.serverName?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+        let fallbackName = request.serverURL.host ?? current.name
+        let serverName = authenticatedName.isEmpty
+            ? (urlChanged ? fallbackName : current.name)
+            : authenticatedName
+
+        let updatedServer = ServerConfig(
+            id: current.id,
+            name: serverName,
+            url: request.serverURL,
+            username: authentication.username,
+            userId: authentication.userId,
+            nameOverride: request.nameOverride
+        )
+        return PreparedServerEdit(server: updatedServer, accessToken: authentication.accessToken)
+    }
+}
+
+extension SessionManager {
+    /// Edits a saved server without disturbing the active shared client until
+    /// any changed connection credentials have been verified. Alias-only
+    /// changes remain local and do not contact Jellyfin.
+    func updateServer(
+        id: String,
+        nameOverride: String?,
+        serverURL: URL,
+        username: String,
+        password: String?,
+        authenticate: ServerEditCoordinator.Authenticator? = nil
+    ) async throws {
+        guard let index = servers.firstIndex(where: { $0.id == id }) else {
+            throw SessionError.serverNotFound
+        }
+
+        let current = servers[index]
+        let request = ServerEditRequest(
+            nameOverride: nameOverride,
+            serverURL: serverURL,
+            username: username,
+            password: password
+        )
+        let connectionChanged = request.changesConnection(from: current)
+
+        let authenticator: ServerEditCoordinator.Authenticator = authenticate ?? { url, loginUsername, loginPassword in
+            let client = JellyfinClient()
+            await client.configure(serverURL: url)
+            let result = try await client.authenticate(username: loginUsername, password: loginPassword)
+            let serverName = try? await client.getPublicSystemInfo().serverName
+            return ServerEditAuthentication(
+                accessToken: result.accessToken,
+                username: result.user.name,
+                userId: result.user.id,
+                serverName: serverName
+            )
+        }
+        let prepared = try await ServerEditCoordinator.prepare(
+            current: current,
+            request: request,
+            authenticate: authenticator
+        )
+
+        let previousToken = token(for: current, allowLegacyFallback: true)
+        if let newToken = prepared.accessToken {
+            guard KeychainHelper.save(newToken, forKey: tokenKey(id)) else {
+                throw SessionError.credentialStorageFailed
+            }
+        }
+
+        servers[index] = prepared.server
+        guard saveServers() else {
+            // Roll back both pieces of the record if metadata cannot be
+            // persisted after a successful credential write.
+            servers[index] = current
+            if let previousToken {
+                _ = KeychainHelper.save(previousToken, forKey: tokenKey(id))
+            } else {
+                _ = KeychainHelper.delete(forKey: tokenKey(id))
+            }
+            throw SessionError.credentialStorageFailed
+        }
+
+        guard activeServerId == id else { return }
+
+        if let token = token(for: prepared.server, allowLegacyFallback: true) {
+            reauthServer = nil
+            await activate(prepared.server, token: token)
+            if connectionChanged {
+                markActiveConnectionChanged()
+            }
+        } else {
+            reauthServer = prepared.server
+        }
+    }
+}

--- a/Shared/Services/SessionManager.swift
+++ b/Shared/Services/SessionManager.swift
@@ -16,6 +16,14 @@ enum SessionError: LocalizedError {
     case credentialStorageFailed
     /// Same server URL + user already saved.
     case duplicateServer
+    /// A connection identity change cannot be verified without a password.
+    case passwordRequiredForConnectionChange
+    /// The server record being edited no longer exists.
+    case serverNotFound
+    /// The edit form supplied an invalid server address.
+    case invalidServerURL
+    /// The edit form supplied an empty username.
+    case invalidUsername
 
     var errorDescription: String? {
         switch self {
@@ -23,6 +31,14 @@ enum SessionError: LocalizedError {
             return "Could not save credentials securely. Please try signing in again."
         case .duplicateServer:
             return "That server and user are already added."
+        case .passwordRequiredForConnectionChange:
+            return "Enter the password to verify the updated server connection."
+        case .serverNotFound:
+            return "That saved server is no longer available."
+        case .invalidServerURL:
+            return "Enter a valid http:// or https:// server address."
+        case .invalidUsername:
+            return "Enter a username."
         }
     }
 }
@@ -32,9 +48,34 @@ enum SessionError: LocalizedError {
 struct ServerConfig: Codable, Identifiable, Equatable {
     let id: String
     var name: String
-    let url: URL
-    let username: String
-    let userId: String
+    /// A local-only name chosen by the user. `name` remains Jellyfin's name
+    /// (or the host fallback) so clearing an alias restores the server's
+    /// natural display name without another network request.
+    var nameOverride: String?
+    var url: URL
+    var username: String
+    var userId: String
+
+    init(
+        id: String,
+        name: String,
+        url: URL,
+        username: String,
+        userId: String,
+        nameOverride: String? = nil
+    ) {
+        self.id = id
+        self.name = name
+        self.nameOverride = nameOverride
+        self.url = url
+        self.username = username
+        self.userId = userId
+    }
+
+    var displayName: String {
+        let trimmedOverride = nameOverride?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+        return trimmedOverride.isEmpty ? name : trimmedOverride
+    }
 }
 
 /// A small async mutex used to serialize changes to JellyfinClient.shared.
@@ -136,8 +177,11 @@ final class SessionManager: ObservableObject {
     @Published private(set) var isAuthenticated = false
     @Published private(set) var currentUser: UserDto?
     @Published private(set) var serverURL: URL?
-    @Published private(set) var servers: [ServerConfig] = []
-    @Published private(set) var activeServerId: String?
+    @Published var servers: [ServerConfig] = []
+    @Published var activeServerId: String?
+    /// Changes only when the active server's connection identity changes, so
+    /// the app can rebuild content view models without refreshing for aliases.
+    @Published private(set) var serverConnectionRevision = 0
     @Published var logoutReason: LogoutReason?
     /// Set when the user picks a saved server whose token was dropped by a past
     /// session expiry — the UI presents a prefilled re-auth for it. Cleared on
@@ -169,7 +213,14 @@ final class SessionManager: ObservableObject {
         servers.first(where: { $0.id == activeServerId })
     }
 
-    private init() {
+    /// The root content identity. Switching servers already changes the first
+    /// component; editing an active URL or credential changes the revision.
+    var activeSessionIdentity: String {
+        "\(activeServerId ?? "none"):\(serverConnectionRevision)"
+    }
+
+    init(restoreOnLaunch: Bool = true) {
+        guard restoreOnLaunch else { return }
         Task {
             await restoreSession()
         }
@@ -185,14 +236,24 @@ final class SessionManager: ObservableObject {
         activeServerId = UserDefaults.standard.string(forKey: activeServerIdKey)
     }
 
-    private func saveServers() {
-        if let data = try? JSONEncoder().encode(servers) {
-            UserDefaults.standard.set(data, forKey: serversKey)
+    @discardableResult
+    func saveServers() -> Bool {
+        guard let data = try? JSONEncoder().encode(servers) else {
+            logger.error("Could not encode saved server metadata")
+            return false
         }
+        UserDefaults.standard.set(data, forKey: serversKey)
         UserDefaults.standard.set(activeServerId, forKey: activeServerIdKey)
+        return true
     }
 
-    private func tokenKey(_ id: String) -> String { "accessToken.\(id)" }
+    func tokenKey(_ id: String) -> String { "accessToken.\(id)" }
+
+    /// Rebuild active content after a successful URL or credential change.
+    /// Alias-only edits intentionally leave this untouched.
+    func markActiveConnectionChanged() {
+        serverConnectionRevision += 1
+    }
 
     /// Returns a server-scoped token and repairs installs created before the
     /// per-server token migration when the active server still has a legacy
@@ -329,7 +390,7 @@ final class SessionManager: ObservableObject {
         logger.info("Migrated legacy single-server session to multi-server store")
     }
 
-    private func activate(_ server: ServerConfig, token: String) async {
+    func activate(_ server: ServerConfig, token: String) async {
         // Keep the legacy single-server keys in sync for unscoped legacy routes
         // that still read them directly. Multi-server downloads, subtitles, and
         // scoped artwork resolve their own server URL and token explicitly, so

--- a/Shared/Views/ServerEditView.swift
+++ b/Shared/Views/ServerEditView.swift
@@ -1,0 +1,166 @@
+import SwiftUI
+
+/// Shared saved-server editor used by tvOS, iPhone, and iPad. The view only
+/// collects values; SessionManager owns validation, authentication, and the
+/// atomic persistence transition.
+struct ServerEditView: View {
+    let server: ServerConfig
+
+    @EnvironmentObject private var sessionManager: SessionManager
+    @Environment(\.dismiss) private var dismiss
+    @State private var alias: String
+    @State private var serverURL: String
+    @State private var username: String
+    @State private var password = ""
+    @State private var isSaving = false
+    @State private var errorMessage: String?
+
+    init(server: ServerConfig) {
+        self.server = server
+        _alias = State(initialValue: server.nameOverride ?? "")
+        _serverURL = State(initialValue: server.url.absoluteString)
+        _username = State(initialValue: server.username)
+    }
+
+    var body: some View {
+        ZStack {
+            Color(red: 0.07, green: 0.07, blue: 0.09)
+                .ignoresSafeArea()
+
+            NavigationStack {
+                ScrollView {
+                    VStack(alignment: .leading, spacing: 24) {
+                        displayNameSection
+                        connectionSection
+
+                        Button {
+                            save()
+                        } label: {
+                            Group {
+                                if isSaving {
+                                    ProgressView()
+                                } else {
+                                    Label("Save Server", systemImage: "checkmark.circle.fill")
+                                }
+                            }
+                            .frame(maxWidth: .infinity)
+                        }
+                        .buttonStyle(.borderedProminent)
+                        .disabled(isSaving)
+                    }
+                    .frame(maxWidth: 720)
+                    .padding(24)
+                    .frame(maxWidth: .infinity)
+                }
+                .navigationTitle("Edit Server")
+                .toolbar {
+                    ToolbarItem(placement: .cancellationAction) {
+                        Button("Cancel") {
+                            dismiss()
+                        }
+                        .disabled(isSaving)
+                    }
+                    ToolbarItem(placement: .confirmationAction) {
+                        Button("Save") {
+                            save()
+                        }
+                        .disabled(isSaving)
+                    }
+                }
+                .alert("Couldn’t Save Server", isPresented: Binding(
+                    get: { errorMessage != nil },
+                    set: { if !$0 { errorMessage = nil } }
+                )) {
+                    Button("OK") { errorMessage = nil }
+                } message: {
+                    Text(errorMessage ?? "Please check the server details and try again.")
+                }
+            }
+        }
+        .interactiveDismissDisabled(isSaving)
+        .preferredColorScheme(.dark)
+    }
+
+    private var displayNameSection: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            Text("Display Name")
+                .font(.headline)
+
+            TextField("Alias (Optional)", text: $alias)
+                .textInputAutocapitalization(.words)
+                .autocorrectionDisabled()
+                .serverEditFieldStyle()
+
+            Text("Leave this blank to use Jellyfin’s name: \(server.name).")
+                .font(.footnote)
+                .foregroundStyle(.secondary)
+        }
+    }
+
+    private var connectionSection: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            Text("Connection")
+                .font(.headline)
+
+            TextField("Server URL", text: $serverURL)
+                .textContentType(.URL)
+                .keyboardType(.URL)
+                .textInputAutocapitalization(.never)
+                .autocorrectionDisabled()
+                .serverEditFieldStyle()
+
+            TextField("Username", text: $username)
+                .textContentType(.username)
+                .textInputAutocapitalization(.never)
+                .autocorrectionDisabled()
+                .serverEditFieldStyle()
+
+            SecureField("New Password (Optional)", text: $password)
+                .textContentType(.newPassword)
+                .serverEditFieldStyle()
+
+            Text("Leave the password blank to keep the current credential. A new password is required when changing the URL or username.")
+                .font(.footnote)
+                .foregroundStyle(.secondary)
+        }
+    }
+
+    private func save() {
+        guard let normalizedURL = ServerEditRequest.normalize(serverURL) else {
+            errorMessage = SessionError.invalidServerURL.localizedDescription
+            return
+        }
+        guard !username.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+            errorMessage = SessionError.invalidUsername.localizedDescription
+            return
+        }
+
+        isSaving = true
+        errorMessage = nil
+
+        Task {
+            do {
+                try await sessionManager.updateServer(
+                    id: server.id,
+                    nameOverride: alias,
+                    serverURL: normalizedURL,
+                    username: username,
+                    password: password
+                )
+                isSaving = false
+                dismiss()
+            } catch {
+                isSaving = false
+                errorMessage = error.localizedDescription
+            }
+        }
+    }
+}
+
+private extension View {
+    func serverEditFieldStyle() -> some View {
+        padding(12)
+            .background(Color.secondary.opacity(0.14))
+            .clipShape(RoundedRectangle(cornerRadius: 10))
+    }
+}

--- a/Shared/Views/ServerMediaSourcePicker.swift
+++ b/Shared/Views/ServerMediaSourcePicker.swift
@@ -17,6 +17,9 @@ private enum ServerSourceOrdering {
         let savedOrder = Dictionary(
             uniqueKeysWithValues: servers.enumerated().map { ($0.element.id, $0.offset) }
         )
+        let displayNames = Dictionary(
+            uniqueKeysWithValues: servers.map { ($0.id, $0.displayName) }
+        )
 
         return sources.sorted {
             let leftIndex = savedOrder[$0.serverID] ?? Int.max
@@ -24,9 +27,20 @@ private enum ServerSourceOrdering {
             if leftIndex != rightIndex {
                 return leftIndex < rightIndex
             }
-            return $0.serverName.localizedCaseInsensitiveCompare($1.serverName) == .orderedAscending
+            let leftName = displayNames[$0.serverID] ?? $0.serverName
+            let rightName = displayNames[$1.serverID] ?? $1.serverName
+            return leftName.localizedCaseInsensitiveCompare(rightName) == .orderedAscending
         }
     }
+}
+
+@MainActor
+private func currentServerName(
+    for source: ServerMediaResult,
+    using sessionManager: SessionManager
+) -> String {
+    sessionManager.servers.first(where: { $0.id == source.serverID })?.displayName
+        ?? source.serverName
 }
 
 /// Compact server labels used under a title wherever the same media exists on
@@ -42,7 +56,7 @@ struct ServerSourcePillsView: View {
                 ScrollView(.horizontal, showsIndicators: false) {
                     HStack(spacing: 6) {
                         ForEach(orderedSources) { source in
-                            ServerSourcePill(label: source.serverName)
+                            ServerSourcePill(label: currentServerName(for: source, using: sessionManager))
                         }
                     }
                     .padding(.vertical, 2)
@@ -146,7 +160,10 @@ struct ServerMediaSourcePickerView: View {
 
                     VStack(spacing: 12) {
                         ForEach(orderedSources) { source in
-                            ServerSourceOptionRow(source: source) {
+                            ServerSourceOptionRow(
+                                source: source,
+                                serverName: currentServerName(for: source, using: sessionManager)
+                            ) {
                                 onSelect(source)
                                 dismiss()
                             }
@@ -186,6 +203,7 @@ struct ServerMediaSourcePickerView: View {
 
 private struct ServerSourceOptionRow: View {
     let source: ServerMediaResult
+    let serverName: String
     let onSelect: () -> Void
 
     @FocusState private var isFocused: Bool
@@ -194,7 +212,7 @@ private struct ServerSourceOptionRow: View {
         Button(action: onSelect) {
             HStack(spacing: 14) {
                 VStack(alignment: .leading, spacing: 5) {
-                    Text(source.serverName)
+                    Text(serverName)
                         .font(.headline)
                         .foregroundStyle(.white)
 
@@ -227,7 +245,7 @@ private struct ServerSourceOptionRow: View {
         .padding(.horizontal, 6)
         .padding(.vertical, 4)
         .accessibilityElement(children: .combine)
-        .accessibilityLabel("Open \(source.item.displayTitle) on \(source.serverName)")
+        .accessibilityLabel("Open \(source.item.displayTitle) on \(serverName)")
     }
 }
 
@@ -350,6 +368,7 @@ struct ServerScopedMediaDetailView: View {
     @State private var isReady = false
     @State private var scopeError: String?
     @Environment(\.dismiss) private var dismiss
+    @ObservedObject private var sessionManager = SessionManager.shared
 
 #if os(tvOS)
     private let backToolbarPlacement: ToolbarItemPlacement = .navigationBarLeading
@@ -359,6 +378,10 @@ struct ServerScopedMediaDetailView: View {
 
     private var isYouTubeStyle: Bool {
         source.item.libraryName?.localizedCaseInsensitiveContains("youtube") == true
+    }
+
+    private var serverName: String {
+        currentServerName(for: source, using: sessionManager)
     }
 
     var body: some View {
@@ -389,7 +412,7 @@ struct ServerScopedMediaDetailView: View {
                 )
 #endif
             } else {
-                ProgressView("Connecting to \(source.serverName)...")
+                ProgressView("Connecting to \(serverName)...")
             }
         }
         .task(id: source.id) {
@@ -411,7 +434,7 @@ struct ServerScopedMediaDetailView: View {
     private func manageServerScope() async {
         guard let scope = await SessionManager.shared.beginServerScope(for: source.serverID) else {
             guard !Task.isCancelled else { return }
-            scopeError = "The saved session for \(source.serverName) is unavailable. Reconnect this server in Settings, then try again."
+            scopeError = "The saved session for \(serverName) is unavailable. Reconnect this server in Settings, then try again."
             return
         }
 


### PR DESCRIPTION
Fixes #399

## Summary

- Add pencil edit actions for saved servers on tvOS, iPhone, and iPad.
- Persist a local alias and use it throughout server labels; clearing it restores the Jellyfin name or host fallback.
- Edit the URL, username, or password with fresh authentication and atomic Keychain/UserDefaults updates.
- Refresh the active session only after connection changes; alias-only edits update labels without refetching media.
- Resolve search, filmography, and server-picker labels from the current alias.

## Verification

- rtk swiftlint lint --strict — passed with 0 violations.
- Full tvOS simulator test suite — passed.
- iOS simulator build — passed.
- git diff --check — passed.
- Delegated review — approved.

Visual proof is stored locally at /Users/pratik/Desktop/Sashimi-PR-379-Screenshots/3/ and is not committed or attached to this PR.